### PR TITLE
Add missing NUnit 2.6.4 link to documentation index page

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -15,14 +15,15 @@ This web site contains the documentation for all active NUnit projects as well a
 * [Team practices](xref:teampractices) describe how NUnit works and how our teams work.
 * [Specifications](xref:Specifications) are descriptions of features we plan to add.
 
-## Older Releases
+## Legacy (NUnit V2) Documentation
 
-Documentation for older releases remains available.
+Documentation for NUnit V2, whcih is no longer developed, remains available.
 
 <!--markdownlint-disable-->
 <div class="across">
 <!--markdownlint-enable -->
 
+* [NUnit 2.6.4](~/2.6.4/docHome.html)
 * [NUnit 2.6.3](~/2.6.3/docHome.html)
 * [NUnit 2.6.2](~/2.6.2/docHome.html)
 * [NUnit 2.6.1](~/2.6.1/docHome.html)

--- a/docs/index.md
+++ b/docs/index.md
@@ -17,7 +17,7 @@ This web site contains the documentation for all active NUnit projects as well a
 
 ## Legacy (NUnit V2) Documentation
 
-Documentation for NUnit V2, whcih is no longer developed, remains available.
+Documentation for NUnit V2, which is no longer developed, remains available.
 
 <!--markdownlint-disable-->
 <div class="across">


### PR DESCRIPTION
NUnit 2.6.4 was the last release of NUnit V2 made by the NUnit Project. On the original nunit.org documentation page it was shown as "Previous Release" but I don't think it needs to be highlighted that way any longer.

At the same time, I modified the text to clarify that we are talking about Legacy documentation.

@SeanKilleen I'm putting this through the PR process so you can use it as a way to decide what the review requirements for PRs should be for this repo.