### PR TITLE
Add simple publish step with conditional

### DIFF
--- a/.github/workflows/build-process.yml
+++ b/.github/workflows/build-process.yml
@@ -24,3 +24,6 @@ jobs:
         name: Build with Docfx
         with:
           args: docs/docfx.json --warningsAsErrors true
+      - name: Push to gh-pages branch (master only)
+        if: ${{ github.ref == 'refs/heads/master'}}
+        run: echo "I will publish!"


### PR DESCRIPTION
No actual code yet; just an echo statement.

Supports #342.

Now we're getting to the fun part! This adds a step to the github actions that should only run for the master branch and not PRs. 

To test it, we're making the step an echo statement for now. It should not run on this PR, and then should run once merged.