### PR TITLE
Switch to NUnit's docfx-action

### DIFF
--- a/.github/workflows/build-process.yml
+++ b/.github/workflows/build-process.yml
@@ -65,7 +65,7 @@ jobs:
     steps:
     - uses: actions/checkout@v2
       name: Check out the code
-    - uses: nikeee/docfx-action@master
+    - uses: nunit/docfx-action@master
       name: Build with Docfx
       with:
         args: docs/docfx.json --warningsAsErrors true


### PR DESCRIPTION
Uses our repo, which builds to our container.

Also uses the docfx version 2.561. as of the action version v1.1.0.

Supports #448.