### PR TITLE
Truly parallel builds (from an attempt at html-proofer)

### DIFF
--- a/.github/workflows/build-process.yml
+++ b/.github/workflows/build-process.yml
@@ -61,7 +61,7 @@ jobs:
     needs: [build_and_publish]
     runs-on: ubuntu-latest
     steps:
-    - name: Download math result for job 2
+    - name: Download site artifacts
       uses: actions/download-artifact@v1
       with:
         name: _site

--- a/.github/workflows/build-process.yml
+++ b/.github/workflows/build-process.yml
@@ -47,6 +47,7 @@ jobs:
       uses: actions/upload-artifact@v2
       with:
         name: _site
+        path: docs/_site
   publish:
     name: Publish (master branch only)
     needs: [build]

--- a/.github/workflows/build-process.yml
+++ b/.github/workflows/build-process.yml
@@ -43,11 +43,13 @@ jobs:
       name: Build with Docfx
       with:
         args: docs/docfx.json --warningsAsErrors true
+    - name: zip site contents
+      run: zip -r _site.zip .docs/_site
     - name: Archive site artifacts
       uses: actions/upload-artifact@v2
       with:
-        name: _site
-        path: docs/_site
+        name: siteArtifact
+        path: _site.zip
   publish:
     name: Publish (master branch only)
     needs: [build]
@@ -57,14 +59,16 @@ jobs:
     - name: Download site artifacts
       uses: actions/download-artifact@v2
       with:
-        name: _site
+        name: siteArtifact
+    - name: unzip site contents
+      run: unzip _site.zip
     - name: Push to gh-pages branch (master only)
       if: ${{ github.ref == 'refs/heads/master'}}
       uses: peaceiris/actions-gh-pages@v3
       with:
         commit_message: ${{ github.event.head_commit.message }}
         github_token: ${{ secrets.GITHUB_TOKEN }}
-        publish_dir: ./_site
+        publish_dir: ./siteArtifact/site
         publish_branch: gh-pages
   html_proofer:
     name: HTML checks (FYI only)
@@ -74,8 +78,10 @@ jobs:
     - name: Download site artifacts
       uses: actions/download-artifact@v2
       with:
-        name: _site
+        name: siteArtifact
+    - name: unzip site contents
+      run: unzip _site.zip
     - name: Check HTML
       uses: chabad360/htmlproofer@master
       with:
-        directory: "./_site"
+        directory: "./siteArtifact/_site"

--- a/.github/workflows/build-process.yml
+++ b/.github/workflows/build-process.yml
@@ -70,19 +70,3 @@ jobs:
         github_token: ${{ secrets.GITHUB_TOKEN }}
         publish_dir: ./docs/_site
         publish_branch: gh-pages
-  html_proofer:
-    name: HTML checks (FYI only)
-    needs: [build]
-    runs-on: ubuntu-latest
-    steps:
-    - name: Download site artifacts
-      uses: actions/download-artifact@v2
-      with:
-        name: siteArtifact
-    - name: unzip site contents
-      run: unzip _site.zip
-    - name: Check HTML
-      uses: chabad360/htmlproofer@master
-      with:
-        directory: "./docs/_site/articles"
-        arguments: --log-level debug

--- a/.github/workflows/build-process.yml
+++ b/.github/workflows/build-process.yml
@@ -68,7 +68,7 @@ jobs:
       with:
         commit_message: ${{ github.event.head_commit.message }}
         github_token: ${{ secrets.GITHUB_TOKEN }}
-        publish_dir: ./siteArtifact/site
+        publish_dir: ./docs/_site
         publish_branch: gh-pages
   html_proofer:
     name: HTML checks (FYI only)
@@ -84,4 +84,4 @@ jobs:
     - name: Check HTML
       uses: chabad360/htmlproofer@master
       with:
-        directory: "./siteArtifact/_site"
+        directory: "./docs/_site"

--- a/.github/workflows/build-process.yml
+++ b/.github/workflows/build-process.yml
@@ -44,6 +44,11 @@ jobs:
       name: Build with Docfx
       with:
         args: docs/docfx.json --warningsAsErrors true
+    - name: Archive site artifacts
+      uses: actions/upload-artifact@v1
+      with:
+        name: _site
+        path: docs/_site   
     - name: Push to gh-pages branch (master only)
       if: ${{ github.ref == 'refs/heads/master'}}
       uses: peaceiris/actions-gh-pages@v3
@@ -56,7 +61,11 @@ jobs:
     needs: [build_and_publish]
     runs-on: ubuntu-latest
     steps:
+    - name: Download math result for job 2
+      uses: actions/download-artifact@v1
+      with:
+        name: _site
     - name: Check HTML
       uses: chabad360/htmlproofer@master
       with:
