### PR TITLE
Add CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,16 @@
+# This is a comment.
+# Each line is a file pattern followed by one or more owners.
+
+# These owners will be the default owners for everything in
+# the repo. Unless a later match takes precedence,
+# @global-owner1 and @global-owner2 will be requested for
+# review when someone opens a pull request.
+*       @SeanKilleen
+
+# Sub-sections of articles that have clear ownership
+
+/docs/articles/vs-test-adapter/ @OsirisTerje
+
+/docs/articles/nunit-analyzers/ @mikkelbu
+
+/docs/articles/xamarin-runners/ @ChrisMaddock

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -10,7 +10,10 @@
 # Sub-sections of articles that have clear ownership
 
 /docs/articles/vs-test-adapter/ @OsirisTerje
+/docs/articles/vs-test-adapter/ @OsirisTerje
 
 /docs/articles/nunit-analyzers/ @mikkelbu
 
 /docs/articles/xamarin-runners/ @ChrisMaddock
+
+/docs/articles/nunit/ @ChrisMaddock @rprouse

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -11,7 +11,7 @@
 # NOTE: Sean is assigned so that he'll be added for review on each PR to these areas. He may merge the PR if it is purely related to docs concerns (typo, formatting, etc.)
 
 /docs/articles/vs-test-adapter/ @OsirisTerje @SeanKilleen
-/docs/articles/vs-test-adapter/ @OsirisTerje @SeanKilleen
+/docs/articles/vs-test-generator/ @OsirisTerje @SeanKilleen
 
 /docs/articles/nunit-analyzers/ @mikkelbu @SeanKilleen
 

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -8,12 +8,13 @@
 *       @SeanKilleen
 
 # Sub-sections of articles that have clear ownership
+# NOTE: Sean is assigned so that he'll be added for review on each PR to these areas. He may merge the PR if it is purely related to docs concerns (typo, formatting, etc.)
 
-/docs/articles/vs-test-adapter/ @OsirisTerje
-/docs/articles/vs-test-adapter/ @OsirisTerje
+/docs/articles/vs-test-adapter/ @OsirisTerje @SeanKilleen
+/docs/articles/vs-test-adapter/ @OsirisTerje @SeanKilleen
 
-/docs/articles/nunit-analyzers/ @mikkelbu
+/docs/articles/nunit-analyzers/ @mikkelbu @SeanKilleen
 
-/docs/articles/xamarin-runners/ @ChrisMaddock
+/docs/articles/xamarin-runners/ @ChrisMaddock @SeanKilleen
 
-/docs/articles/nunit/ @ChrisMaddock @rprouse
+/docs/articles/nunit/ @ChrisMaddock @rprouse @SeanKilleen


### PR DESCRIPTION
This won't do anything yet but indicate ownership of a given area of the docs with an icon while editing files in a pull request.

In the future, I intend to use it to:

* Automatically ask for review from content area owners when I make a change (though I may skip that review if the change is purely related to formatting)
* Allow codeowners to merge changes for their respective area once things are approved (GitHub does not currently support this out of the box, but looking into a bot.)