### PR TITLE
Correct NUnit casing

### DIFF
--- a/docs/articles/developer-info/Packaging-the-Console-and-Engine.md
+++ b/docs/articles/developer-info/Packaging-the-Console-and-Engine.md
@@ -139,7 +139,7 @@ Packages are archived on nunit.org in the downloads directory. Create a new sub-
 
 ### Github
 
-1. Log onto Github and go to the main nunit repository at <https://github.com/nunit/nunit>.
+1. Log onto Github and go to the main NUnit repository at <https://github.com/nunit/nunit>.
 
 2. Select Releases and then click on the "Draft a new release" button.
 

--- a/docs/articles/developer-info/Packaging-the-Framework.md
+++ b/docs/articles/developer-info/Packaging-the-Framework.md
@@ -170,7 +170,7 @@ Packages are archived on nunit.org in the downloads directory. Create a new sub-
 
 ### Github
 
-1. Log onto Github and go to the main nunit repository at <https://github.com/nunit/nunit>.
+1. Log onto Github and go to the main NUnit repository at <https://github.com/nunit/nunit>.
 
 2. Select Releases and then click on the "Draft a new release" button.
 

--- a/docs/articles/nunit-analyzers/NUnit1013.md
+++ b/docs/articles/nunit-analyzers/NUnit1013.md
@@ -24,7 +24,7 @@ To prevent tests that will fail at runtime due to improper construction.
 
 ```csharp
 [TestCase(1)]
-public async Task<string> Nunit1013SampleTest(int numberValue)
+public async Task<string> NUnit1013SampleTest(int numberValue)
 {
 
     return await ConvertNumber(numberValue);
@@ -46,7 +46,7 @@ Utilize the `ExpectedResult` syntax:
 
 ```csharp
 [TestCase(1, ExpectedResult = "1")]
-public async Task<string> Nunit1013SampleTest(int numberValue)
+public async Task<string> NUnit1013SampleTest(int numberValue)
 {
     return await ConvertNumber(numberValue);
 }
@@ -61,7 +61,7 @@ Or, use an assertion and a generic `Task` rather than `Task<string>`:
 
 ```csharp
 [TestCase(1)]
-public async Task Nunit1013SampleTest(int numberValue)
+public async Task NUnit1013SampleTest(int numberValue)
 {
     var result = await ConvertNumber(numberValue);
     Assert.That(result, Is.EqualTo("1"));

--- a/docs/articles/nunit-analyzers/NUnit1014.md
+++ b/docs/articles/nunit-analyzers/NUnit1014.md
@@ -24,7 +24,7 @@ To prevent tests that will fail at runtime due to improper construction.
 
 ```csharp
 [TestCase(1, ExpectedResult = true)]
-public async Task Nunit1014SampleTest(int numberValue)
+public async Task NUnit1014SampleTest(int numberValue)
 {
     return;
 }
@@ -40,7 +40,7 @@ Remove the `ExpectedResult` syntax:
 
 ```csharp
 [TestCase(1)]
-public async Task Nunit1014SampleTest(int numberValue)
+public async Task NUnit1014SampleTest(int numberValue)
 {
     Assert.Pass();
 }
@@ -50,7 +50,7 @@ Or, update the return task type to be what you're looking for, e.g. `Task<bool>`
 
 ```csharp
 [TestCase(1, ExpectedResult = true)]
-public async Task<bool> Nunit1014SampleTest(int numberValue)
+public async Task<bool> NUnit1014SampleTest(int numberValue)
 {
     return Task.FromResult(true);
 }

--- a/docs/articles/nunit-analyzers/NUnit2007.md
+++ b/docs/articles/nunit-analyzers/NUnit2007.md
@@ -24,7 +24,7 @@ Bring developers' attention to a scenario in which their test is most likely tes
 
 ```csharp
 [Test]
-public void Nunit2007SampleTest()
+public void NUnit2007SampleTest()
 {
     var x = 5;
     Assert.That(5, Is.EqualTo(x));
@@ -46,7 +46,7 @@ Flip the actual and expected values so that your expected value is the constant 
 
 ```csharp
 [Test]
