### PR TITLE
Use https for links where possible

### DIFF
--- a/docs/articles/developer-info/Issue-Tracking.md
+++ b/docs/articles/developer-info/Issue-Tracking.md
@@ -1,10 +1,10 @@
 # Issue Tracking
 
-We use the GitHub issue tracker to keep track of our ongoing work. We supplement GitHub's native issue handling by using [ZenHub](http://www.zenhub.com), which provides a number of additional features.
+We use the GitHub issue tracker to keep track of our ongoing work. We supplement GitHub's native issue handling by using [ZenHub](https://www.zenhub.com/), which provides a number of additional features.
 
 ## Workflow
 
-We use a [ZenHub](http://www.zenhub.com) Board with a standard set of pipelines to track the flow of work in each repo. Our standard set of pipeline columns are slightly different from the ZenHub default:
+We use a [ZenHub](https://www.zenhub.com/) Board with a standard set of pipelines to track the flow of work in each repo. Our standard set of pipeline columns are slightly different from the ZenHub default:
 
 * **New Issues** All issues start as new. We like to review them as quickly as possible. Some issues can be immediately closed while others need to be categorized for further work. We usually assign at least an _is_ and a _priority_ label (see below) to every issue and then move it to either the **Discussion** or the **Backlog** column.
 
@@ -88,7 +88,7 @@ Labels starting with **closed:** indicate the status of the bug at closing and s
 
 ## Epics
 
-Where appropriate, we make use of the [ZenHub](http://www.zenhub.com) **Epic** feature to create issues that include a number of sub-issues. For example, when we split the original NUnit repository into separate framework and engine repositories, we created an epic that included a number of separate issues that had to be completed in order to accomplish the split smoothly.
+Where appropriate, we make use of the [ZenHub](https://www.zenhub.com/) **Epic** feature to create issues that include a number of sub-issues. For example, when we split the original NUnit repository into separate framework and engine repositories, we created an epic that included a number of separate issues that had to be completed in order to accomplish the split smoothly.
 
 ## Milestones
 

--- a/docs/articles/developer-info/Packaging-the-Console-and-Engine.md
+++ b/docs/articles/developer-info/Packaging-the-Console-and-Engine.md
@@ -187,4 +187,4 @@ Send notifications to the mailing list and twitter.
 
 The milestone representing this release should be closed at this time.
 
-[semantic versioning]:http://semver.org/
+[semantic versioning]:https://semver.org/

--- a/docs/articles/developer-info/Packaging-the-Framework.md
+++ b/docs/articles/developer-info/Packaging-the-Framework.md
@@ -218,4 +218,4 @@ Send notifications to the mailing list and twitter.
 
 The milestone representing this release should be closed at this time.
 
-[semantic versioning]:http://semver.org
+[semantic versioning]:https://semver.org/

--- a/docs/articles/developer-info/Packaging-the-V2-Adapter.md
+++ b/docs/articles/developer-info/Packaging-the-V2-Adapter.md
@@ -94,8 +94,8 @@ The file is named **vsTestAdapterReleaseNotes.html**, and is found under Docs/2.
 
 Also check that the files **vsTestAdapterLicense.html** and **vsTestAdapterReleaseNotes.html** is up to date.
 
-[semantic versioning]:http://semver.org/
+[semantic versioning]:https://semver.org/
 [Visual Studio Gallery]:http://visualstudiogallery.msdn.microsoft.com/6ab922d0-21c0-4f06-ab5f-4ecd1fe7175d
-[NuGet for the adapter]:http://www.nuget.org/packages/NUnitTestAdapter/
-[NuGet for the adapter with framework]:http://www.nuget.org/packages/NUnitTestAdapter.WithFramework/
-[nunit.org repository]:http://github.com/nunit/nunit.org
+[NuGet for the adapter]:https://www.nuget.org/packages/NUnitTestAdapter/
+[NuGet for the adapter with framework]:https://www.nuget.org/packages/NUnitTestAdapter.WithFramework/
+[nunit.org repository]:https://github.com/nunit/nunit.org

--- a/docs/articles/developer-info/Packaging-the-V3-Adapter.md
+++ b/docs/articles/developer-info/Packaging-the-V3-Adapter.md
@@ -92,8 +92,8 @@ Test both the vsix and NuGet packages using each version of Visual Studio you ha
 2. **Visual Studio SDK**  
    You need this to work with the vsix.
 
-[semantic versioning]:http://semver.org/
+[semantic versioning]:https://semver.org/
 [Visual Studio Gallery]:https://visualstudiogallery.msdn.microsoft.com/0da0f6bd-9bb6-4ae3-87a8-537788622f2d
-[NuGet for the adapter]:http://www.nuget.org/packages/NUnitTestAdapter/
+[NuGet for the adapter]:https://www.nuget.org/packages/NUnitTestAdapter/
 [NuGet for the adapter with framework]:http://www.nuget.org/packages/NUnitTestAdapter.WithFramework/
 [nunit.org repository]:http://github.com/nunit/nunit.org

--- a/docs/articles/nunit/getting-started/installation.md
+++ b/docs/articles/nunit/getting-started/installation.md
@@ -39,7 +39,7 @@ To run your tests, simply run your executable test assembly. No other runner is 
 
 ### Downloading the Zip File
 
-Download the latest binary zip of the NUnit Framework from our [Download page](http://nunit.org/download/). Unzip the file into any convenient directory.
+Download the latest binary zip of the NUnit Framework from our [Download page](https://nunit.org/download/). Unzip the file into any convenient directory.
 
 You can also download the latest binary zip or an MSI installer of the NUnit Console from [GitHub](https://github.com/nunit/nunit-console/releases). Unzip the file or install the MSI and then if you would like be able to run nunit3-console from the command line, put the bin directory, containing nunit3-console.exe on your path.
 

--- a/docs/articles/nunit/technical-notes/nunit-internals/specs/Extended-Constraint-Syntax-Spec.md
+++ b/docs/articles/nunit/technical-notes/nunit-internals/specs/Extended-Constraint-Syntax-Spec.md
@@ -25,7 +25,7 @@ There are already a couple of implementations implementing a fluent syntax or ex
 
   * Extension Methods for NUnit: this is substantially an aliasing mechanism which, without touching the constraints themselves, provides a fluent way to express them
   * [SharpTestsEx](http://sharptestsex.codeplex.com): this is an improvement of [NUnitEx](http://code.google.com/p/nunitex/) and provides an extension-method based constraint syntax in addition to a starting point for an expression-based mechanism of assertions.
-  * [ExpressionToCode](http://code.google.com/p/expressiontocode/): this is an expression-based assertion library.  It is a reimplementation of [Power Assert .NET](http://powerassert.codeplex.com/), which is itself a port of [Groovy's Power Assert](http://dontmindthelanguage.wordpress.com/2009/12/11/groovy-1-7-power-assert/).
+  * [ExpressionToCode](http://code.google.com/p/expressiontocode/): this is an expression-based assertion library.  It is a reimplementation of [Power Assert .NET](http://powerassert.codeplex.com/), which is itself a port of [Groovy's Power Assert](https://dontmindthelanguage.wordpress.com/2009/12/11/groovy-1-7-power-assert/).
 
 ### Extensible Fluent Constraint Proposal
 Ideally we would like to be able to use a constraint syntax similar to the current fluent syntax that is extensible.  This requires using extension methods instead of static classes, as the following example demonstrates:

--- a/docs/articles/nunit/technical-notes/usage/XML-Formats.md
+++ b/docs/articles/nunit/technical-notes/usage/XML-Formats.md
@@ -11,7 +11,7 @@ The samples given here represent the current state of the application and are su
 
 An NUnit project is stored as a file with the extension .nunit and describes one or more test assemblies to be executed, together with certain parameters used in running them. No schema is used for this file.
 
-  * [Sample NUnit Project](http://nunit.org/files/nunit_project_25.txt)
+  * [Sample NUnit Project](https://nunit.org/files/nunit_project_25.txt)
 
 Currently, the format is the same as for NUnit 2.x but it is likely to change as the project proceeds. Note that NUnitLite does not use or recognize NUnit projects, but only assemblies.
 
@@ -21,13 +21,13 @@ For details of the file contents, see [NUnit Project XML Format](xref:nunitproje
 
 The NUnitSettings30.xml file holds default settings for NUnit 3.0. No schema is used for this file. The format is the same as for 2.x but new settings may be added and the names of certain keys are likely to change.
 
-  * [Sample NUnit Settings File](http://nunit.org/files/sample_nunitsettings_file.txt)
+  * [Sample NUnit Settings File](https://nunit.org/files/sample_nunitsettings_file.txt)
 
 #### Test Results
 
 The results of an test run are saved in a file with the default name of TestResult.xml. The schema of this file is being modified substantially for NUnit 3.0.
 
-  * [Sample](http://nunit.org/files/testresult_30.txt)
+  * [Sample](https://nunit.org/files/testresult_30.txt)
   * Schema not yet available
 
 For details of the file layout see [Test Result XML Format](Test-Result-XML-Format.md).
@@ -36,8 +36,8 @@ For details of the file layout see [Test Result XML Format](Test-Result-XML-Form
 
 Optionally, NUnit 3.0 is able to save results in the NUnit 2.x format for use with CI servers that do not yet understand the new format.
 
-  * [Sample](http://nunit.org/files/testresult_25.txt)
-  * [Schema](http://nunit.org/files/testresult_schema_25.txt)
+  * [Sample](https://nunit.org/files/testresult_25.txt)
+  * [Schema](https://nunit.org/files/testresult_schema_25.txt)
 
 #### Test Representation
 
@@ -59,5 +59,5 @@ As a test run progresses, individual test run results are sent as xml fragments 
 
 The Gui runner uses a file with the suffix .VisualState.xml to save the current visual state of a project so that it may be restored upon re-opening. This file is private to the Gui but is included here for completeness. The current format is identical to that used in NUnit 2.x.
 
-  * [Sample Visual State File](http://nunit.org/files/sample_visual_state_25.txt)
+  * [Sample Visual State File](https://nunit.org/files/sample_visual_state_25.txt)
 

--- a/docs/articles/vs-test-adapter/Adapter-Release-Notes.md
+++ b/docs/articles/vs-test-adapter/Adapter-Release-Notes.md
@@ -65,7 +65,7 @@ This release has three major changes.
 
 2. The filter syntax issues we've had with special names and characters have been mostly solved, thanks to excellent work by [John M.Wright](https://github.com/johnmwright).  The filter syntax is now closer to a correct FQN (Full Qualified Name), but this might cause some issues with your own filter in some rare cases.  The fix done resolves a lot of issues, all of them listed below.  For a detailed explanation of what has been done, see the [Pull Request #668](https://github.com/nunit/nunit3-vs-adapter/pull/668).
 
-3. You can now use the NUnit filter syntax, either from command line or through settings in the runsettings file. This was due to an idea by [Michael Letterle](https://github.com/mletterle) and a subsequent implementation [Pull Request #669](https://github.com/nunit/nunit3-vs-adapter/pull/669).  Michael also wrote [a great blogpost](http://blog.prokrams.com/2019/12/16/nunit3-filter-dotnet/) to explain how this works, and how he arrived at the solution.  For more information see the [NUnit Test Selection Language](xref:TestSelectionLanguage).
+3. You can now use the NUnit filter syntax, either from command line or through settings in the runsettings file. This was due to an idea by [Michael Letterle](https://github.com/mletterle) and a subsequent implementation [Pull Request #669](https://github.com/nunit/nunit3-vs-adapter/pull/669).  Michael also wrote [a great blogpost](https://blog.prokrams.com/2019/12/16/nunit3-filter-dotnet/) to explain how this works, and how he arrived at the solution.  For more information see the [NUnit Test Selection Language](xref:TestSelectionLanguage).
 
 ### Resolved issues
 

--- a/docs/articles/vs-test-adapter/Tips-And-Tricks.md
+++ b/docs/articles/vs-test-adapter/Tips-And-Tricks.md
@@ -135,7 +135,7 @@ The [NUnit internal properties](https://github.com/nunit/nunit/blob/master/src/N
 
 #### Where
 
-A NUnit Test Selection Language filter can be added to the runsettings file.  The details are described in **[this blogpost](http://blog.prokrams.com/2019/12/16/nunit3-filter-dotnet/)**
+A NUnit Test Selection Language filter can be added to the runsettings file.  The details are described in **[this blogpost](https://blog.prokrams.com/2019/12/16/nunit3-filter-dotnet/)**
 
 Using the runsettings should be like:
 


### PR DESCRIPTION
Using an old tool I have from a different project, which converts any links to https where possible. 

For ease of review, it ignores anything which redirects, hence why there's still some VS/Google Code links left as http.