-        directory: "./docs/_site"
+        directory: "./_site"

--- a/.github/workflows/build-process.yml
+++ b/.github/workflows/build-process.yml
@@ -33,9 +33,8 @@ jobs:
       name: Install cSpell
     - run: cspell --config ./cSpell.json "docs/**/*.md"
       name: run cSpell
-  build_and_publish:
-    name: "Build the site with docfx and publish"
-    needs: [linting, spellcheck]
+  build:
+    name: "Build the site with docfx"
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
@@ -48,18 +47,27 @@ jobs:
       uses: actions/upload-artifact@v2
       with:
         name: _site
-        path: docs/_site   
+  publish:
+    name: Publish (master branch only)
+    needs: [build]
+    runs-on: ubuntu-latest
+    if: ${{ github.ref == 'refs/heads/master'}}
+    steps:
+    - name: Download site artifacts
+      uses: actions/download-artifact@v2
+      with:
+        name: _site
     - name: Push to gh-pages branch (master only)
       if: ${{ github.ref == 'refs/heads/master'}}
       uses: peaceiris/actions-gh-pages@v3
       with:
         commit_message: ${{ github.event.head_commit.message }}
         github_token: ${{ secrets.GITHUB_TOKEN }}
-        publish_dir: ./docs/_site
+        publish_dir: ./_site
         publish_branch: gh-pages
   html_proofer:
     name: HTML checks (FYI only)
-    needs: [build_and_publish]
+    needs: [build]
     runs-on: ubuntu-latest
     steps:
     - name: Download site artifacts

--- a/.github/workflows/build-process.yml
+++ b/.github/workflows/build-process.yml
@@ -44,7 +44,7 @@ jobs:
       with:
         args: docs/docfx.json --warningsAsErrors true
     - name: zip site contents
-      run: zip -r _site.zip . -i .docs/_site
+      run: zip -r _site.zip docs/_site/
     - name: Archive site artifacts
       uses: actions/upload-artifact@v2
       with:

--- a/.github/workflows/build-process.yml
+++ b/.github/workflows/build-process.yml
@@ -45,7 +45,7 @@ jobs:
       with:
         args: docs/docfx.json --warningsAsErrors true
     - name: Archive site artifacts
-      uses: actions/upload-artifact@v1
+      uses: actions/upload-artifact@v2
       with:
         name: _site
         path: docs/_site   
@@ -57,12 +57,13 @@ jobs:
         github_token: ${{ secrets.GITHUB_TOKEN }}
         publish_dir: ./docs/_site
         publish_branch: gh-pages
-  check_links:
+  html_proofer:
+    name: HTML checks (FYI only)
     needs: [build_and_publish]
     runs-on: ubuntu-latest
     steps:
     - name: Download site artifacts
-      uses: actions/download-artifact@v1
+      uses: actions/download-artifact@v2
       with:
         name: _site
     - name: Check HTML

--- a/.github/workflows/build-process.yml
+++ b/.github/workflows/build-process.yml
@@ -84,5 +84,5 @@ jobs:
     - name: Check HTML
       uses: chabad360/htmlproofer@master
       with:
-        directory: "./docs/_site"
+        directory: "./docs/_site/articles"
         arguments: --log-level debug

--- a/.github/workflows/build-process.yml
+++ b/.github/workflows/build-process.yml
@@ -52,3 +52,11 @@ jobs:
         github_token: ${{ secrets.GITHUB_TOKEN }}
         publish_dir: ./docs/_site
         publish_branch: gh-pages
+  check_links:
+    needs: [build_and_publish]
+    runs-on: ubuntu-latest
+    steps:
+    - name: Check HTML
+      uses: chabad360/htmlproofer@master
+      with:
+        directory: "./docs/_site"

--- a/.github/workflows/build-process.yml
+++ b/.github/workflows/build-process.yml
@@ -44,7 +44,7 @@ jobs:
       with:
         args: docs/docfx.json --warningsAsErrors true
     - name: zip site contents
-      run: zip -r _site.zip .docs/_site
+      run: zip -r _site.zip . -i .docs/_site
     - name: Archive site artifacts
       uses: actions/upload-artifact@v2
       with:

--- a/.github/workflows/build-process.yml
+++ b/.github/workflows/build-process.yml
@@ -85,3 +85,4 @@ jobs:
       uses: chabad360/htmlproofer@master
       with:
         directory: "./docs/_site"
+        arguments: --log-level debug


### PR DESCRIPTION
This started out as an attempt to use html-proofer, but then I realized it would need the artifacts.

So, this PR expanded a little.

It now:

* Splits the build & publish steps into separate steps
* Creates artifacts in the build step
* Uses those artifacts in the publish step
* Also added an html-proofer step that uses the build outputs.
* Runs everything in parallel as much as possible.

Supports #352 