-public void Nunit2007SampleTest()
+public void NUnit2007SampleTest()
 {
     var x = 5;
     Assert.That(x, Is.EqualTo(5));

--- a/docs/articles/nunit-analyzers/NUnit2008.md
+++ b/docs/articles/nunit-analyzers/NUnit2008.md
@@ -24,7 +24,7 @@ To bring developers' attention to a scenario in which their code is actually hav
 
 ```csharp
 [Test]
-public void Nunit2008SampleTest()
+public void NUnit2008SampleTest()
 {
     var date = DateTime.Now;
     Assert.That(date, Is.Not.EqualTo(date.AddDays(1)).IgnoreCase);
@@ -41,7 +41,7 @@ Remove the errant call to `IgnoreCase`:
 
 ```csharp
 [Test]
-public void Nunit2008SampleTest()
+public void NUnit2008SampleTest()
 {
     var date = DateTime.Now;
     Assert.That(date, Is.Not.EqualTo(date.AddDays(1)));
@@ -52,7 +52,7 @@ Or update the code to compare based on the primitives that are supported by `Ign
 
 ```csharp
 [Test]
-public void Nunit2008SampleTest()
+public void NUnit2008SampleTest()
 {
     var date = DateTime.Now;
     Assert.That(date.ToString(), Is.Not.EqualTo(date.AddDays(1).ToString()).IgnoreCase);

--- a/docs/articles/nunit-analyzers/NUnit2009.md
+++ b/docs/articles/nunit-analyzers/NUnit2009.md
@@ -24,7 +24,7 @@ To bring developers' attention to a situation in which their code may not be ope
 
 ```csharp
 [Test]
-public void Nunit2009SampleTest()
+public void NUnit2009SampleTest()
 {
     var x = 1;
     Assert.That(x, Is.EqualTo(x));
@@ -41,7 +41,7 @@ Ensure the `expected` and `actual` values come from different places.
 
 ```csharp
 [Test]
-public void Nunit2009SampleTest()
+public void NUnit2009SampleTest()
 {
     var x = 1;
     Assert.That(x, Is.EqualTo(1));

--- a/docs/articles/nunit/release-notes/Pre-3.5-Release-Notes.md
+++ b/docs/articles/nunit/release-notes/Pre-3.5-Release-Notes.md
@@ -5,7 +5,7 @@ uid: pre35releasenotes
 # Pre 3.5 Release Notes
 
 > [!NOTE]
-> Combined Release Notes for the nunit framework, console and engine, up to version 3.5. For later releases, see:
+> Combined Release Notes for the NUnit framework, console and engine, up to version 3.5. For later releases, see:
 >
 > * [Framework Release Notes](framework.md)
 > * [Console Release Notes](console-and-engine.md)

--- a/docs/articles/nunit/release-notes/framework.md
+++ b/docs/articles/nunit/release-notes/framework.md
@@ -330,7 +330,7 @@ that test fixtures will be run.
 * [2251](https://github.com/nunit/nunit/issues/2251) Randomizer.NextGuid()
 * [2253](https://github.com/nunit/nunit/issues/2253) Parallelizable(ParallelScope.Fixtures) doesn't work on a TestFixture
 * [2254](https://github.com/nunit/nunit/issues/2254) EqualTo on ValueTuple with Nullable unexpected
-* [2261](https://github.com/nunit/nunit/issues/2261) When an assembly is marked with ParallelScope.None and there are Parallelizable tests Nunit hangs
+* [2261](https://github.com/nunit/nunit/issues/2261) When an assembly is marked with ParallelScope.None and there are Parallelizable tests NUnit hangs
 * [2269](https://github.com/nunit/nunit/issues/2269) Parallelizable and NonParallelizable attributes on setup and teardown silently ignored
 * [2276](https://github.com/nunit/nunit/issues/2276) Intermittent test failures in Travis CI: TestContextTests
 * [2281](https://github.com/nunit/nunit/issues/2281) Add type constraint for Throws and any method requiring Exception

--- a/docs/articles/nunit/technical-notes/nunit-internals/NUnit-3.0-Architecture-(2009).md
+++ b/docs/articles/nunit/technical-notes/nunit-internals/NUnit-3.0-Architecture-(2009).md
@@ -2,7 +2,7 @@
 uid: NUnit3Architecture2009
 ---
 
-# Nunit 3.0 Architecture (2009)
+# NUnit 3.0 Architecture (2009)
 
 
 > This is the original - now out of date - document created to describe the planned architecture for NUnit 3.0. We are keeping it for whatever historical interest it may have.

--- a/docs/articles/vs-test-adapter/Adapter-Release-Notes.md
+++ b/docs/articles/vs-test-adapter/Adapter-Release-Notes.md
@@ -254,7 +254,7 @@ Exception thrown while loading tests if In-Proc VSTest DataCollector is used (Th
 
 ### Features
 
-* [461](https://github.com/nunit/nunit3-vs-adapter/issues/461)  Publish symbols with the adapter for debugging into the adapter and nunit
+* [461](https://github.com/nunit/nunit3-vs-adapter/issues/461)  Publish symbols with the adapter for debugging into the adapter and NUnit
 
 ### Resolved Issues
 

--- a/docs/articles/vs-test-adapter/AdapterV2-Release-Notes.md
+++ b/docs/articles/vs-test-adapter/AdapterV2-Release-Notes.md
@@ -21,7 +21,7 @@ Thanks to [BobSilent](https://github.com/BobSilent) for [#188](https://github.co
 
 ### Features
 
-* [#180](https://github.com/nunit/nunit-vs-adapter/issues/180) Nunit 2 test adapter does not support Visual Studio 2019
+* [#180](https://github.com/nunit/nunit-vs-adapter/issues/180) NUnit 2 test adapter does not support Visual Studio 2019
 * [#175](https://github.com/nunit/nunit-vs-adapter/issues/175) NuGet Package : Add `repository` metadata. Thanks to [MaximRouiller](https://github.com/MaximRouiller) for the PR
 * [#174](https://github.com/nunit/nunit-vs-adapter/issues/174)  NUnitTestAdapter 2.1.1 not working with Visual Studio 2017 15.8.0  
 

--- a/docs/articles/vs-test-adapter/AdapterV2-Release-Notes.md
+++ b/docs/articles/vs-test-adapter/AdapterV2-Release-Notes.md
@@ -6,7 +6,7 @@
 
 Updates the NUnit framework to 2.7.1
 
-* [#186](https://github.com/nunit/nunit-vs-adapter/issues/186) How to change used nunit 2 version of test adapter to e.g. v2.7.1 ?  
+* [#186](https://github.com/nunit/nunit-vs-adapter/issues/186) How to change used NUnit 2 version of test adapter to e.g. v2.7.1 ?  
 * [#184](https://github.com/nunit/nunit-vs-adapter/issues/184) Update NUnit library to 2.7.1
 
 Thanks to [BobSilent](https://github.com/BobSilent) for [#188](https://github.com/nunit/nunit-vs-adapter/pull/188) solving [#184](https://github.com/nunit/nunit-vs-adapter/issues/184) and [#186](https://github.com/nunit/nunit-vs-adapter/issues/186).


### PR DESCRIPTION
Resolves #364.

There actually weren't too many instances of this.