### PR TITLE
Switch to markdownlint-cli

### DIFF
--- a/.github/workflows/build-process.yml
+++ b/.github/workflows/build-process.yml
@@ -15,7 +15,7 @@ jobs:
     steps:
     - uses: actions/checkout@v2
       name: Check out the code
-    - name: Lint Code Base```
+    - name: Lint Code Base
       uses: docker://avtodev/markdown-lint:v1
       with:
         args: 'docs/**/*.md'      

--- a/.github/workflows/build-process.yml
+++ b/.github/workflows/build-process.yml
@@ -15,35 +15,10 @@ jobs:
     steps:
     - uses: actions/checkout@v2
       name: Check out the code
-    - name: Lint Code Base
-      uses: docker://github/super-linter:v2.2.0
-      env:
-        VALIDATE_ALL_CODEBASE: true
-        DISABLE_ERRORS: false
-        VALIDATE_MD: true # Only validate markdown
-        VALIDATE_YAML: false
-        VALIDATE_JSON: false
-        VALIDATE_XML: false
-        VALIDATE_BASH: false
-        VALIDATE_PERL: false
-        VALIDATE_PHP: false
-        VALIDATE_PYTHON: false
-        VALIDATE_RUBY: false
-        VALIDATE_COFFEE: false
-        VALIDATE_ANSIBLE: false
-        VALIDATE_JAVASCRIPT_ES: false
-        VALIDATE_JAVASCRIPT_STANDARD: false
-        VALIDATE_TYPESCRIPT_ES: false
-        VALIDATE_TYPESCRIPT_STANDARD: false
-        VALIDATE_DOCKER: false
-        VALIDATE_GO: false
-        VALIDATE_POWERSHELL: false
-        VALIDATE_TERRAFORM: false
-        VALIDATE_CSS: false
-        VALIDATE_ENV: false
-        VALIDATE_CLOJURE: false
-        VALIDATE_KOTLIN: false
-        VALIDATE_OPENAPI: false
+    - name: Lint changelog file
+      uses: docker://avtodev/markdown-lint:v1
+      with:
+        args: 'docs/**/*.md'      
   spellcheck: 
     name: "Spell check"
     runs-on: ubuntu-latest

--- a/.github/workflows/build-process.yml
+++ b/.github/workflows/build-process.yml
@@ -15,7 +15,7 @@ jobs:
     steps:
     - uses: actions/checkout@v2
       name: Check out the code
-    - name: Lint changelog file
+    - name: Lint Code Base```
       uses: docker://avtodev/markdown-lint:v1
       with:
         args: 'docs/**/*.md'      

--- a/docs/articles/nunit/intro.md
+++ b/docs/articles/nunit/intro.md
@@ -4,8 +4,6 @@ uid: intro
 
 # NUnit Documentation
 
-# Heading that fails markdown validation
-
 This documentation covers NUnit 3.0 and higher.
 
 Where applicable, we have marked sections with the version in which a feature first appeared.

--- a/docs/articles/nunit/intro.md
+++ b/docs/articles/nunit/intro.md
@@ -4,6 +4,8 @@ uid: intro
 
 # NUnit Documentation
 
+# Heading that fails markdown validation
+
 This documentation covers NUnit 3.0 and higher.
 
 Where applicable, we have marked sections with the version in which a feature first appeared.


### PR DESCRIPTION
Supports #466.

We'll check the output from this and see if it makes more sense than super-linter.