### PR TITLE
Replace broken nav links in all legacy docs html files

### DIFF
--- a/docs/2.2.1/assertions.html
+++ b/docs/2.2.1/assertions.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.2.1/assertions.html
+++ b/docs/2.2.1/assertions.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.2.1/assertions.html
+++ b/docs/2.2.1/assertions.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.2.1/assertions.html
+++ b/docs/2.2.1/assertions.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.2.1/attributes.html
+++ b/docs/2.2.1/attributes.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.2.1/attributes.html
+++ b/docs/2.2.1/attributes.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.2.1/attributes.html
+++ b/docs/2.2.1/attributes.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.2.1/attributes.html
+++ b/docs/2.2.1/attributes.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.2.1/category.html
+++ b/docs/2.2.1/category.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.2.1/category.html
+++ b/docs/2.2.1/category.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.2.1/category.html
+++ b/docs/2.2.1/category.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.2.1/category.html
+++ b/docs/2.2.1/category.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.2.1/comparisonAsserts.html
+++ b/docs/2.2.1/comparisonAsserts.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.2.1/comparisonAsserts.html
+++ b/docs/2.2.1/comparisonAsserts.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.2.1/comparisonAsserts.html
+++ b/docs/2.2.1/comparisonAsserts.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.2.1/comparisonAsserts.html
+++ b/docs/2.2.1/comparisonAsserts.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.2.1/conditionAsserts.html
+++ b/docs/2.2.1/conditionAsserts.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.2.1/conditionAsserts.html
+++ b/docs/2.2.1/conditionAsserts.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.2.1/conditionAsserts.html
+++ b/docs/2.2.1/conditionAsserts.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.2.1/conditionAsserts.html
+++ b/docs/2.2.1/conditionAsserts.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.2.1/configEditor.html
+++ b/docs/2.2.1/configEditor.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.2.1/configEditor.html
+++ b/docs/2.2.1/configEditor.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.2.1/configEditor.html
+++ b/docs/2.2.1/configEditor.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.2.1/configEditor.html
+++ b/docs/2.2.1/configEditor.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.2.1/configFiles.html
+++ b/docs/2.2.1/configFiles.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.2.1/configFiles.html
+++ b/docs/2.2.1/configFiles.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.2.1/configFiles.html
+++ b/docs/2.2.1/configFiles.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.2.1/configFiles.html
+++ b/docs/2.2.1/configFiles.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.2.1/consoleCommandLine.html
+++ b/docs/2.2.1/consoleCommandLine.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.2.1/consoleCommandLine.html
+++ b/docs/2.2.1/consoleCommandLine.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.2.1/consoleCommandLine.html
+++ b/docs/2.2.1/consoleCommandLine.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.2.1/consoleCommandLine.html
+++ b/docs/2.2.1/consoleCommandLine.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.2.1/contextMenu.html
+++ b/docs/2.2.1/contextMenu.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.2.1/contextMenu.html
+++ b/docs/2.2.1/contextMenu.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.2.1/contextMenu.html
+++ b/docs/2.2.1/contextMenu.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.2.1/contextMenu.html
+++ b/docs/2.2.1/contextMenu.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.2.1/docHome.html
+++ b/docs/2.2.1/docHome.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.2.1/docHome.html
+++ b/docs/2.2.1/docHome.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.2.1/docHome.html
+++ b/docs/2.2.1/docHome.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.2.1/docHome.html
+++ b/docs/2.2.1/docHome.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.2.1/exception.html
+++ b/docs/2.2.1/exception.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.2.1/exception.html
+++ b/docs/2.2.1/exception.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.2.1/exception.html
+++ b/docs/2.2.1/exception.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.2.1/exception.html
+++ b/docs/2.2.1/exception.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.2.1/explicit.html
+++ b/docs/2.2.1/explicit.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.2.1/explicit.html
+++ b/docs/2.2.1/explicit.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.2.1/explicit.html
+++ b/docs/2.2.1/explicit.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.2.1/explicit.html
+++ b/docs/2.2.1/explicit.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.2.1/features.html
+++ b/docs/2.2.1/features.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.2.1/features.html
+++ b/docs/2.2.1/features.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.2.1/features.html
+++ b/docs/2.2.1/features.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.2.1/features.html
+++ b/docs/2.2.1/features.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.2.1/fixtureSetup.html
+++ b/docs/2.2.1/fixtureSetup.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.2.1/fixtureSetup.html
+++ b/docs/2.2.1/fixtureSetup.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.2.1/fixtureSetup.html
+++ b/docs/2.2.1/fixtureSetup.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.2.1/fixtureSetup.html
+++ b/docs/2.2.1/fixtureSetup.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.2.1/fixtureTeardown.html
+++ b/docs/2.2.1/fixtureTeardown.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.2.1/fixtureTeardown.html
+++ b/docs/2.2.1/fixtureTeardown.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.2.1/fixtureTeardown.html
+++ b/docs/2.2.1/fixtureTeardown.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.2.1/fixtureTeardown.html
+++ b/docs/2.2.1/fixtureTeardown.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.2.1/getStarted.html
+++ b/docs/2.2.1/getStarted.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.2.1/getStarted.html
+++ b/docs/2.2.1/getStarted.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.2.1/getStarted.html
+++ b/docs/2.2.1/getStarted.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.2.1/getStarted.html
+++ b/docs/2.2.1/getStarted.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.2.1/guiCommandLine.html
+++ b/docs/2.2.1/guiCommandLine.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.2.1/guiCommandLine.html
+++ b/docs/2.2.1/guiCommandLine.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.2.1/guiCommandLine.html
+++ b/docs/2.2.1/guiCommandLine.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.2.1/guiCommandLine.html
+++ b/docs/2.2.1/guiCommandLine.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.2.1/ignore.html
+++ b/docs/2.2.1/ignore.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.2.1/ignore.html
+++ b/docs/2.2.1/ignore.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.2.1/ignore.html
+++ b/docs/2.2.1/ignore.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.2.1/ignore.html
+++ b/docs/2.2.1/ignore.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.2.1/installation.html
+++ b/docs/2.2.1/installation.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.2.1/installation.html
+++ b/docs/2.2.1/installation.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.2.1/installation.html
+++ b/docs/2.2.1/installation.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.2.1/installation.html
+++ b/docs/2.2.1/installation.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.2.1/license.html
+++ b/docs/2.2.1/license.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.2.1/license.html
+++ b/docs/2.2.1/license.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.2.1/license.html
+++ b/docs/2.2.1/license.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.2.1/license.html
+++ b/docs/2.2.1/license.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.2.1/mainMenu.html
+++ b/docs/2.2.1/mainMenu.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.2.1/mainMenu.html
+++ b/docs/2.2.1/mainMenu.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.2.1/mainMenu.html
+++ b/docs/2.2.1/mainMenu.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.2.1/mainMenu.html
+++ b/docs/2.2.1/mainMenu.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.2.1/multiAssembly.html
+++ b/docs/2.2.1/multiAssembly.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.2.1/multiAssembly.html
+++ b/docs/2.2.1/multiAssembly.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.2.1/multiAssembly.html
+++ b/docs/2.2.1/multiAssembly.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.2.1/multiAssembly.html
+++ b/docs/2.2.1/multiAssembly.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.2.1/nunit-console.html
+++ b/docs/2.2.1/nunit-console.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.2.1/nunit-console.html
+++ b/docs/2.2.1/nunit-console.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.2.1/nunit-console.html
+++ b/docs/2.2.1/nunit-console.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.2.1/nunit-console.html
+++ b/docs/2.2.1/nunit-console.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.2.1/nunit-gui.html
+++ b/docs/2.2.1/nunit-gui.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.2.1/nunit-gui.html
+++ b/docs/2.2.1/nunit-gui.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.2.1/nunit-gui.html
+++ b/docs/2.2.1/nunit-gui.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.2.1/nunit-gui.html
+++ b/docs/2.2.1/nunit-gui.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.2.1/optionsDialog.html
+++ b/docs/2.2.1/optionsDialog.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.2.1/optionsDialog.html
+++ b/docs/2.2.1/optionsDialog.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.2.1/optionsDialog.html
+++ b/docs/2.2.1/optionsDialog.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.2.1/optionsDialog.html
+++ b/docs/2.2.1/optionsDialog.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.2.1/projectEditor.html
+++ b/docs/2.2.1/projectEditor.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.2.1/projectEditor.html
+++ b/docs/2.2.1/projectEditor.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.2.1/projectEditor.html
+++ b/docs/2.2.1/projectEditor.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.2.1/projectEditor.html
+++ b/docs/2.2.1/projectEditor.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.2.1/quickStart.html
+++ b/docs/2.2.1/quickStart.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.2.1/quickStart.html
+++ b/docs/2.2.1/quickStart.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.2.1/quickStart.html
+++ b/docs/2.2.1/quickStart.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.2.1/quickStart.html
+++ b/docs/2.2.1/quickStart.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.2.1/quickStartSource.html
+++ b/docs/2.2.1/quickStartSource.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.2.1/quickStartSource.html
+++ b/docs/2.2.1/quickStartSource.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.2.1/quickStartSource.html
+++ b/docs/2.2.1/quickStartSource.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.2.1/quickStartSource.html
+++ b/docs/2.2.1/quickStartSource.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.2.1/releaseNotes.html
+++ b/docs/2.2.1/releaseNotes.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.2.1/releaseNotes.html
+++ b/docs/2.2.1/releaseNotes.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.2.1/releaseNotes.html
+++ b/docs/2.2.1/releaseNotes.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.2.1/releaseNotes.html
+++ b/docs/2.2.1/releaseNotes.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.2.1/samples.html
+++ b/docs/2.2.1/samples.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.2.1/samples.html
+++ b/docs/2.2.1/samples.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.2.1/samples.html
+++ b/docs/2.2.1/samples.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.2.1/samples.html
+++ b/docs/2.2.1/samples.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.2.1/setup.html
+++ b/docs/2.2.1/setup.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.2.1/setup.html
+++ b/docs/2.2.1/setup.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.2.1/setup.html
+++ b/docs/2.2.1/setup.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.2.1/setup.html
+++ b/docs/2.2.1/setup.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.2.1/suite.html
+++ b/docs/2.2.1/suite.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.2.1/suite.html
+++ b/docs/2.2.1/suite.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.2.1/suite.html
+++ b/docs/2.2.1/suite.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.2.1/suite.html
+++ b/docs/2.2.1/suite.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.2.1/teardown.html
+++ b/docs/2.2.1/teardown.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.2.1/teardown.html
+++ b/docs/2.2.1/teardown.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.2.1/teardown.html
+++ b/docs/2.2.1/teardown.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.2.1/teardown.html
+++ b/docs/2.2.1/teardown.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.2.1/test.html
+++ b/docs/2.2.1/test.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.2.1/test.html
+++ b/docs/2.2.1/test.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.2.1/test.html
+++ b/docs/2.2.1/test.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.2.1/test.html
+++ b/docs/2.2.1/test.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.2.1/testFixture.html
+++ b/docs/2.2.1/testFixture.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.2.1/testFixture.html
+++ b/docs/2.2.1/testFixture.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.2.1/testFixture.html
+++ b/docs/2.2.1/testFixture.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.2.1/testFixture.html
+++ b/docs/2.2.1/testFixture.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.2.1/testProperties.html
+++ b/docs/2.2.1/testProperties.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.2.1/testProperties.html
+++ b/docs/2.2.1/testProperties.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.2.1/testProperties.html
+++ b/docs/2.2.1/testProperties.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.2.1/testProperties.html
+++ b/docs/2.2.1/testProperties.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.2.1/upgrade.html
+++ b/docs/2.2.1/upgrade.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.2.1/upgrade.html
+++ b/docs/2.2.1/upgrade.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.2.1/upgrade.html
+++ b/docs/2.2.1/upgrade.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.2.1/upgrade.html
+++ b/docs/2.2.1/upgrade.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.2.1/utilityAsserts.html
+++ b/docs/2.2.1/utilityAsserts.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.2.1/utilityAsserts.html
+++ b/docs/2.2.1/utilityAsserts.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.2.1/utilityAsserts.html
+++ b/docs/2.2.1/utilityAsserts.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.2.1/utilityAsserts.html
+++ b/docs/2.2.1/utilityAsserts.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.2.1/vsSupport.html
+++ b/docs/2.2.1/vsSupport.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.2.1/vsSupport.html
+++ b/docs/2.2.1/vsSupport.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.2.1/vsSupport.html
+++ b/docs/2.2.1/vsSupport.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.2.1/vsSupport.html
+++ b/docs/2.2.1/vsSupport.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.2.10/assertions.html
+++ b/docs/2.2.10/assertions.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.2.10/assertions.html
+++ b/docs/2.2.10/assertions.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.2.10/assertions.html
+++ b/docs/2.2.10/assertions.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.2.10/assertions.html
+++ b/docs/2.2.10/assertions.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.2.10/attributes.html
+++ b/docs/2.2.10/attributes.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.2.10/attributes.html
+++ b/docs/2.2.10/attributes.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.2.10/attributes.html
+++ b/docs/2.2.10/attributes.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.2.10/attributes.html
+++ b/docs/2.2.10/attributes.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.2.10/category.html
+++ b/docs/2.2.10/category.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.2.10/category.html
+++ b/docs/2.2.10/category.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.2.10/category.html
+++ b/docs/2.2.10/category.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.2.10/category.html
+++ b/docs/2.2.10/category.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.2.10/comparisonAsserts.html
+++ b/docs/2.2.10/comparisonAsserts.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.2.10/comparisonAsserts.html
+++ b/docs/2.2.10/comparisonAsserts.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.2.10/comparisonAsserts.html
+++ b/docs/2.2.10/comparisonAsserts.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.2.10/comparisonAsserts.html
+++ b/docs/2.2.10/comparisonAsserts.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.2.10/conditionAsserts.html
+++ b/docs/2.2.10/conditionAsserts.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.2.10/conditionAsserts.html
+++ b/docs/2.2.10/conditionAsserts.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.2.10/conditionAsserts.html
+++ b/docs/2.2.10/conditionAsserts.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.2.10/conditionAsserts.html
+++ b/docs/2.2.10/conditionAsserts.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.2.10/configEditor.html
+++ b/docs/2.2.10/configEditor.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.2.10/configEditor.html
+++ b/docs/2.2.10/configEditor.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.2.10/configEditor.html
+++ b/docs/2.2.10/configEditor.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.2.10/configEditor.html
+++ b/docs/2.2.10/configEditor.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.2.10/configFiles.html
+++ b/docs/2.2.10/configFiles.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.2.10/configFiles.html
+++ b/docs/2.2.10/configFiles.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.2.10/configFiles.html
+++ b/docs/2.2.10/configFiles.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.2.10/configFiles.html
+++ b/docs/2.2.10/configFiles.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.2.10/consoleCommandLine.html
+++ b/docs/2.2.10/consoleCommandLine.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.2.10/consoleCommandLine.html
+++ b/docs/2.2.10/consoleCommandLine.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.2.10/consoleCommandLine.html
+++ b/docs/2.2.10/consoleCommandLine.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.2.10/consoleCommandLine.html
+++ b/docs/2.2.10/consoleCommandLine.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.2.10/contextMenu.html
+++ b/docs/2.2.10/contextMenu.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.2.10/contextMenu.html
+++ b/docs/2.2.10/contextMenu.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.2.10/contextMenu.html
+++ b/docs/2.2.10/contextMenu.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.2.10/contextMenu.html
+++ b/docs/2.2.10/contextMenu.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.2.10/docHome.html
+++ b/docs/2.2.10/docHome.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.2.10/docHome.html
+++ b/docs/2.2.10/docHome.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.2.10/docHome.html
+++ b/docs/2.2.10/docHome.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.2.10/docHome.html
+++ b/docs/2.2.10/docHome.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.2.10/equalityAsserts.html
+++ b/docs/2.2.10/equalityAsserts.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.2.10/equalityAsserts.html
+++ b/docs/2.2.10/equalityAsserts.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.2.10/equalityAsserts.html
+++ b/docs/2.2.10/equalityAsserts.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.2.10/equalityAsserts.html
+++ b/docs/2.2.10/equalityAsserts.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.2.10/exception.html
+++ b/docs/2.2.10/exception.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.2.10/exception.html
+++ b/docs/2.2.10/exception.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.2.10/exception.html
+++ b/docs/2.2.10/exception.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.2.10/exception.html
+++ b/docs/2.2.10/exception.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.2.10/explicit.html
+++ b/docs/2.2.10/explicit.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.2.10/explicit.html
+++ b/docs/2.2.10/explicit.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.2.10/explicit.html
+++ b/docs/2.2.10/explicit.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.2.10/explicit.html
+++ b/docs/2.2.10/explicit.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.2.10/features.html
+++ b/docs/2.2.10/features.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.2.10/features.html
+++ b/docs/2.2.10/features.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.2.10/features.html
+++ b/docs/2.2.10/features.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.2.10/features.html
+++ b/docs/2.2.10/features.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.2.10/fixtureSetup.html
+++ b/docs/2.2.10/fixtureSetup.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.2.10/fixtureSetup.html
+++ b/docs/2.2.10/fixtureSetup.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.2.10/fixtureSetup.html
+++ b/docs/2.2.10/fixtureSetup.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.2.10/fixtureSetup.html
+++ b/docs/2.2.10/fixtureSetup.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.2.10/fixtureTeardown.html
+++ b/docs/2.2.10/fixtureTeardown.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.2.10/fixtureTeardown.html
+++ b/docs/2.2.10/fixtureTeardown.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.2.10/fixtureTeardown.html
+++ b/docs/2.2.10/fixtureTeardown.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.2.10/fixtureTeardown.html
+++ b/docs/2.2.10/fixtureTeardown.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.2.10/getStarted.html
+++ b/docs/2.2.10/getStarted.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.2.10/getStarted.html
+++ b/docs/2.2.10/getStarted.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.2.10/getStarted.html
+++ b/docs/2.2.10/getStarted.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.2.10/getStarted.html
+++ b/docs/2.2.10/getStarted.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.2.10/guiCommandLine.html
+++ b/docs/2.2.10/guiCommandLine.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.2.10/guiCommandLine.html
+++ b/docs/2.2.10/guiCommandLine.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.2.10/guiCommandLine.html
+++ b/docs/2.2.10/guiCommandLine.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.2.10/guiCommandLine.html
+++ b/docs/2.2.10/guiCommandLine.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.2.10/identityAsserts.html
+++ b/docs/2.2.10/identityAsserts.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.2.10/identityAsserts.html
+++ b/docs/2.2.10/identityAsserts.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.2.10/identityAsserts.html
+++ b/docs/2.2.10/identityAsserts.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.2.10/identityAsserts.html
+++ b/docs/2.2.10/identityAsserts.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.2.10/ignore.html
+++ b/docs/2.2.10/ignore.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.2.10/ignore.html
+++ b/docs/2.2.10/ignore.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.2.10/ignore.html
+++ b/docs/2.2.10/ignore.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.2.10/ignore.html
+++ b/docs/2.2.10/ignore.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.2.10/installation.html
+++ b/docs/2.2.10/installation.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.2.10/installation.html
+++ b/docs/2.2.10/installation.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.2.10/installation.html
+++ b/docs/2.2.10/installation.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.2.10/installation.html
+++ b/docs/2.2.10/installation.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.2.10/license.html
+++ b/docs/2.2.10/license.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.2.10/license.html
+++ b/docs/2.2.10/license.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.2.10/license.html
+++ b/docs/2.2.10/license.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.2.10/license.html
+++ b/docs/2.2.10/license.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.2.10/mainMenu.html
+++ b/docs/2.2.10/mainMenu.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.2.10/mainMenu.html
+++ b/docs/2.2.10/mainMenu.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.2.10/mainMenu.html
+++ b/docs/2.2.10/mainMenu.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.2.10/mainMenu.html
+++ b/docs/2.2.10/mainMenu.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.2.10/multiAssembly.html
+++ b/docs/2.2.10/multiAssembly.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.2.10/multiAssembly.html
+++ b/docs/2.2.10/multiAssembly.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.2.10/multiAssembly.html
+++ b/docs/2.2.10/multiAssembly.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.2.10/multiAssembly.html
+++ b/docs/2.2.10/multiAssembly.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.2.10/nunit-console.html
+++ b/docs/2.2.10/nunit-console.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.2.10/nunit-console.html
+++ b/docs/2.2.10/nunit-console.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.2.10/nunit-console.html
+++ b/docs/2.2.10/nunit-console.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.2.10/nunit-console.html
+++ b/docs/2.2.10/nunit-console.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.2.10/nunit-gui.html
+++ b/docs/2.2.10/nunit-gui.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.2.10/nunit-gui.html
+++ b/docs/2.2.10/nunit-gui.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.2.10/nunit-gui.html
+++ b/docs/2.2.10/nunit-gui.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.2.10/nunit-gui.html
+++ b/docs/2.2.10/nunit-gui.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.2.10/optionsDialog.html
+++ b/docs/2.2.10/optionsDialog.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.2.10/optionsDialog.html
+++ b/docs/2.2.10/optionsDialog.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.2.10/optionsDialog.html
+++ b/docs/2.2.10/optionsDialog.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.2.10/optionsDialog.html
+++ b/docs/2.2.10/optionsDialog.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.2.10/platform.html
+++ b/docs/2.2.10/platform.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.2.10/platform.html
+++ b/docs/2.2.10/platform.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.2.10/platform.html
+++ b/docs/2.2.10/platform.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.2.10/platform.html
+++ b/docs/2.2.10/platform.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.2.10/projectEditor.html
+++ b/docs/2.2.10/projectEditor.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.2.10/projectEditor.html
+++ b/docs/2.2.10/projectEditor.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.2.10/projectEditor.html
+++ b/docs/2.2.10/projectEditor.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.2.10/projectEditor.html
+++ b/docs/2.2.10/projectEditor.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.2.10/quickStart.html
+++ b/docs/2.2.10/quickStart.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.2.10/quickStart.html
+++ b/docs/2.2.10/quickStart.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.2.10/quickStart.html
+++ b/docs/2.2.10/quickStart.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.2.10/quickStart.html
+++ b/docs/2.2.10/quickStart.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.2.10/quickStartSource.html
+++ b/docs/2.2.10/quickStartSource.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.2.10/quickStartSource.html
+++ b/docs/2.2.10/quickStartSource.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.2.10/quickStartSource.html
+++ b/docs/2.2.10/quickStartSource.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.2.10/quickStartSource.html
+++ b/docs/2.2.10/quickStartSource.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.2.10/releaseNotes.html
+++ b/docs/2.2.10/releaseNotes.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.2.10/releaseNotes.html
+++ b/docs/2.2.10/releaseNotes.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.2.10/releaseNotes.html
+++ b/docs/2.2.10/releaseNotes.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.2.10/releaseNotes.html
+++ b/docs/2.2.10/releaseNotes.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.2.10/samples.html
+++ b/docs/2.2.10/samples.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.2.10/samples.html
+++ b/docs/2.2.10/samples.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.2.10/samples.html
+++ b/docs/2.2.10/samples.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.2.10/samples.html
+++ b/docs/2.2.10/samples.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.2.10/setup.html
+++ b/docs/2.2.10/setup.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.2.10/setup.html
+++ b/docs/2.2.10/setup.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.2.10/setup.html
+++ b/docs/2.2.10/setup.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.2.10/setup.html
+++ b/docs/2.2.10/setup.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.2.10/stringAssert.html
+++ b/docs/2.2.10/stringAssert.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.2.10/stringAssert.html
+++ b/docs/2.2.10/stringAssert.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.2.10/stringAssert.html
+++ b/docs/2.2.10/stringAssert.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.2.10/stringAssert.html
+++ b/docs/2.2.10/stringAssert.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.2.10/suite.html
+++ b/docs/2.2.10/suite.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.2.10/suite.html
+++ b/docs/2.2.10/suite.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.2.10/suite.html
+++ b/docs/2.2.10/suite.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.2.10/suite.html
+++ b/docs/2.2.10/suite.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.2.10/teardown.html
+++ b/docs/2.2.10/teardown.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.2.10/teardown.html
+++ b/docs/2.2.10/teardown.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.2.10/teardown.html
+++ b/docs/2.2.10/teardown.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.2.10/teardown.html
+++ b/docs/2.2.10/teardown.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.2.10/test.html
+++ b/docs/2.2.10/test.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.2.10/test.html
+++ b/docs/2.2.10/test.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.2.10/test.html
+++ b/docs/2.2.10/test.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.2.10/test.html
+++ b/docs/2.2.10/test.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.2.10/testFixture.html
+++ b/docs/2.2.10/testFixture.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.2.10/testFixture.html
+++ b/docs/2.2.10/testFixture.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.2.10/testFixture.html
+++ b/docs/2.2.10/testFixture.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.2.10/testFixture.html
+++ b/docs/2.2.10/testFixture.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.2.10/testProperties.html
+++ b/docs/2.2.10/testProperties.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.2.10/testProperties.html
+++ b/docs/2.2.10/testProperties.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.2.10/testProperties.html
+++ b/docs/2.2.10/testProperties.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.2.10/testProperties.html
+++ b/docs/2.2.10/testProperties.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.2.10/typeAsserts.html
+++ b/docs/2.2.10/typeAsserts.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.2.10/typeAsserts.html
+++ b/docs/2.2.10/typeAsserts.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.2.10/typeAsserts.html
+++ b/docs/2.2.10/typeAsserts.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.2.10/typeAsserts.html
+++ b/docs/2.2.10/typeAsserts.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.2.10/upgrade.html
+++ b/docs/2.2.10/upgrade.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.2.10/upgrade.html
+++ b/docs/2.2.10/upgrade.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.2.10/upgrade.html
+++ b/docs/2.2.10/upgrade.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.2.10/upgrade.html
+++ b/docs/2.2.10/upgrade.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.2.10/utilityAsserts.html
+++ b/docs/2.2.10/utilityAsserts.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.2.10/utilityAsserts.html
+++ b/docs/2.2.10/utilityAsserts.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.2.10/utilityAsserts.html
+++ b/docs/2.2.10/utilityAsserts.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.2.10/utilityAsserts.html
+++ b/docs/2.2.10/utilityAsserts.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.2.10/vsSupport.html
+++ b/docs/2.2.10/vsSupport.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.2.10/vsSupport.html
+++ b/docs/2.2.10/vsSupport.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.2.10/vsSupport.html
+++ b/docs/2.2.10/vsSupport.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.2.10/vsSupport.html
+++ b/docs/2.2.10/vsSupport.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.2.2/assertions.html
+++ b/docs/2.2.2/assertions.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.2.2/assertions.html
+++ b/docs/2.2.2/assertions.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.2.2/assertions.html
+++ b/docs/2.2.2/assertions.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.2.2/assertions.html
+++ b/docs/2.2.2/assertions.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.2.2/attributes.html
+++ b/docs/2.2.2/attributes.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.2.2/attributes.html
+++ b/docs/2.2.2/attributes.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.2.2/attributes.html
+++ b/docs/2.2.2/attributes.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.2.2/attributes.html
+++ b/docs/2.2.2/attributes.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.2.2/category.html
+++ b/docs/2.2.2/category.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.2.2/category.html
+++ b/docs/2.2.2/category.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.2.2/category.html
+++ b/docs/2.2.2/category.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.2.2/category.html
+++ b/docs/2.2.2/category.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.2.2/comparisonAsserts.html
+++ b/docs/2.2.2/comparisonAsserts.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.2.2/comparisonAsserts.html
+++ b/docs/2.2.2/comparisonAsserts.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.2.2/comparisonAsserts.html
+++ b/docs/2.2.2/comparisonAsserts.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.2.2/comparisonAsserts.html
+++ b/docs/2.2.2/comparisonAsserts.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.2.2/conditionAsserts.html
+++ b/docs/2.2.2/conditionAsserts.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.2.2/conditionAsserts.html
+++ b/docs/2.2.2/conditionAsserts.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.2.2/conditionAsserts.html
+++ b/docs/2.2.2/conditionAsserts.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.2.2/conditionAsserts.html
+++ b/docs/2.2.2/conditionAsserts.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.2.2/configEditor.html
+++ b/docs/2.2.2/configEditor.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.2.2/configEditor.html
+++ b/docs/2.2.2/configEditor.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.2.2/configEditor.html
+++ b/docs/2.2.2/configEditor.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.2.2/configEditor.html
+++ b/docs/2.2.2/configEditor.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.2.2/configFiles.html
+++ b/docs/2.2.2/configFiles.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.2.2/configFiles.html
+++ b/docs/2.2.2/configFiles.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.2.2/configFiles.html
+++ b/docs/2.2.2/configFiles.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.2.2/configFiles.html
+++ b/docs/2.2.2/configFiles.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.2.2/consoleCommandLine.html
+++ b/docs/2.2.2/consoleCommandLine.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.2.2/consoleCommandLine.html
+++ b/docs/2.2.2/consoleCommandLine.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.2.2/consoleCommandLine.html
+++ b/docs/2.2.2/consoleCommandLine.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.2.2/consoleCommandLine.html
+++ b/docs/2.2.2/consoleCommandLine.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.2.2/contextMenu.html
+++ b/docs/2.2.2/contextMenu.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.2.2/contextMenu.html
+++ b/docs/2.2.2/contextMenu.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.2.2/contextMenu.html
+++ b/docs/2.2.2/contextMenu.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.2.2/contextMenu.html
+++ b/docs/2.2.2/contextMenu.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.2.2/docHome.html
+++ b/docs/2.2.2/docHome.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.2.2/docHome.html
+++ b/docs/2.2.2/docHome.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.2.2/docHome.html
+++ b/docs/2.2.2/docHome.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.2.2/docHome.html
+++ b/docs/2.2.2/docHome.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.2.2/exception.html
+++ b/docs/2.2.2/exception.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.2.2/exception.html
+++ b/docs/2.2.2/exception.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.2.2/exception.html
+++ b/docs/2.2.2/exception.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.2.2/exception.html
+++ b/docs/2.2.2/exception.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.2.2/explicit.html
+++ b/docs/2.2.2/explicit.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.2.2/explicit.html
+++ b/docs/2.2.2/explicit.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.2.2/explicit.html
+++ b/docs/2.2.2/explicit.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.2.2/explicit.html
+++ b/docs/2.2.2/explicit.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.2.2/features.html
+++ b/docs/2.2.2/features.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.2.2/features.html
+++ b/docs/2.2.2/features.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.2.2/features.html
+++ b/docs/2.2.2/features.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.2.2/features.html
+++ b/docs/2.2.2/features.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.2.2/fixtureSetup.html
+++ b/docs/2.2.2/fixtureSetup.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.2.2/fixtureSetup.html
+++ b/docs/2.2.2/fixtureSetup.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.2.2/fixtureSetup.html
+++ b/docs/2.2.2/fixtureSetup.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.2.2/fixtureSetup.html
+++ b/docs/2.2.2/fixtureSetup.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.2.2/fixtureTeardown.html
+++ b/docs/2.2.2/fixtureTeardown.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.2.2/fixtureTeardown.html
+++ b/docs/2.2.2/fixtureTeardown.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.2.2/fixtureTeardown.html
+++ b/docs/2.2.2/fixtureTeardown.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.2.2/fixtureTeardown.html
+++ b/docs/2.2.2/fixtureTeardown.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.2.2/getStarted.html
+++ b/docs/2.2.2/getStarted.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.2.2/getStarted.html
+++ b/docs/2.2.2/getStarted.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.2.2/getStarted.html
+++ b/docs/2.2.2/getStarted.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.2.2/getStarted.html
+++ b/docs/2.2.2/getStarted.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.2.2/guiCommandLine.html
+++ b/docs/2.2.2/guiCommandLine.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.2.2/guiCommandLine.html
+++ b/docs/2.2.2/guiCommandLine.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.2.2/guiCommandLine.html
+++ b/docs/2.2.2/guiCommandLine.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.2.2/guiCommandLine.html
+++ b/docs/2.2.2/guiCommandLine.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.2.2/ignore.html
+++ b/docs/2.2.2/ignore.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.2.2/ignore.html
+++ b/docs/2.2.2/ignore.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.2.2/ignore.html
+++ b/docs/2.2.2/ignore.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.2.2/ignore.html
+++ b/docs/2.2.2/ignore.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.2.2/installation.html
+++ b/docs/2.2.2/installation.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.2.2/installation.html
+++ b/docs/2.2.2/installation.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.2.2/installation.html
+++ b/docs/2.2.2/installation.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.2.2/installation.html
+++ b/docs/2.2.2/installation.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.2.2/license.html
+++ b/docs/2.2.2/license.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.2.2/license.html
+++ b/docs/2.2.2/license.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.2.2/license.html
+++ b/docs/2.2.2/license.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.2.2/license.html
+++ b/docs/2.2.2/license.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.2.2/mainMenu.html
+++ b/docs/2.2.2/mainMenu.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.2.2/mainMenu.html
+++ b/docs/2.2.2/mainMenu.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.2.2/mainMenu.html
+++ b/docs/2.2.2/mainMenu.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.2.2/mainMenu.html
+++ b/docs/2.2.2/mainMenu.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.2.2/multiAssembly.html
+++ b/docs/2.2.2/multiAssembly.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.2.2/multiAssembly.html
+++ b/docs/2.2.2/multiAssembly.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.2.2/multiAssembly.html
+++ b/docs/2.2.2/multiAssembly.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.2.2/multiAssembly.html
+++ b/docs/2.2.2/multiAssembly.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.2.2/nunit-console.html
+++ b/docs/2.2.2/nunit-console.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.2.2/nunit-console.html
+++ b/docs/2.2.2/nunit-console.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.2.2/nunit-console.html
+++ b/docs/2.2.2/nunit-console.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.2.2/nunit-console.html
+++ b/docs/2.2.2/nunit-console.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.2.2/nunit-gui.html
+++ b/docs/2.2.2/nunit-gui.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.2.2/nunit-gui.html
+++ b/docs/2.2.2/nunit-gui.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.2.2/nunit-gui.html
+++ b/docs/2.2.2/nunit-gui.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.2.2/nunit-gui.html
+++ b/docs/2.2.2/nunit-gui.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.2.2/optionsDialog.html
+++ b/docs/2.2.2/optionsDialog.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.2.2/optionsDialog.html
+++ b/docs/2.2.2/optionsDialog.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.2.2/optionsDialog.html
+++ b/docs/2.2.2/optionsDialog.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.2.2/optionsDialog.html
+++ b/docs/2.2.2/optionsDialog.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.2.2/platform.html
+++ b/docs/2.2.2/platform.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.2.2/platform.html
+++ b/docs/2.2.2/platform.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.2.2/platform.html
+++ b/docs/2.2.2/platform.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.2.2/platform.html
+++ b/docs/2.2.2/platform.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.2.2/projectEditor.html
+++ b/docs/2.2.2/projectEditor.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.2.2/projectEditor.html
+++ b/docs/2.2.2/projectEditor.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.2.2/projectEditor.html
+++ b/docs/2.2.2/projectEditor.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.2.2/projectEditor.html
+++ b/docs/2.2.2/projectEditor.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.2.2/quickStart.html
+++ b/docs/2.2.2/quickStart.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.2.2/quickStart.html
+++ b/docs/2.2.2/quickStart.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.2.2/quickStart.html
+++ b/docs/2.2.2/quickStart.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.2.2/quickStart.html
+++ b/docs/2.2.2/quickStart.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.2.2/quickStartSource.html
+++ b/docs/2.2.2/quickStartSource.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.2.2/quickStartSource.html
+++ b/docs/2.2.2/quickStartSource.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.2.2/quickStartSource.html
+++ b/docs/2.2.2/quickStartSource.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.2.2/quickStartSource.html
+++ b/docs/2.2.2/quickStartSource.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.2.2/releaseNotes.html
+++ b/docs/2.2.2/releaseNotes.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.2.2/releaseNotes.html
+++ b/docs/2.2.2/releaseNotes.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.2.2/releaseNotes.html
+++ b/docs/2.2.2/releaseNotes.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.2.2/releaseNotes.html
+++ b/docs/2.2.2/releaseNotes.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.2.2/samples.html
+++ b/docs/2.2.2/samples.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.2.2/samples.html
+++ b/docs/2.2.2/samples.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.2.2/samples.html
+++ b/docs/2.2.2/samples.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.2.2/samples.html
+++ b/docs/2.2.2/samples.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.2.2/setup.html
+++ b/docs/2.2.2/setup.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.2.2/setup.html
+++ b/docs/2.2.2/setup.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.2.2/setup.html
+++ b/docs/2.2.2/setup.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.2.2/setup.html
+++ b/docs/2.2.2/setup.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.2.2/stringAssert.html
+++ b/docs/2.2.2/stringAssert.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.2.2/stringAssert.html
+++ b/docs/2.2.2/stringAssert.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.2.2/stringAssert.html
+++ b/docs/2.2.2/stringAssert.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.2.2/stringAssert.html
+++ b/docs/2.2.2/stringAssert.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.2.2/suite.html
+++ b/docs/2.2.2/suite.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.2.2/suite.html
+++ b/docs/2.2.2/suite.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.2.2/suite.html
+++ b/docs/2.2.2/suite.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.2.2/suite.html
+++ b/docs/2.2.2/suite.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.2.2/teardown.html
+++ b/docs/2.2.2/teardown.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.2.2/teardown.html
+++ b/docs/2.2.2/teardown.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.2.2/teardown.html
+++ b/docs/2.2.2/teardown.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.2.2/teardown.html
+++ b/docs/2.2.2/teardown.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.2.2/test.html
+++ b/docs/2.2.2/test.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.2.2/test.html
+++ b/docs/2.2.2/test.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.2.2/test.html
+++ b/docs/2.2.2/test.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.2.2/test.html
+++ b/docs/2.2.2/test.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.2.2/testFixture.html
+++ b/docs/2.2.2/testFixture.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.2.2/testFixture.html
+++ b/docs/2.2.2/testFixture.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.2.2/testFixture.html
+++ b/docs/2.2.2/testFixture.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.2.2/testFixture.html
+++ b/docs/2.2.2/testFixture.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.2.2/testProperties.html
+++ b/docs/2.2.2/testProperties.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.2.2/testProperties.html
+++ b/docs/2.2.2/testProperties.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.2.2/testProperties.html
+++ b/docs/2.2.2/testProperties.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.2.2/testProperties.html
+++ b/docs/2.2.2/testProperties.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.2.2/upgrade.html
+++ b/docs/2.2.2/upgrade.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.2.2/upgrade.html
+++ b/docs/2.2.2/upgrade.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.2.2/upgrade.html
+++ b/docs/2.2.2/upgrade.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.2.2/upgrade.html
+++ b/docs/2.2.2/upgrade.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.2.2/utilityAsserts.html
+++ b/docs/2.2.2/utilityAsserts.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.2.2/utilityAsserts.html
+++ b/docs/2.2.2/utilityAsserts.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.2.2/utilityAsserts.html
+++ b/docs/2.2.2/utilityAsserts.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.2.2/utilityAsserts.html
+++ b/docs/2.2.2/utilityAsserts.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.2.2/vsSupport.html
+++ b/docs/2.2.2/vsSupport.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.2.2/vsSupport.html
+++ b/docs/2.2.2/vsSupport.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.2.2/vsSupport.html
+++ b/docs/2.2.2/vsSupport.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.2.2/vsSupport.html
+++ b/docs/2.2.2/vsSupport.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.2.3/assertions.html
+++ b/docs/2.2.3/assertions.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.2.3/assertions.html
+++ b/docs/2.2.3/assertions.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.2.3/assertions.html
+++ b/docs/2.2.3/assertions.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.2.3/assertions.html
+++ b/docs/2.2.3/assertions.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.2.3/attributes.html
+++ b/docs/2.2.3/attributes.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.2.3/attributes.html
+++ b/docs/2.2.3/attributes.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.2.3/attributes.html
+++ b/docs/2.2.3/attributes.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.2.3/attributes.html
+++ b/docs/2.2.3/attributes.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.2.3/category.html
+++ b/docs/2.2.3/category.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.2.3/category.html
+++ b/docs/2.2.3/category.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.2.3/category.html
+++ b/docs/2.2.3/category.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.2.3/category.html
+++ b/docs/2.2.3/category.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.2.3/conditionAsserts.html
+++ b/docs/2.2.3/conditionAsserts.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.2.3/conditionAsserts.html
+++ b/docs/2.2.3/conditionAsserts.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.2.3/conditionAsserts.html
+++ b/docs/2.2.3/conditionAsserts.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.2.3/conditionAsserts.html
+++ b/docs/2.2.3/conditionAsserts.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.2.3/configEditor.html
+++ b/docs/2.2.3/configEditor.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.2.3/configEditor.html
+++ b/docs/2.2.3/configEditor.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.2.3/configEditor.html
+++ b/docs/2.2.3/configEditor.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.2.3/configEditor.html
+++ b/docs/2.2.3/configEditor.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.2.3/configFiles.html
+++ b/docs/2.2.3/configFiles.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.2.3/configFiles.html
+++ b/docs/2.2.3/configFiles.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.2.3/configFiles.html
+++ b/docs/2.2.3/configFiles.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.2.3/configFiles.html
+++ b/docs/2.2.3/configFiles.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.2.3/consoleCommandLine.html
+++ b/docs/2.2.3/consoleCommandLine.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.2.3/consoleCommandLine.html
+++ b/docs/2.2.3/consoleCommandLine.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.2.3/consoleCommandLine.html
+++ b/docs/2.2.3/consoleCommandLine.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.2.3/consoleCommandLine.html
+++ b/docs/2.2.3/consoleCommandLine.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.2.3/contextMenu.html
+++ b/docs/2.2.3/contextMenu.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.2.3/contextMenu.html
+++ b/docs/2.2.3/contextMenu.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.2.3/contextMenu.html
+++ b/docs/2.2.3/contextMenu.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.2.3/contextMenu.html
+++ b/docs/2.2.3/contextMenu.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.2.3/docHome.html
+++ b/docs/2.2.3/docHome.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.2.3/docHome.html
+++ b/docs/2.2.3/docHome.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.2.3/docHome.html
+++ b/docs/2.2.3/docHome.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.2.3/docHome.html
+++ b/docs/2.2.3/docHome.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.2.3/equalityAsserts.html
+++ b/docs/2.2.3/equalityAsserts.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.2.3/equalityAsserts.html
+++ b/docs/2.2.3/equalityAsserts.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.2.3/equalityAsserts.html
+++ b/docs/2.2.3/equalityAsserts.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.2.3/equalityAsserts.html
+++ b/docs/2.2.3/equalityAsserts.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.2.3/exception.html
+++ b/docs/2.2.3/exception.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.2.3/exception.html
+++ b/docs/2.2.3/exception.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.2.3/exception.html
+++ b/docs/2.2.3/exception.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.2.3/exception.html
+++ b/docs/2.2.3/exception.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.2.3/explicit.html
+++ b/docs/2.2.3/explicit.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.2.3/explicit.html
+++ b/docs/2.2.3/explicit.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.2.3/explicit.html
+++ b/docs/2.2.3/explicit.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.2.3/explicit.html
+++ b/docs/2.2.3/explicit.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.2.3/features.html
+++ b/docs/2.2.3/features.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.2.3/features.html
+++ b/docs/2.2.3/features.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.2.3/features.html
+++ b/docs/2.2.3/features.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.2.3/features.html
+++ b/docs/2.2.3/features.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.2.3/fixtureSetup.html
+++ b/docs/2.2.3/fixtureSetup.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.2.3/fixtureSetup.html
+++ b/docs/2.2.3/fixtureSetup.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.2.3/fixtureSetup.html
+++ b/docs/2.2.3/fixtureSetup.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.2.3/fixtureSetup.html
+++ b/docs/2.2.3/fixtureSetup.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.2.3/fixtureTeardown.html
+++ b/docs/2.2.3/fixtureTeardown.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.2.3/fixtureTeardown.html
+++ b/docs/2.2.3/fixtureTeardown.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.2.3/fixtureTeardown.html
+++ b/docs/2.2.3/fixtureTeardown.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.2.3/fixtureTeardown.html
+++ b/docs/2.2.3/fixtureTeardown.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.2.3/getStarted.html
+++ b/docs/2.2.3/getStarted.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.2.3/getStarted.html
+++ b/docs/2.2.3/getStarted.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.2.3/getStarted.html
+++ b/docs/2.2.3/getStarted.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.2.3/getStarted.html
+++ b/docs/2.2.3/getStarted.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.2.3/guiCommandLine.html
+++ b/docs/2.2.3/guiCommandLine.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.2.3/guiCommandLine.html
+++ b/docs/2.2.3/guiCommandLine.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.2.3/guiCommandLine.html
+++ b/docs/2.2.3/guiCommandLine.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.2.3/guiCommandLine.html
+++ b/docs/2.2.3/guiCommandLine.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.2.3/identityAsserts.html
+++ b/docs/2.2.3/identityAsserts.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.2.3/identityAsserts.html
+++ b/docs/2.2.3/identityAsserts.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.2.3/identityAsserts.html
+++ b/docs/2.2.3/identityAsserts.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.2.3/identityAsserts.html
+++ b/docs/2.2.3/identityAsserts.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.2.3/ignore.html
+++ b/docs/2.2.3/ignore.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.2.3/ignore.html
+++ b/docs/2.2.3/ignore.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.2.3/ignore.html
+++ b/docs/2.2.3/ignore.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.2.3/ignore.html
+++ b/docs/2.2.3/ignore.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.2.3/installation.html
+++ b/docs/2.2.3/installation.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.2.3/installation.html
+++ b/docs/2.2.3/installation.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.2.3/installation.html
+++ b/docs/2.2.3/installation.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.2.3/installation.html
+++ b/docs/2.2.3/installation.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.2.3/license.html
+++ b/docs/2.2.3/license.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.2.3/license.html
+++ b/docs/2.2.3/license.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.2.3/license.html
+++ b/docs/2.2.3/license.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.2.3/license.html
+++ b/docs/2.2.3/license.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.2.3/mainMenu.html
+++ b/docs/2.2.3/mainMenu.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.2.3/mainMenu.html
+++ b/docs/2.2.3/mainMenu.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.2.3/mainMenu.html
+++ b/docs/2.2.3/mainMenu.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.2.3/mainMenu.html
+++ b/docs/2.2.3/mainMenu.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.2.3/multiAssembly.html
+++ b/docs/2.2.3/multiAssembly.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.2.3/multiAssembly.html
+++ b/docs/2.2.3/multiAssembly.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.2.3/multiAssembly.html
+++ b/docs/2.2.3/multiAssembly.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.2.3/multiAssembly.html
+++ b/docs/2.2.3/multiAssembly.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.2.3/nunit-console.html
+++ b/docs/2.2.3/nunit-console.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.2.3/nunit-console.html
+++ b/docs/2.2.3/nunit-console.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.2.3/nunit-console.html
+++ b/docs/2.2.3/nunit-console.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.2.3/nunit-console.html
+++ b/docs/2.2.3/nunit-console.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.2.3/nunit-gui.html
+++ b/docs/2.2.3/nunit-gui.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.2.3/nunit-gui.html
+++ b/docs/2.2.3/nunit-gui.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.2.3/nunit-gui.html
+++ b/docs/2.2.3/nunit-gui.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.2.3/nunit-gui.html
+++ b/docs/2.2.3/nunit-gui.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.2.3/optionsDialog.html
+++ b/docs/2.2.3/optionsDialog.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.2.3/optionsDialog.html
+++ b/docs/2.2.3/optionsDialog.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.2.3/optionsDialog.html
+++ b/docs/2.2.3/optionsDialog.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.2.3/optionsDialog.html
+++ b/docs/2.2.3/optionsDialog.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.2.3/platform.html
+++ b/docs/2.2.3/platform.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.2.3/platform.html
+++ b/docs/2.2.3/platform.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.2.3/platform.html
+++ b/docs/2.2.3/platform.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.2.3/platform.html
+++ b/docs/2.2.3/platform.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.2.3/projectEditor.html
+++ b/docs/2.2.3/projectEditor.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.2.3/projectEditor.html
+++ b/docs/2.2.3/projectEditor.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.2.3/projectEditor.html
+++ b/docs/2.2.3/projectEditor.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.2.3/projectEditor.html
+++ b/docs/2.2.3/projectEditor.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.2.3/quickStart.html
+++ b/docs/2.2.3/quickStart.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.2.3/quickStart.html
+++ b/docs/2.2.3/quickStart.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.2.3/quickStart.html
+++ b/docs/2.2.3/quickStart.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.2.3/quickStart.html
+++ b/docs/2.2.3/quickStart.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.2.3/quickStartSource.html
+++ b/docs/2.2.3/quickStartSource.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.2.3/quickStartSource.html
+++ b/docs/2.2.3/quickStartSource.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.2.3/quickStartSource.html
+++ b/docs/2.2.3/quickStartSource.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.2.3/quickStartSource.html
+++ b/docs/2.2.3/quickStartSource.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.2.3/releaseNotes.html
+++ b/docs/2.2.3/releaseNotes.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.2.3/releaseNotes.html
+++ b/docs/2.2.3/releaseNotes.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.2.3/releaseNotes.html
+++ b/docs/2.2.3/releaseNotes.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.2.3/releaseNotes.html
+++ b/docs/2.2.3/releaseNotes.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.2.3/samples.html
+++ b/docs/2.2.3/samples.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.2.3/samples.html
+++ b/docs/2.2.3/samples.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.2.3/samples.html
+++ b/docs/2.2.3/samples.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.2.3/samples.html
+++ b/docs/2.2.3/samples.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.2.3/setup.html
+++ b/docs/2.2.3/setup.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.2.3/setup.html
+++ b/docs/2.2.3/setup.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.2.3/setup.html
+++ b/docs/2.2.3/setup.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.2.3/setup.html
+++ b/docs/2.2.3/setup.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.2.3/stringAssert.html
+++ b/docs/2.2.3/stringAssert.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.2.3/stringAssert.html
+++ b/docs/2.2.3/stringAssert.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.2.3/stringAssert.html
+++ b/docs/2.2.3/stringAssert.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.2.3/stringAssert.html
+++ b/docs/2.2.3/stringAssert.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.2.3/suite.html
+++ b/docs/2.2.3/suite.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.2.3/suite.html
+++ b/docs/2.2.3/suite.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.2.3/suite.html
+++ b/docs/2.2.3/suite.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.2.3/suite.html
+++ b/docs/2.2.3/suite.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.2.3/teardown.html
+++ b/docs/2.2.3/teardown.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.2.3/teardown.html
+++ b/docs/2.2.3/teardown.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.2.3/teardown.html
+++ b/docs/2.2.3/teardown.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.2.3/teardown.html
+++ b/docs/2.2.3/teardown.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.2.3/test.html
+++ b/docs/2.2.3/test.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.2.3/test.html
+++ b/docs/2.2.3/test.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.2.3/test.html
+++ b/docs/2.2.3/test.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.2.3/test.html
+++ b/docs/2.2.3/test.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.2.3/testFixture.html
+++ b/docs/2.2.3/testFixture.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.2.3/testFixture.html
+++ b/docs/2.2.3/testFixture.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.2.3/testFixture.html
+++ b/docs/2.2.3/testFixture.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.2.3/testFixture.html
+++ b/docs/2.2.3/testFixture.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.2.3/testProperties.html
+++ b/docs/2.2.3/testProperties.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.2.3/testProperties.html
+++ b/docs/2.2.3/testProperties.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.2.3/testProperties.html
+++ b/docs/2.2.3/testProperties.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.2.3/testProperties.html
+++ b/docs/2.2.3/testProperties.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.2.3/typeAsserts.html
+++ b/docs/2.2.3/typeAsserts.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.2.3/typeAsserts.html
+++ b/docs/2.2.3/typeAsserts.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.2.3/typeAsserts.html
+++ b/docs/2.2.3/typeAsserts.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.2.3/typeAsserts.html
+++ b/docs/2.2.3/typeAsserts.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.2.3/upgrade.html
+++ b/docs/2.2.3/upgrade.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.2.3/upgrade.html
+++ b/docs/2.2.3/upgrade.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.2.3/upgrade.html
+++ b/docs/2.2.3/upgrade.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.2.3/upgrade.html
+++ b/docs/2.2.3/upgrade.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.2.3/utilityAsserts.html
+++ b/docs/2.2.3/utilityAsserts.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.2.3/utilityAsserts.html
+++ b/docs/2.2.3/utilityAsserts.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.2.3/utilityAsserts.html
+++ b/docs/2.2.3/utilityAsserts.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.2.3/utilityAsserts.html
+++ b/docs/2.2.3/utilityAsserts.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.2.3/vsSupport.html
+++ b/docs/2.2.3/vsSupport.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.2.3/vsSupport.html
+++ b/docs/2.2.3/vsSupport.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.2.3/vsSupport.html
+++ b/docs/2.2.3/vsSupport.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.2.3/vsSupport.html
+++ b/docs/2.2.3/vsSupport.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.2.4/assertions.html
+++ b/docs/2.2.4/assertions.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.2.4/assertions.html
+++ b/docs/2.2.4/assertions.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.2.4/assertions.html
+++ b/docs/2.2.4/assertions.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.2.4/assertions.html
+++ b/docs/2.2.4/assertions.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.2.4/attributes.html
+++ b/docs/2.2.4/attributes.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.2.4/attributes.html
+++ b/docs/2.2.4/attributes.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.2.4/attributes.html
+++ b/docs/2.2.4/attributes.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.2.4/attributes.html
+++ b/docs/2.2.4/attributes.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.2.4/category.html
+++ b/docs/2.2.4/category.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.2.4/category.html
+++ b/docs/2.2.4/category.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.2.4/category.html
+++ b/docs/2.2.4/category.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.2.4/category.html
+++ b/docs/2.2.4/category.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.2.4/comparisonAsserts.html
+++ b/docs/2.2.4/comparisonAsserts.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.2.4/comparisonAsserts.html
+++ b/docs/2.2.4/comparisonAsserts.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.2.4/comparisonAsserts.html
+++ b/docs/2.2.4/comparisonAsserts.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.2.4/comparisonAsserts.html
+++ b/docs/2.2.4/comparisonAsserts.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.2.4/conditionAsserts.html
+++ b/docs/2.2.4/conditionAsserts.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.2.4/conditionAsserts.html
+++ b/docs/2.2.4/conditionAsserts.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.2.4/conditionAsserts.html
+++ b/docs/2.2.4/conditionAsserts.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.2.4/conditionAsserts.html
+++ b/docs/2.2.4/conditionAsserts.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.2.4/configEditor.html
+++ b/docs/2.2.4/configEditor.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.2.4/configEditor.html
+++ b/docs/2.2.4/configEditor.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.2.4/configEditor.html
+++ b/docs/2.2.4/configEditor.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.2.4/configEditor.html
+++ b/docs/2.2.4/configEditor.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.2.4/configFiles.html
+++ b/docs/2.2.4/configFiles.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.2.4/configFiles.html
+++ b/docs/2.2.4/configFiles.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.2.4/configFiles.html
+++ b/docs/2.2.4/configFiles.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.2.4/configFiles.html
+++ b/docs/2.2.4/configFiles.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.2.4/consoleCommandLine.html
+++ b/docs/2.2.4/consoleCommandLine.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.2.4/consoleCommandLine.html
+++ b/docs/2.2.4/consoleCommandLine.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.2.4/consoleCommandLine.html
+++ b/docs/2.2.4/consoleCommandLine.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.2.4/consoleCommandLine.html
+++ b/docs/2.2.4/consoleCommandLine.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.2.4/contextMenu.html
+++ b/docs/2.2.4/contextMenu.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.2.4/contextMenu.html
+++ b/docs/2.2.4/contextMenu.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.2.4/contextMenu.html
+++ b/docs/2.2.4/contextMenu.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.2.4/contextMenu.html
+++ b/docs/2.2.4/contextMenu.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.2.4/docHome.html
+++ b/docs/2.2.4/docHome.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.2.4/docHome.html
+++ b/docs/2.2.4/docHome.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.2.4/docHome.html
+++ b/docs/2.2.4/docHome.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.2.4/docHome.html
+++ b/docs/2.2.4/docHome.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.2.4/equalityAsserts.html
+++ b/docs/2.2.4/equalityAsserts.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.2.4/equalityAsserts.html
+++ b/docs/2.2.4/equalityAsserts.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.2.4/equalityAsserts.html
+++ b/docs/2.2.4/equalityAsserts.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.2.4/equalityAsserts.html
+++ b/docs/2.2.4/equalityAsserts.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.2.4/exception.html
+++ b/docs/2.2.4/exception.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.2.4/exception.html
+++ b/docs/2.2.4/exception.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.2.4/exception.html
+++ b/docs/2.2.4/exception.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.2.4/exception.html
+++ b/docs/2.2.4/exception.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.2.4/explicit.html
+++ b/docs/2.2.4/explicit.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.2.4/explicit.html
+++ b/docs/2.2.4/explicit.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.2.4/explicit.html
+++ b/docs/2.2.4/explicit.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.2.4/explicit.html
+++ b/docs/2.2.4/explicit.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.2.4/features.html
+++ b/docs/2.2.4/features.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.2.4/features.html
+++ b/docs/2.2.4/features.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.2.4/features.html
+++ b/docs/2.2.4/features.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.2.4/features.html
+++ b/docs/2.2.4/features.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.2.4/fixtureSetup.html
+++ b/docs/2.2.4/fixtureSetup.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.2.4/fixtureSetup.html
+++ b/docs/2.2.4/fixtureSetup.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.2.4/fixtureSetup.html
+++ b/docs/2.2.4/fixtureSetup.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.2.4/fixtureSetup.html
+++ b/docs/2.2.4/fixtureSetup.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.2.4/fixtureTeardown.html
+++ b/docs/2.2.4/fixtureTeardown.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.2.4/fixtureTeardown.html
+++ b/docs/2.2.4/fixtureTeardown.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.2.4/fixtureTeardown.html
+++ b/docs/2.2.4/fixtureTeardown.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.2.4/fixtureTeardown.html
+++ b/docs/2.2.4/fixtureTeardown.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.2.4/getStarted.html
+++ b/docs/2.2.4/getStarted.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.2.4/getStarted.html
+++ b/docs/2.2.4/getStarted.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.2.4/getStarted.html
+++ b/docs/2.2.4/getStarted.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.2.4/getStarted.html
+++ b/docs/2.2.4/getStarted.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.2.4/guiCommandLine.html
+++ b/docs/2.2.4/guiCommandLine.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.2.4/guiCommandLine.html
+++ b/docs/2.2.4/guiCommandLine.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.2.4/guiCommandLine.html
+++ b/docs/2.2.4/guiCommandLine.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.2.4/guiCommandLine.html
+++ b/docs/2.2.4/guiCommandLine.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.2.4/identityAsserts.html
+++ b/docs/2.2.4/identityAsserts.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.2.4/identityAsserts.html
+++ b/docs/2.2.4/identityAsserts.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.2.4/identityAsserts.html
+++ b/docs/2.2.4/identityAsserts.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.2.4/identityAsserts.html
+++ b/docs/2.2.4/identityAsserts.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.2.4/ignore.html
+++ b/docs/2.2.4/ignore.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.2.4/ignore.html
+++ b/docs/2.2.4/ignore.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.2.4/ignore.html
+++ b/docs/2.2.4/ignore.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.2.4/ignore.html
+++ b/docs/2.2.4/ignore.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.2.4/installation.html
+++ b/docs/2.2.4/installation.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.2.4/installation.html
+++ b/docs/2.2.4/installation.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.2.4/installation.html
+++ b/docs/2.2.4/installation.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.2.4/installation.html
+++ b/docs/2.2.4/installation.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.2.4/license.html
+++ b/docs/2.2.4/license.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.2.4/license.html
+++ b/docs/2.2.4/license.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.2.4/license.html
+++ b/docs/2.2.4/license.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.2.4/license.html
+++ b/docs/2.2.4/license.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.2.4/mainMenu.html
+++ b/docs/2.2.4/mainMenu.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.2.4/mainMenu.html
+++ b/docs/2.2.4/mainMenu.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.2.4/mainMenu.html
+++ b/docs/2.2.4/mainMenu.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.2.4/mainMenu.html
+++ b/docs/2.2.4/mainMenu.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.2.4/multiAssembly.html
+++ b/docs/2.2.4/multiAssembly.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.2.4/multiAssembly.html
+++ b/docs/2.2.4/multiAssembly.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.2.4/multiAssembly.html
+++ b/docs/2.2.4/multiAssembly.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.2.4/multiAssembly.html
+++ b/docs/2.2.4/multiAssembly.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.2.4/nunit-console.html
+++ b/docs/2.2.4/nunit-console.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.2.4/nunit-console.html
+++ b/docs/2.2.4/nunit-console.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.2.4/nunit-console.html
+++ b/docs/2.2.4/nunit-console.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.2.4/nunit-console.html
+++ b/docs/2.2.4/nunit-console.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.2.4/nunit-gui.html
+++ b/docs/2.2.4/nunit-gui.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.2.4/nunit-gui.html
+++ b/docs/2.2.4/nunit-gui.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.2.4/nunit-gui.html
+++ b/docs/2.2.4/nunit-gui.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.2.4/nunit-gui.html
+++ b/docs/2.2.4/nunit-gui.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.2.4/optionsDialog.html
+++ b/docs/2.2.4/optionsDialog.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.2.4/optionsDialog.html
+++ b/docs/2.2.4/optionsDialog.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.2.4/optionsDialog.html
+++ b/docs/2.2.4/optionsDialog.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.2.4/optionsDialog.html
+++ b/docs/2.2.4/optionsDialog.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.2.4/platform.html
+++ b/docs/2.2.4/platform.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.2.4/platform.html
+++ b/docs/2.2.4/platform.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.2.4/platform.html
+++ b/docs/2.2.4/platform.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.2.4/platform.html
+++ b/docs/2.2.4/platform.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.2.4/projectEditor.html
+++ b/docs/2.2.4/projectEditor.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.2.4/projectEditor.html
+++ b/docs/2.2.4/projectEditor.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.2.4/projectEditor.html
+++ b/docs/2.2.4/projectEditor.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.2.4/projectEditor.html
+++ b/docs/2.2.4/projectEditor.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.2.4/quickStart.html
+++ b/docs/2.2.4/quickStart.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.2.4/quickStart.html
+++ b/docs/2.2.4/quickStart.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.2.4/quickStart.html
+++ b/docs/2.2.4/quickStart.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.2.4/quickStart.html
+++ b/docs/2.2.4/quickStart.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.2.4/quickStartSource.html
+++ b/docs/2.2.4/quickStartSource.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.2.4/quickStartSource.html
+++ b/docs/2.2.4/quickStartSource.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.2.4/quickStartSource.html
+++ b/docs/2.2.4/quickStartSource.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.2.4/quickStartSource.html
+++ b/docs/2.2.4/quickStartSource.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.2.4/releaseNotes.html
+++ b/docs/2.2.4/releaseNotes.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.2.4/releaseNotes.html
+++ b/docs/2.2.4/releaseNotes.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.2.4/releaseNotes.html
+++ b/docs/2.2.4/releaseNotes.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.2.4/releaseNotes.html
+++ b/docs/2.2.4/releaseNotes.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.2.4/samples.html
+++ b/docs/2.2.4/samples.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.2.4/samples.html
+++ b/docs/2.2.4/samples.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.2.4/samples.html
+++ b/docs/2.2.4/samples.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.2.4/samples.html
+++ b/docs/2.2.4/samples.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.2.4/setup.html
+++ b/docs/2.2.4/setup.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.2.4/setup.html
+++ b/docs/2.2.4/setup.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.2.4/setup.html
+++ b/docs/2.2.4/setup.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.2.4/setup.html
+++ b/docs/2.2.4/setup.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.2.4/stringAssert.html
+++ b/docs/2.2.4/stringAssert.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.2.4/stringAssert.html
+++ b/docs/2.2.4/stringAssert.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.2.4/stringAssert.html
+++ b/docs/2.2.4/stringAssert.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.2.4/stringAssert.html
+++ b/docs/2.2.4/stringAssert.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.2.4/suite.html
+++ b/docs/2.2.4/suite.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.2.4/suite.html
+++ b/docs/2.2.4/suite.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.2.4/suite.html
+++ b/docs/2.2.4/suite.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.2.4/suite.html
+++ b/docs/2.2.4/suite.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.2.4/teardown.html
+++ b/docs/2.2.4/teardown.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.2.4/teardown.html
+++ b/docs/2.2.4/teardown.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.2.4/teardown.html
+++ b/docs/2.2.4/teardown.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.2.4/teardown.html
+++ b/docs/2.2.4/teardown.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.2.4/test.html
+++ b/docs/2.2.4/test.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.2.4/test.html
+++ b/docs/2.2.4/test.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.2.4/test.html
+++ b/docs/2.2.4/test.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.2.4/test.html
+++ b/docs/2.2.4/test.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.2.4/testFixture.html
+++ b/docs/2.2.4/testFixture.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.2.4/testFixture.html
+++ b/docs/2.2.4/testFixture.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.2.4/testFixture.html
+++ b/docs/2.2.4/testFixture.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.2.4/testFixture.html
+++ b/docs/2.2.4/testFixture.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.2.4/testProperties.html
+++ b/docs/2.2.4/testProperties.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.2.4/testProperties.html
+++ b/docs/2.2.4/testProperties.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.2.4/testProperties.html
+++ b/docs/2.2.4/testProperties.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.2.4/testProperties.html
+++ b/docs/2.2.4/testProperties.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.2.4/typeAsserts.html
+++ b/docs/2.2.4/typeAsserts.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.2.4/typeAsserts.html
+++ b/docs/2.2.4/typeAsserts.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.2.4/typeAsserts.html
+++ b/docs/2.2.4/typeAsserts.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.2.4/typeAsserts.html
+++ b/docs/2.2.4/typeAsserts.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.2.4/upgrade.html
+++ b/docs/2.2.4/upgrade.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.2.4/upgrade.html
+++ b/docs/2.2.4/upgrade.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.2.4/upgrade.html
+++ b/docs/2.2.4/upgrade.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.2.4/upgrade.html
+++ b/docs/2.2.4/upgrade.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.2.4/utilityAsserts.html
+++ b/docs/2.2.4/utilityAsserts.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.2.4/utilityAsserts.html
+++ b/docs/2.2.4/utilityAsserts.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.2.4/utilityAsserts.html
+++ b/docs/2.2.4/utilityAsserts.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.2.4/utilityAsserts.html
+++ b/docs/2.2.4/utilityAsserts.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.2.4/vsSupport.html
+++ b/docs/2.2.4/vsSupport.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.2.4/vsSupport.html
+++ b/docs/2.2.4/vsSupport.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.2.4/vsSupport.html
+++ b/docs/2.2.4/vsSupport.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.2.4/vsSupport.html
+++ b/docs/2.2.4/vsSupport.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.2.5/assertions.html
+++ b/docs/2.2.5/assertions.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.2.5/assertions.html
+++ b/docs/2.2.5/assertions.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.2.5/assertions.html
+++ b/docs/2.2.5/assertions.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.2.5/assertions.html
+++ b/docs/2.2.5/assertions.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.2.5/attributes.html
+++ b/docs/2.2.5/attributes.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.2.5/attributes.html
+++ b/docs/2.2.5/attributes.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.2.5/attributes.html
+++ b/docs/2.2.5/attributes.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.2.5/attributes.html
+++ b/docs/2.2.5/attributes.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.2.5/category.html
+++ b/docs/2.2.5/category.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.2.5/category.html
+++ b/docs/2.2.5/category.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.2.5/category.html
+++ b/docs/2.2.5/category.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.2.5/category.html
+++ b/docs/2.2.5/category.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.2.5/comparisonAsserts.html
+++ b/docs/2.2.5/comparisonAsserts.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.2.5/comparisonAsserts.html
+++ b/docs/2.2.5/comparisonAsserts.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.2.5/comparisonAsserts.html
+++ b/docs/2.2.5/comparisonAsserts.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.2.5/comparisonAsserts.html
+++ b/docs/2.2.5/comparisonAsserts.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.2.5/conditionAsserts.html
+++ b/docs/2.2.5/conditionAsserts.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.2.5/conditionAsserts.html
+++ b/docs/2.2.5/conditionAsserts.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.2.5/conditionAsserts.html
+++ b/docs/2.2.5/conditionAsserts.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.2.5/conditionAsserts.html
+++ b/docs/2.2.5/conditionAsserts.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.2.5/configEditor.html
+++ b/docs/2.2.5/configEditor.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.2.5/configEditor.html
+++ b/docs/2.2.5/configEditor.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.2.5/configEditor.html
+++ b/docs/2.2.5/configEditor.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.2.5/configEditor.html
+++ b/docs/2.2.5/configEditor.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.2.5/configFiles.html
+++ b/docs/2.2.5/configFiles.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.2.5/configFiles.html
+++ b/docs/2.2.5/configFiles.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.2.5/configFiles.html
+++ b/docs/2.2.5/configFiles.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.2.5/configFiles.html
+++ b/docs/2.2.5/configFiles.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.2.5/consoleCommandLine.html
+++ b/docs/2.2.5/consoleCommandLine.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.2.5/consoleCommandLine.html
+++ b/docs/2.2.5/consoleCommandLine.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.2.5/consoleCommandLine.html
+++ b/docs/2.2.5/consoleCommandLine.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.2.5/consoleCommandLine.html
+++ b/docs/2.2.5/consoleCommandLine.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.2.5/contextMenu.html
+++ b/docs/2.2.5/contextMenu.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.2.5/contextMenu.html
+++ b/docs/2.2.5/contextMenu.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.2.5/contextMenu.html
+++ b/docs/2.2.5/contextMenu.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.2.5/contextMenu.html
+++ b/docs/2.2.5/contextMenu.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.2.5/docHome.html
+++ b/docs/2.2.5/docHome.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.2.5/docHome.html
+++ b/docs/2.2.5/docHome.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.2.5/docHome.html
+++ b/docs/2.2.5/docHome.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.2.5/docHome.html
+++ b/docs/2.2.5/docHome.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.2.5/equalityAsserts.html
+++ b/docs/2.2.5/equalityAsserts.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.2.5/equalityAsserts.html
+++ b/docs/2.2.5/equalityAsserts.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.2.5/equalityAsserts.html
+++ b/docs/2.2.5/equalityAsserts.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.2.5/equalityAsserts.html
+++ b/docs/2.2.5/equalityAsserts.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.2.5/exception.html
+++ b/docs/2.2.5/exception.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.2.5/exception.html
+++ b/docs/2.2.5/exception.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.2.5/exception.html
+++ b/docs/2.2.5/exception.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.2.5/exception.html
+++ b/docs/2.2.5/exception.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.2.5/explicit.html
+++ b/docs/2.2.5/explicit.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.2.5/explicit.html
+++ b/docs/2.2.5/explicit.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.2.5/explicit.html
+++ b/docs/2.2.5/explicit.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.2.5/explicit.html
+++ b/docs/2.2.5/explicit.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.2.5/features.html
+++ b/docs/2.2.5/features.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.2.5/features.html
+++ b/docs/2.2.5/features.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.2.5/features.html
+++ b/docs/2.2.5/features.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.2.5/features.html
+++ b/docs/2.2.5/features.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.2.5/fixtureSetup.html
+++ b/docs/2.2.5/fixtureSetup.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.2.5/fixtureSetup.html
+++ b/docs/2.2.5/fixtureSetup.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.2.5/fixtureSetup.html
+++ b/docs/2.2.5/fixtureSetup.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.2.5/fixtureSetup.html
+++ b/docs/2.2.5/fixtureSetup.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.2.5/fixtureTeardown.html
+++ b/docs/2.2.5/fixtureTeardown.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.2.5/fixtureTeardown.html
+++ b/docs/2.2.5/fixtureTeardown.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.2.5/fixtureTeardown.html
+++ b/docs/2.2.5/fixtureTeardown.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.2.5/fixtureTeardown.html
+++ b/docs/2.2.5/fixtureTeardown.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.2.5/getStarted.html
+++ b/docs/2.2.5/getStarted.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.2.5/getStarted.html
+++ b/docs/2.2.5/getStarted.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.2.5/getStarted.html
+++ b/docs/2.2.5/getStarted.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.2.5/getStarted.html
+++ b/docs/2.2.5/getStarted.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.2.5/guiCommandLine.html
+++ b/docs/2.2.5/guiCommandLine.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.2.5/guiCommandLine.html
+++ b/docs/2.2.5/guiCommandLine.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.2.5/guiCommandLine.html
+++ b/docs/2.2.5/guiCommandLine.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.2.5/guiCommandLine.html
+++ b/docs/2.2.5/guiCommandLine.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.2.5/identityAsserts.html
+++ b/docs/2.2.5/identityAsserts.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.2.5/identityAsserts.html
+++ b/docs/2.2.5/identityAsserts.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.2.5/identityAsserts.html
+++ b/docs/2.2.5/identityAsserts.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.2.5/identityAsserts.html
+++ b/docs/2.2.5/identityAsserts.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.2.5/ignore.html
+++ b/docs/2.2.5/ignore.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.2.5/ignore.html
+++ b/docs/2.2.5/ignore.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.2.5/ignore.html
+++ b/docs/2.2.5/ignore.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.2.5/ignore.html
+++ b/docs/2.2.5/ignore.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.2.5/installation.html
+++ b/docs/2.2.5/installation.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.2.5/installation.html
+++ b/docs/2.2.5/installation.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.2.5/installation.html
+++ b/docs/2.2.5/installation.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.2.5/installation.html
+++ b/docs/2.2.5/installation.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.2.5/license.html
+++ b/docs/2.2.5/license.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.2.5/license.html
+++ b/docs/2.2.5/license.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.2.5/license.html
+++ b/docs/2.2.5/license.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.2.5/license.html
+++ b/docs/2.2.5/license.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.2.5/mainMenu.html
+++ b/docs/2.2.5/mainMenu.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.2.5/mainMenu.html
+++ b/docs/2.2.5/mainMenu.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.2.5/mainMenu.html
+++ b/docs/2.2.5/mainMenu.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.2.5/mainMenu.html
+++ b/docs/2.2.5/mainMenu.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.2.5/multiAssembly.html
+++ b/docs/2.2.5/multiAssembly.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.2.5/multiAssembly.html
+++ b/docs/2.2.5/multiAssembly.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.2.5/multiAssembly.html
+++ b/docs/2.2.5/multiAssembly.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.2.5/multiAssembly.html
+++ b/docs/2.2.5/multiAssembly.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.2.5/nunit-console.html
+++ b/docs/2.2.5/nunit-console.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.2.5/nunit-console.html
+++ b/docs/2.2.5/nunit-console.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.2.5/nunit-console.html
+++ b/docs/2.2.5/nunit-console.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.2.5/nunit-console.html
+++ b/docs/2.2.5/nunit-console.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.2.5/nunit-gui.html
+++ b/docs/2.2.5/nunit-gui.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.2.5/nunit-gui.html
+++ b/docs/2.2.5/nunit-gui.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.2.5/nunit-gui.html
+++ b/docs/2.2.5/nunit-gui.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.2.5/nunit-gui.html
+++ b/docs/2.2.5/nunit-gui.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.2.5/optionsDialog.html
+++ b/docs/2.2.5/optionsDialog.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.2.5/optionsDialog.html
+++ b/docs/2.2.5/optionsDialog.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.2.5/optionsDialog.html
+++ b/docs/2.2.5/optionsDialog.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.2.5/optionsDialog.html
+++ b/docs/2.2.5/optionsDialog.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.2.5/platform.html
+++ b/docs/2.2.5/platform.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.2.5/platform.html
+++ b/docs/2.2.5/platform.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.2.5/platform.html
+++ b/docs/2.2.5/platform.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.2.5/platform.html
+++ b/docs/2.2.5/platform.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.2.5/projectEditor.html
+++ b/docs/2.2.5/projectEditor.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.2.5/projectEditor.html
+++ b/docs/2.2.5/projectEditor.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.2.5/projectEditor.html
+++ b/docs/2.2.5/projectEditor.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.2.5/projectEditor.html
+++ b/docs/2.2.5/projectEditor.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.2.5/quickStart.html
+++ b/docs/2.2.5/quickStart.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.2.5/quickStart.html
+++ b/docs/2.2.5/quickStart.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.2.5/quickStart.html
+++ b/docs/2.2.5/quickStart.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.2.5/quickStart.html
+++ b/docs/2.2.5/quickStart.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.2.5/quickStartSource.html
+++ b/docs/2.2.5/quickStartSource.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.2.5/quickStartSource.html
+++ b/docs/2.2.5/quickStartSource.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.2.5/quickStartSource.html
+++ b/docs/2.2.5/quickStartSource.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.2.5/quickStartSource.html
+++ b/docs/2.2.5/quickStartSource.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.2.5/releaseNotes.html
+++ b/docs/2.2.5/releaseNotes.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.2.5/releaseNotes.html
+++ b/docs/2.2.5/releaseNotes.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.2.5/releaseNotes.html
+++ b/docs/2.2.5/releaseNotes.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.2.5/releaseNotes.html
+++ b/docs/2.2.5/releaseNotes.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.2.5/samples.html
+++ b/docs/2.2.5/samples.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.2.5/samples.html
+++ b/docs/2.2.5/samples.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.2.5/samples.html
+++ b/docs/2.2.5/samples.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.2.5/samples.html
+++ b/docs/2.2.5/samples.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.2.5/setup.html
+++ b/docs/2.2.5/setup.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.2.5/setup.html
+++ b/docs/2.2.5/setup.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.2.5/setup.html
+++ b/docs/2.2.5/setup.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.2.5/setup.html
+++ b/docs/2.2.5/setup.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.2.5/stringAssert.html
+++ b/docs/2.2.5/stringAssert.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.2.5/stringAssert.html
+++ b/docs/2.2.5/stringAssert.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.2.5/stringAssert.html
+++ b/docs/2.2.5/stringAssert.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.2.5/stringAssert.html
+++ b/docs/2.2.5/stringAssert.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.2.5/suite.html
+++ b/docs/2.2.5/suite.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.2.5/suite.html
+++ b/docs/2.2.5/suite.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.2.5/suite.html
+++ b/docs/2.2.5/suite.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.2.5/suite.html
+++ b/docs/2.2.5/suite.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.2.5/teardown.html
+++ b/docs/2.2.5/teardown.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.2.5/teardown.html
+++ b/docs/2.2.5/teardown.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.2.5/teardown.html
+++ b/docs/2.2.5/teardown.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.2.5/teardown.html
+++ b/docs/2.2.5/teardown.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.2.5/test.html
+++ b/docs/2.2.5/test.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.2.5/test.html
+++ b/docs/2.2.5/test.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.2.5/test.html
+++ b/docs/2.2.5/test.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.2.5/test.html
+++ b/docs/2.2.5/test.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.2.5/testFixture.html
+++ b/docs/2.2.5/testFixture.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.2.5/testFixture.html
+++ b/docs/2.2.5/testFixture.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.2.5/testFixture.html
+++ b/docs/2.2.5/testFixture.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.2.5/testFixture.html
+++ b/docs/2.2.5/testFixture.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.2.5/testProperties.html
+++ b/docs/2.2.5/testProperties.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.2.5/testProperties.html
+++ b/docs/2.2.5/testProperties.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.2.5/testProperties.html
+++ b/docs/2.2.5/testProperties.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.2.5/testProperties.html
+++ b/docs/2.2.5/testProperties.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.2.5/typeAsserts.html
+++ b/docs/2.2.5/typeAsserts.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.2.5/typeAsserts.html
+++ b/docs/2.2.5/typeAsserts.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.2.5/typeAsserts.html
+++ b/docs/2.2.5/typeAsserts.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.2.5/typeAsserts.html
+++ b/docs/2.2.5/typeAsserts.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.2.5/upgrade.html
+++ b/docs/2.2.5/upgrade.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.2.5/upgrade.html
+++ b/docs/2.2.5/upgrade.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.2.5/upgrade.html
+++ b/docs/2.2.5/upgrade.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.2.5/upgrade.html
+++ b/docs/2.2.5/upgrade.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.2.5/utilityAsserts.html
+++ b/docs/2.2.5/utilityAsserts.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.2.5/utilityAsserts.html
+++ b/docs/2.2.5/utilityAsserts.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.2.5/utilityAsserts.html
+++ b/docs/2.2.5/utilityAsserts.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.2.5/utilityAsserts.html
+++ b/docs/2.2.5/utilityAsserts.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.2.5/vsSupport.html
+++ b/docs/2.2.5/vsSupport.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.2.5/vsSupport.html
+++ b/docs/2.2.5/vsSupport.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.2.5/vsSupport.html
+++ b/docs/2.2.5/vsSupport.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.2.5/vsSupport.html
+++ b/docs/2.2.5/vsSupport.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.2.6/assertions.html
+++ b/docs/2.2.6/assertions.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.2.6/assertions.html
+++ b/docs/2.2.6/assertions.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.2.6/assertions.html
+++ b/docs/2.2.6/assertions.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.2.6/assertions.html
+++ b/docs/2.2.6/assertions.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.2.6/attributes.html
+++ b/docs/2.2.6/attributes.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.2.6/attributes.html
+++ b/docs/2.2.6/attributes.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.2.6/attributes.html
+++ b/docs/2.2.6/attributes.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.2.6/attributes.html
+++ b/docs/2.2.6/attributes.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.2.6/category.html
+++ b/docs/2.2.6/category.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.2.6/category.html
+++ b/docs/2.2.6/category.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.2.6/category.html
+++ b/docs/2.2.6/category.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.2.6/category.html
+++ b/docs/2.2.6/category.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.2.6/comparisonAsserts.html
+++ b/docs/2.2.6/comparisonAsserts.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.2.6/comparisonAsserts.html
+++ b/docs/2.2.6/comparisonAsserts.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.2.6/comparisonAsserts.html
+++ b/docs/2.2.6/comparisonAsserts.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.2.6/comparisonAsserts.html
+++ b/docs/2.2.6/comparisonAsserts.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.2.6/conditionAsserts.html
+++ b/docs/2.2.6/conditionAsserts.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.2.6/conditionAsserts.html
+++ b/docs/2.2.6/conditionAsserts.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.2.6/conditionAsserts.html
+++ b/docs/2.2.6/conditionAsserts.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.2.6/conditionAsserts.html
+++ b/docs/2.2.6/conditionAsserts.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.2.6/configEditor.html
+++ b/docs/2.2.6/configEditor.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.2.6/configEditor.html
+++ b/docs/2.2.6/configEditor.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.2.6/configEditor.html
+++ b/docs/2.2.6/configEditor.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.2.6/configEditor.html
+++ b/docs/2.2.6/configEditor.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.2.6/configFiles.html
+++ b/docs/2.2.6/configFiles.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.2.6/configFiles.html
+++ b/docs/2.2.6/configFiles.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.2.6/configFiles.html
+++ b/docs/2.2.6/configFiles.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.2.6/configFiles.html
+++ b/docs/2.2.6/configFiles.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.2.6/consoleCommandLine.html
+++ b/docs/2.2.6/consoleCommandLine.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.2.6/consoleCommandLine.html
+++ b/docs/2.2.6/consoleCommandLine.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.2.6/consoleCommandLine.html
+++ b/docs/2.2.6/consoleCommandLine.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.2.6/consoleCommandLine.html
+++ b/docs/2.2.6/consoleCommandLine.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.2.6/contextMenu.html
+++ b/docs/2.2.6/contextMenu.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.2.6/contextMenu.html
+++ b/docs/2.2.6/contextMenu.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.2.6/contextMenu.html
+++ b/docs/2.2.6/contextMenu.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.2.6/contextMenu.html
+++ b/docs/2.2.6/contextMenu.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.2.6/docHome.html
+++ b/docs/2.2.6/docHome.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.2.6/docHome.html
+++ b/docs/2.2.6/docHome.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.2.6/docHome.html
+++ b/docs/2.2.6/docHome.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.2.6/docHome.html
+++ b/docs/2.2.6/docHome.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.2.6/equalityAsserts.html
+++ b/docs/2.2.6/equalityAsserts.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.2.6/equalityAsserts.html
+++ b/docs/2.2.6/equalityAsserts.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.2.6/equalityAsserts.html
+++ b/docs/2.2.6/equalityAsserts.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.2.6/equalityAsserts.html
+++ b/docs/2.2.6/equalityAsserts.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.2.6/exception.html
+++ b/docs/2.2.6/exception.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.2.6/exception.html
+++ b/docs/2.2.6/exception.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.2.6/exception.html
+++ b/docs/2.2.6/exception.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.2.6/exception.html
+++ b/docs/2.2.6/exception.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.2.6/explicit.html
+++ b/docs/2.2.6/explicit.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.2.6/explicit.html
+++ b/docs/2.2.6/explicit.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.2.6/explicit.html
+++ b/docs/2.2.6/explicit.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.2.6/explicit.html
+++ b/docs/2.2.6/explicit.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.2.6/features.html
+++ b/docs/2.2.6/features.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.2.6/features.html
+++ b/docs/2.2.6/features.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.2.6/features.html
+++ b/docs/2.2.6/features.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.2.6/features.html
+++ b/docs/2.2.6/features.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.2.6/fixtureSetup.html
+++ b/docs/2.2.6/fixtureSetup.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.2.6/fixtureSetup.html
+++ b/docs/2.2.6/fixtureSetup.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.2.6/fixtureSetup.html
+++ b/docs/2.2.6/fixtureSetup.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.2.6/fixtureSetup.html
+++ b/docs/2.2.6/fixtureSetup.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.2.6/fixtureTeardown.html
+++ b/docs/2.2.6/fixtureTeardown.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.2.6/fixtureTeardown.html
+++ b/docs/2.2.6/fixtureTeardown.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.2.6/fixtureTeardown.html
+++ b/docs/2.2.6/fixtureTeardown.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.2.6/fixtureTeardown.html
+++ b/docs/2.2.6/fixtureTeardown.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.2.6/getStarted.html
+++ b/docs/2.2.6/getStarted.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.2.6/getStarted.html
+++ b/docs/2.2.6/getStarted.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.2.6/getStarted.html
+++ b/docs/2.2.6/getStarted.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.2.6/getStarted.html
+++ b/docs/2.2.6/getStarted.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.2.6/guiCommandLine.html
+++ b/docs/2.2.6/guiCommandLine.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.2.6/guiCommandLine.html
+++ b/docs/2.2.6/guiCommandLine.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.2.6/guiCommandLine.html
+++ b/docs/2.2.6/guiCommandLine.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.2.6/guiCommandLine.html
+++ b/docs/2.2.6/guiCommandLine.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.2.6/identityAsserts.html
+++ b/docs/2.2.6/identityAsserts.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.2.6/identityAsserts.html
+++ b/docs/2.2.6/identityAsserts.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.2.6/identityAsserts.html
+++ b/docs/2.2.6/identityAsserts.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.2.6/identityAsserts.html
+++ b/docs/2.2.6/identityAsserts.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.2.6/ignore.html
+++ b/docs/2.2.6/ignore.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.2.6/ignore.html
+++ b/docs/2.2.6/ignore.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.2.6/ignore.html
+++ b/docs/2.2.6/ignore.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.2.6/ignore.html
+++ b/docs/2.2.6/ignore.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.2.6/installation.html
+++ b/docs/2.2.6/installation.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.2.6/installation.html
+++ b/docs/2.2.6/installation.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.2.6/installation.html
+++ b/docs/2.2.6/installation.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.2.6/installation.html
+++ b/docs/2.2.6/installation.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.2.6/license.html
+++ b/docs/2.2.6/license.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.2.6/license.html
+++ b/docs/2.2.6/license.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.2.6/license.html
+++ b/docs/2.2.6/license.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.2.6/license.html
+++ b/docs/2.2.6/license.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.2.6/mainMenu.html
+++ b/docs/2.2.6/mainMenu.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.2.6/mainMenu.html
+++ b/docs/2.2.6/mainMenu.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.2.6/mainMenu.html
+++ b/docs/2.2.6/mainMenu.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.2.6/mainMenu.html
+++ b/docs/2.2.6/mainMenu.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.2.6/multiAssembly.html
+++ b/docs/2.2.6/multiAssembly.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.2.6/multiAssembly.html
+++ b/docs/2.2.6/multiAssembly.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.2.6/multiAssembly.html
+++ b/docs/2.2.6/multiAssembly.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.2.6/multiAssembly.html
+++ b/docs/2.2.6/multiAssembly.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.2.6/nunit-console.html
+++ b/docs/2.2.6/nunit-console.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.2.6/nunit-console.html
+++ b/docs/2.2.6/nunit-console.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.2.6/nunit-console.html
+++ b/docs/2.2.6/nunit-console.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.2.6/nunit-console.html
+++ b/docs/2.2.6/nunit-console.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.2.6/nunit-gui.html
+++ b/docs/2.2.6/nunit-gui.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.2.6/nunit-gui.html
+++ b/docs/2.2.6/nunit-gui.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.2.6/nunit-gui.html
+++ b/docs/2.2.6/nunit-gui.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.2.6/nunit-gui.html
+++ b/docs/2.2.6/nunit-gui.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.2.6/optionsDialog.html
+++ b/docs/2.2.6/optionsDialog.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.2.6/optionsDialog.html
+++ b/docs/2.2.6/optionsDialog.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.2.6/optionsDialog.html
+++ b/docs/2.2.6/optionsDialog.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.2.6/optionsDialog.html
+++ b/docs/2.2.6/optionsDialog.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.2.6/platform.html
+++ b/docs/2.2.6/platform.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.2.6/platform.html
+++ b/docs/2.2.6/platform.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.2.6/platform.html
+++ b/docs/2.2.6/platform.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.2.6/platform.html
+++ b/docs/2.2.6/platform.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.2.6/projectEditor.html
+++ b/docs/2.2.6/projectEditor.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.2.6/projectEditor.html
+++ b/docs/2.2.6/projectEditor.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.2.6/projectEditor.html
+++ b/docs/2.2.6/projectEditor.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.2.6/projectEditor.html
+++ b/docs/2.2.6/projectEditor.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.2.6/quickStart.html
+++ b/docs/2.2.6/quickStart.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.2.6/quickStart.html
+++ b/docs/2.2.6/quickStart.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.2.6/quickStart.html
+++ b/docs/2.2.6/quickStart.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.2.6/quickStart.html
+++ b/docs/2.2.6/quickStart.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.2.6/quickStartSource.html
+++ b/docs/2.2.6/quickStartSource.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.2.6/quickStartSource.html
+++ b/docs/2.2.6/quickStartSource.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.2.6/quickStartSource.html
+++ b/docs/2.2.6/quickStartSource.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.2.6/quickStartSource.html
+++ b/docs/2.2.6/quickStartSource.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.2.6/releaseNotes.html
+++ b/docs/2.2.6/releaseNotes.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.2.6/releaseNotes.html
+++ b/docs/2.2.6/releaseNotes.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.2.6/releaseNotes.html
+++ b/docs/2.2.6/releaseNotes.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.2.6/releaseNotes.html
+++ b/docs/2.2.6/releaseNotes.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.2.6/samples.html
+++ b/docs/2.2.6/samples.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.2.6/samples.html
+++ b/docs/2.2.6/samples.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.2.6/samples.html
+++ b/docs/2.2.6/samples.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.2.6/samples.html
+++ b/docs/2.2.6/samples.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.2.6/setup.html
+++ b/docs/2.2.6/setup.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.2.6/setup.html
+++ b/docs/2.2.6/setup.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.2.6/setup.html
+++ b/docs/2.2.6/setup.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.2.6/setup.html
+++ b/docs/2.2.6/setup.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.2.6/stringAssert.html
+++ b/docs/2.2.6/stringAssert.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.2.6/stringAssert.html
+++ b/docs/2.2.6/stringAssert.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.2.6/stringAssert.html
+++ b/docs/2.2.6/stringAssert.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.2.6/stringAssert.html
+++ b/docs/2.2.6/stringAssert.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.2.6/suite.html
+++ b/docs/2.2.6/suite.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.2.6/suite.html
+++ b/docs/2.2.6/suite.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.2.6/suite.html
+++ b/docs/2.2.6/suite.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.2.6/suite.html
+++ b/docs/2.2.6/suite.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.2.6/teardown.html
+++ b/docs/2.2.6/teardown.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.2.6/teardown.html
+++ b/docs/2.2.6/teardown.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.2.6/teardown.html
+++ b/docs/2.2.6/teardown.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.2.6/teardown.html
+++ b/docs/2.2.6/teardown.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.2.6/test.html
+++ b/docs/2.2.6/test.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.2.6/test.html
+++ b/docs/2.2.6/test.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.2.6/test.html
+++ b/docs/2.2.6/test.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.2.6/test.html
+++ b/docs/2.2.6/test.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.2.6/testFixture.html
+++ b/docs/2.2.6/testFixture.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.2.6/testFixture.html
+++ b/docs/2.2.6/testFixture.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.2.6/testFixture.html
+++ b/docs/2.2.6/testFixture.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.2.6/testFixture.html
+++ b/docs/2.2.6/testFixture.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.2.6/testProperties.html
+++ b/docs/2.2.6/testProperties.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.2.6/testProperties.html
+++ b/docs/2.2.6/testProperties.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.2.6/testProperties.html
+++ b/docs/2.2.6/testProperties.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.2.6/testProperties.html
+++ b/docs/2.2.6/testProperties.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.2.6/typeAsserts.html
+++ b/docs/2.2.6/typeAsserts.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.2.6/typeAsserts.html
+++ b/docs/2.2.6/typeAsserts.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.2.6/typeAsserts.html
+++ b/docs/2.2.6/typeAsserts.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.2.6/typeAsserts.html
+++ b/docs/2.2.6/typeAsserts.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.2.6/upgrade.html
+++ b/docs/2.2.6/upgrade.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.2.6/upgrade.html
+++ b/docs/2.2.6/upgrade.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.2.6/upgrade.html
+++ b/docs/2.2.6/upgrade.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.2.6/upgrade.html
+++ b/docs/2.2.6/upgrade.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.2.6/utilityAsserts.html
+++ b/docs/2.2.6/utilityAsserts.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.2.6/utilityAsserts.html
+++ b/docs/2.2.6/utilityAsserts.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.2.6/utilityAsserts.html
+++ b/docs/2.2.6/utilityAsserts.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.2.6/utilityAsserts.html
+++ b/docs/2.2.6/utilityAsserts.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.2.6/vsSupport.html
+++ b/docs/2.2.6/vsSupport.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.2.6/vsSupport.html
+++ b/docs/2.2.6/vsSupport.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.2.6/vsSupport.html
+++ b/docs/2.2.6/vsSupport.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.2.6/vsSupport.html
+++ b/docs/2.2.6/vsSupport.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.2.7/assertions.html
+++ b/docs/2.2.7/assertions.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.2.7/assertions.html
+++ b/docs/2.2.7/assertions.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.2.7/assertions.html
+++ b/docs/2.2.7/assertions.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.2.7/assertions.html
+++ b/docs/2.2.7/assertions.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.2.7/attributes.html
+++ b/docs/2.2.7/attributes.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.2.7/attributes.html
+++ b/docs/2.2.7/attributes.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.2.7/attributes.html
+++ b/docs/2.2.7/attributes.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.2.7/attributes.html
+++ b/docs/2.2.7/attributes.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.2.7/category.html
+++ b/docs/2.2.7/category.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.2.7/category.html
+++ b/docs/2.2.7/category.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.2.7/category.html
+++ b/docs/2.2.7/category.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.2.7/category.html
+++ b/docs/2.2.7/category.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.2.7/comparisonAsserts.html
+++ b/docs/2.2.7/comparisonAsserts.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.2.7/comparisonAsserts.html
+++ b/docs/2.2.7/comparisonAsserts.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.2.7/comparisonAsserts.html
+++ b/docs/2.2.7/comparisonAsserts.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.2.7/comparisonAsserts.html
+++ b/docs/2.2.7/comparisonAsserts.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.2.7/conditionAsserts.html
+++ b/docs/2.2.7/conditionAsserts.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.2.7/conditionAsserts.html
+++ b/docs/2.2.7/conditionAsserts.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.2.7/conditionAsserts.html
+++ b/docs/2.2.7/conditionAsserts.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.2.7/conditionAsserts.html
+++ b/docs/2.2.7/conditionAsserts.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.2.7/configEditor.html
+++ b/docs/2.2.7/configEditor.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.2.7/configEditor.html
+++ b/docs/2.2.7/configEditor.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.2.7/configEditor.html
+++ b/docs/2.2.7/configEditor.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.2.7/configEditor.html
+++ b/docs/2.2.7/configEditor.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.2.7/configFiles.html
+++ b/docs/2.2.7/configFiles.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.2.7/configFiles.html
+++ b/docs/2.2.7/configFiles.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.2.7/configFiles.html
+++ b/docs/2.2.7/configFiles.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.2.7/configFiles.html
+++ b/docs/2.2.7/configFiles.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.2.7/consoleCommandLine.html
+++ b/docs/2.2.7/consoleCommandLine.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.2.7/consoleCommandLine.html
+++ b/docs/2.2.7/consoleCommandLine.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.2.7/consoleCommandLine.html
+++ b/docs/2.2.7/consoleCommandLine.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.2.7/consoleCommandLine.html
+++ b/docs/2.2.7/consoleCommandLine.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.2.7/contextMenu.html
+++ b/docs/2.2.7/contextMenu.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.2.7/contextMenu.html
+++ b/docs/2.2.7/contextMenu.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.2.7/contextMenu.html
+++ b/docs/2.2.7/contextMenu.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.2.7/contextMenu.html
+++ b/docs/2.2.7/contextMenu.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.2.7/docHome.html
+++ b/docs/2.2.7/docHome.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.2.7/docHome.html
+++ b/docs/2.2.7/docHome.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.2.7/docHome.html
+++ b/docs/2.2.7/docHome.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.2.7/docHome.html
+++ b/docs/2.2.7/docHome.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.2.7/equalityAsserts.html
+++ b/docs/2.2.7/equalityAsserts.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.2.7/equalityAsserts.html
+++ b/docs/2.2.7/equalityAsserts.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.2.7/equalityAsserts.html
+++ b/docs/2.2.7/equalityAsserts.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.2.7/equalityAsserts.html
+++ b/docs/2.2.7/equalityAsserts.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.2.7/exception.html
+++ b/docs/2.2.7/exception.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.2.7/exception.html
+++ b/docs/2.2.7/exception.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.2.7/exception.html
+++ b/docs/2.2.7/exception.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.2.7/exception.html
+++ b/docs/2.2.7/exception.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.2.7/explicit.html
+++ b/docs/2.2.7/explicit.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.2.7/explicit.html
+++ b/docs/2.2.7/explicit.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.2.7/explicit.html
+++ b/docs/2.2.7/explicit.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.2.7/explicit.html
+++ b/docs/2.2.7/explicit.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.2.7/features.html
+++ b/docs/2.2.7/features.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.2.7/features.html
+++ b/docs/2.2.7/features.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.2.7/features.html
+++ b/docs/2.2.7/features.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.2.7/features.html
+++ b/docs/2.2.7/features.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.2.7/fixtureSetup.html
+++ b/docs/2.2.7/fixtureSetup.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.2.7/fixtureSetup.html
+++ b/docs/2.2.7/fixtureSetup.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.2.7/fixtureSetup.html
+++ b/docs/2.2.7/fixtureSetup.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.2.7/fixtureSetup.html
+++ b/docs/2.2.7/fixtureSetup.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.2.7/fixtureTeardown.html
+++ b/docs/2.2.7/fixtureTeardown.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.2.7/fixtureTeardown.html
+++ b/docs/2.2.7/fixtureTeardown.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.2.7/fixtureTeardown.html
+++ b/docs/2.2.7/fixtureTeardown.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.2.7/fixtureTeardown.html
+++ b/docs/2.2.7/fixtureTeardown.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.2.7/getStarted.html
+++ b/docs/2.2.7/getStarted.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.2.7/getStarted.html
+++ b/docs/2.2.7/getStarted.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.2.7/getStarted.html
+++ b/docs/2.2.7/getStarted.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.2.7/getStarted.html
+++ b/docs/2.2.7/getStarted.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.2.7/guiCommandLine.html
+++ b/docs/2.2.7/guiCommandLine.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.2.7/guiCommandLine.html
+++ b/docs/2.2.7/guiCommandLine.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.2.7/guiCommandLine.html
+++ b/docs/2.2.7/guiCommandLine.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.2.7/guiCommandLine.html
+++ b/docs/2.2.7/guiCommandLine.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.2.7/identityAsserts.html
+++ b/docs/2.2.7/identityAsserts.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.2.7/identityAsserts.html
+++ b/docs/2.2.7/identityAsserts.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.2.7/identityAsserts.html
+++ b/docs/2.2.7/identityAsserts.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.2.7/identityAsserts.html
+++ b/docs/2.2.7/identityAsserts.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.2.7/ignore.html
+++ b/docs/2.2.7/ignore.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.2.7/ignore.html
+++ b/docs/2.2.7/ignore.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.2.7/ignore.html
+++ b/docs/2.2.7/ignore.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.2.7/ignore.html
+++ b/docs/2.2.7/ignore.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.2.7/installation.html
+++ b/docs/2.2.7/installation.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.2.7/installation.html
+++ b/docs/2.2.7/installation.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.2.7/installation.html
+++ b/docs/2.2.7/installation.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.2.7/installation.html
+++ b/docs/2.2.7/installation.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.2.7/license.html
+++ b/docs/2.2.7/license.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.2.7/license.html
+++ b/docs/2.2.7/license.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.2.7/license.html
+++ b/docs/2.2.7/license.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.2.7/license.html
+++ b/docs/2.2.7/license.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.2.7/mainMenu.html
+++ b/docs/2.2.7/mainMenu.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.2.7/mainMenu.html
+++ b/docs/2.2.7/mainMenu.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.2.7/mainMenu.html
+++ b/docs/2.2.7/mainMenu.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.2.7/mainMenu.html
+++ b/docs/2.2.7/mainMenu.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.2.7/multiAssembly.html
+++ b/docs/2.2.7/multiAssembly.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.2.7/multiAssembly.html
+++ b/docs/2.2.7/multiAssembly.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.2.7/multiAssembly.html
+++ b/docs/2.2.7/multiAssembly.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.2.7/multiAssembly.html
+++ b/docs/2.2.7/multiAssembly.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.2.7/nunit-console.html
+++ b/docs/2.2.7/nunit-console.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.2.7/nunit-console.html
+++ b/docs/2.2.7/nunit-console.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.2.7/nunit-console.html
+++ b/docs/2.2.7/nunit-console.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.2.7/nunit-console.html
+++ b/docs/2.2.7/nunit-console.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.2.7/nunit-gui.html
+++ b/docs/2.2.7/nunit-gui.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.2.7/nunit-gui.html
+++ b/docs/2.2.7/nunit-gui.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.2.7/nunit-gui.html
+++ b/docs/2.2.7/nunit-gui.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.2.7/nunit-gui.html
+++ b/docs/2.2.7/nunit-gui.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.2.7/optionsDialog.html
+++ b/docs/2.2.7/optionsDialog.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.2.7/optionsDialog.html
+++ b/docs/2.2.7/optionsDialog.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.2.7/optionsDialog.html
+++ b/docs/2.2.7/optionsDialog.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.2.7/optionsDialog.html
+++ b/docs/2.2.7/optionsDialog.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.2.7/platform.html
+++ b/docs/2.2.7/platform.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.2.7/platform.html
+++ b/docs/2.2.7/platform.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.2.7/platform.html
+++ b/docs/2.2.7/platform.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.2.7/platform.html
+++ b/docs/2.2.7/platform.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.2.7/projectEditor.html
+++ b/docs/2.2.7/projectEditor.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.2.7/projectEditor.html
+++ b/docs/2.2.7/projectEditor.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.2.7/projectEditor.html
+++ b/docs/2.2.7/projectEditor.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.2.7/projectEditor.html
+++ b/docs/2.2.7/projectEditor.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.2.7/quickStart.html
+++ b/docs/2.2.7/quickStart.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.2.7/quickStart.html
+++ b/docs/2.2.7/quickStart.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.2.7/quickStart.html
+++ b/docs/2.2.7/quickStart.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.2.7/quickStart.html
+++ b/docs/2.2.7/quickStart.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.2.7/quickStartSource.html
+++ b/docs/2.2.7/quickStartSource.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.2.7/quickStartSource.html
+++ b/docs/2.2.7/quickStartSource.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.2.7/quickStartSource.html
+++ b/docs/2.2.7/quickStartSource.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.2.7/quickStartSource.html
+++ b/docs/2.2.7/quickStartSource.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.2.7/releaseNotes.html
+++ b/docs/2.2.7/releaseNotes.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.2.7/releaseNotes.html
+++ b/docs/2.2.7/releaseNotes.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.2.7/releaseNotes.html
+++ b/docs/2.2.7/releaseNotes.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.2.7/releaseNotes.html
+++ b/docs/2.2.7/releaseNotes.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.2.7/samples.html
+++ b/docs/2.2.7/samples.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.2.7/samples.html
+++ b/docs/2.2.7/samples.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.2.7/samples.html
+++ b/docs/2.2.7/samples.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.2.7/samples.html
+++ b/docs/2.2.7/samples.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.2.7/setup.html
+++ b/docs/2.2.7/setup.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.2.7/setup.html
+++ b/docs/2.2.7/setup.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.2.7/setup.html
+++ b/docs/2.2.7/setup.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.2.7/setup.html
+++ b/docs/2.2.7/setup.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.2.7/stringAssert.html
+++ b/docs/2.2.7/stringAssert.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.2.7/stringAssert.html
+++ b/docs/2.2.7/stringAssert.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.2.7/stringAssert.html
+++ b/docs/2.2.7/stringAssert.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.2.7/stringAssert.html
+++ b/docs/2.2.7/stringAssert.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.2.7/suite.html
+++ b/docs/2.2.7/suite.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.2.7/suite.html
+++ b/docs/2.2.7/suite.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.2.7/suite.html
+++ b/docs/2.2.7/suite.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.2.7/suite.html
+++ b/docs/2.2.7/suite.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.2.7/teardown.html
+++ b/docs/2.2.7/teardown.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.2.7/teardown.html
+++ b/docs/2.2.7/teardown.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.2.7/teardown.html
+++ b/docs/2.2.7/teardown.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.2.7/teardown.html
+++ b/docs/2.2.7/teardown.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.2.7/test.html
+++ b/docs/2.2.7/test.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.2.7/test.html
+++ b/docs/2.2.7/test.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.2.7/test.html
+++ b/docs/2.2.7/test.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.2.7/test.html
+++ b/docs/2.2.7/test.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.2.7/testFixture.html
+++ b/docs/2.2.7/testFixture.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.2.7/testFixture.html
+++ b/docs/2.2.7/testFixture.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.2.7/testFixture.html
+++ b/docs/2.2.7/testFixture.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.2.7/testFixture.html
+++ b/docs/2.2.7/testFixture.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.2.7/testProperties.html
+++ b/docs/2.2.7/testProperties.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.2.7/testProperties.html
+++ b/docs/2.2.7/testProperties.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.2.7/testProperties.html
+++ b/docs/2.2.7/testProperties.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.2.7/testProperties.html
+++ b/docs/2.2.7/testProperties.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.2.7/typeAsserts.html
+++ b/docs/2.2.7/typeAsserts.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.2.7/typeAsserts.html
+++ b/docs/2.2.7/typeAsserts.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.2.7/typeAsserts.html
+++ b/docs/2.2.7/typeAsserts.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.2.7/typeAsserts.html
+++ b/docs/2.2.7/typeAsserts.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.2.7/upgrade.html
+++ b/docs/2.2.7/upgrade.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.2.7/upgrade.html
+++ b/docs/2.2.7/upgrade.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.2.7/upgrade.html
+++ b/docs/2.2.7/upgrade.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.2.7/upgrade.html
+++ b/docs/2.2.7/upgrade.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.2.7/utilityAsserts.html
+++ b/docs/2.2.7/utilityAsserts.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.2.7/utilityAsserts.html
+++ b/docs/2.2.7/utilityAsserts.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.2.7/utilityAsserts.html
+++ b/docs/2.2.7/utilityAsserts.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.2.7/utilityAsserts.html
+++ b/docs/2.2.7/utilityAsserts.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.2.7/vsSupport.html
+++ b/docs/2.2.7/vsSupport.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.2.7/vsSupport.html
+++ b/docs/2.2.7/vsSupport.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.2.7/vsSupport.html
+++ b/docs/2.2.7/vsSupport.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.2.7/vsSupport.html
+++ b/docs/2.2.7/vsSupport.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.2.8/assertions.html
+++ b/docs/2.2.8/assertions.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.2.8/assertions.html
+++ b/docs/2.2.8/assertions.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.2.8/assertions.html
+++ b/docs/2.2.8/assertions.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.2.8/assertions.html
+++ b/docs/2.2.8/assertions.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.2.8/attributes.html
+++ b/docs/2.2.8/attributes.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.2.8/attributes.html
+++ b/docs/2.2.8/attributes.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.2.8/attributes.html
+++ b/docs/2.2.8/attributes.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.2.8/attributes.html
+++ b/docs/2.2.8/attributes.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.2.8/category.html
+++ b/docs/2.2.8/category.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.2.8/category.html
+++ b/docs/2.2.8/category.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.2.8/category.html
+++ b/docs/2.2.8/category.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.2.8/category.html
+++ b/docs/2.2.8/category.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.2.8/comparisonAsserts.html
+++ b/docs/2.2.8/comparisonAsserts.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.2.8/comparisonAsserts.html
+++ b/docs/2.2.8/comparisonAsserts.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.2.8/comparisonAsserts.html
+++ b/docs/2.2.8/comparisonAsserts.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.2.8/comparisonAsserts.html
+++ b/docs/2.2.8/comparisonAsserts.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.2.8/conditionAsserts.html
+++ b/docs/2.2.8/conditionAsserts.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.2.8/conditionAsserts.html
+++ b/docs/2.2.8/conditionAsserts.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.2.8/conditionAsserts.html
+++ b/docs/2.2.8/conditionAsserts.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.2.8/conditionAsserts.html
+++ b/docs/2.2.8/conditionAsserts.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.2.8/configEditor.html
+++ b/docs/2.2.8/configEditor.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.2.8/configEditor.html
+++ b/docs/2.2.8/configEditor.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.2.8/configEditor.html
+++ b/docs/2.2.8/configEditor.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.2.8/configEditor.html
+++ b/docs/2.2.8/configEditor.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.2.8/configFiles.html
+++ b/docs/2.2.8/configFiles.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.2.8/configFiles.html
+++ b/docs/2.2.8/configFiles.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.2.8/configFiles.html
+++ b/docs/2.2.8/configFiles.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.2.8/configFiles.html
+++ b/docs/2.2.8/configFiles.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.2.8/consoleCommandLine.html
+++ b/docs/2.2.8/consoleCommandLine.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.2.8/consoleCommandLine.html
+++ b/docs/2.2.8/consoleCommandLine.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.2.8/consoleCommandLine.html
+++ b/docs/2.2.8/consoleCommandLine.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.2.8/consoleCommandLine.html
+++ b/docs/2.2.8/consoleCommandLine.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.2.8/contextMenu.html
+++ b/docs/2.2.8/contextMenu.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.2.8/contextMenu.html
+++ b/docs/2.2.8/contextMenu.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.2.8/contextMenu.html
+++ b/docs/2.2.8/contextMenu.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.2.8/contextMenu.html
+++ b/docs/2.2.8/contextMenu.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.2.8/docHome.html
+++ b/docs/2.2.8/docHome.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.2.8/docHome.html
+++ b/docs/2.2.8/docHome.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.2.8/docHome.html
+++ b/docs/2.2.8/docHome.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.2.8/docHome.html
+++ b/docs/2.2.8/docHome.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.2.8/equalityAsserts.html
+++ b/docs/2.2.8/equalityAsserts.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.2.8/equalityAsserts.html
+++ b/docs/2.2.8/equalityAsserts.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.2.8/equalityAsserts.html
+++ b/docs/2.2.8/equalityAsserts.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.2.8/equalityAsserts.html
+++ b/docs/2.2.8/equalityAsserts.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.2.8/exception.html
+++ b/docs/2.2.8/exception.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.2.8/exception.html
+++ b/docs/2.2.8/exception.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.2.8/exception.html
+++ b/docs/2.2.8/exception.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.2.8/exception.html
+++ b/docs/2.2.8/exception.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.2.8/explicit.html
+++ b/docs/2.2.8/explicit.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.2.8/explicit.html
+++ b/docs/2.2.8/explicit.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.2.8/explicit.html
+++ b/docs/2.2.8/explicit.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.2.8/explicit.html
+++ b/docs/2.2.8/explicit.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.2.8/features.html
+++ b/docs/2.2.8/features.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.2.8/features.html
+++ b/docs/2.2.8/features.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.2.8/features.html
+++ b/docs/2.2.8/features.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.2.8/features.html
+++ b/docs/2.2.8/features.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.2.8/fixtureSetup.html
+++ b/docs/2.2.8/fixtureSetup.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.2.8/fixtureSetup.html
+++ b/docs/2.2.8/fixtureSetup.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.2.8/fixtureSetup.html
+++ b/docs/2.2.8/fixtureSetup.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.2.8/fixtureSetup.html
+++ b/docs/2.2.8/fixtureSetup.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.2.8/fixtureTeardown.html
+++ b/docs/2.2.8/fixtureTeardown.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.2.8/fixtureTeardown.html
+++ b/docs/2.2.8/fixtureTeardown.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.2.8/fixtureTeardown.html
+++ b/docs/2.2.8/fixtureTeardown.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.2.8/fixtureTeardown.html
+++ b/docs/2.2.8/fixtureTeardown.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.2.8/getStarted.html
+++ b/docs/2.2.8/getStarted.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.2.8/getStarted.html
+++ b/docs/2.2.8/getStarted.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.2.8/getStarted.html
+++ b/docs/2.2.8/getStarted.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.2.8/getStarted.html
+++ b/docs/2.2.8/getStarted.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.2.8/guiCommandLine.html
+++ b/docs/2.2.8/guiCommandLine.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.2.8/guiCommandLine.html
+++ b/docs/2.2.8/guiCommandLine.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.2.8/guiCommandLine.html
+++ b/docs/2.2.8/guiCommandLine.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.2.8/guiCommandLine.html
+++ b/docs/2.2.8/guiCommandLine.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.2.8/identityAsserts.html
+++ b/docs/2.2.8/identityAsserts.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.2.8/identityAsserts.html
+++ b/docs/2.2.8/identityAsserts.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.2.8/identityAsserts.html
+++ b/docs/2.2.8/identityAsserts.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.2.8/identityAsserts.html
+++ b/docs/2.2.8/identityAsserts.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.2.8/ignore.html
+++ b/docs/2.2.8/ignore.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.2.8/ignore.html
+++ b/docs/2.2.8/ignore.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.2.8/ignore.html
+++ b/docs/2.2.8/ignore.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.2.8/ignore.html
+++ b/docs/2.2.8/ignore.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.2.8/installation.html
+++ b/docs/2.2.8/installation.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.2.8/installation.html
+++ b/docs/2.2.8/installation.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.2.8/installation.html
+++ b/docs/2.2.8/installation.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.2.8/installation.html
+++ b/docs/2.2.8/installation.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.2.8/license.html
+++ b/docs/2.2.8/license.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.2.8/license.html
+++ b/docs/2.2.8/license.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.2.8/license.html
+++ b/docs/2.2.8/license.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.2.8/license.html
+++ b/docs/2.2.8/license.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.2.8/mainMenu.html
+++ b/docs/2.2.8/mainMenu.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.2.8/mainMenu.html
+++ b/docs/2.2.8/mainMenu.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.2.8/mainMenu.html
+++ b/docs/2.2.8/mainMenu.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.2.8/mainMenu.html
+++ b/docs/2.2.8/mainMenu.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.2.8/multiAssembly.html
+++ b/docs/2.2.8/multiAssembly.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.2.8/multiAssembly.html
+++ b/docs/2.2.8/multiAssembly.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.2.8/multiAssembly.html
+++ b/docs/2.2.8/multiAssembly.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.2.8/multiAssembly.html
+++ b/docs/2.2.8/multiAssembly.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.2.8/nunit-console.html
+++ b/docs/2.2.8/nunit-console.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.2.8/nunit-console.html
+++ b/docs/2.2.8/nunit-console.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.2.8/nunit-console.html
+++ b/docs/2.2.8/nunit-console.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.2.8/nunit-console.html
+++ b/docs/2.2.8/nunit-console.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.2.8/nunit-gui.html
+++ b/docs/2.2.8/nunit-gui.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.2.8/nunit-gui.html
+++ b/docs/2.2.8/nunit-gui.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.2.8/nunit-gui.html
+++ b/docs/2.2.8/nunit-gui.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.2.8/nunit-gui.html
+++ b/docs/2.2.8/nunit-gui.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.2.8/optionsDialog.html
+++ b/docs/2.2.8/optionsDialog.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.2.8/optionsDialog.html
+++ b/docs/2.2.8/optionsDialog.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.2.8/optionsDialog.html
+++ b/docs/2.2.8/optionsDialog.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.2.8/optionsDialog.html
+++ b/docs/2.2.8/optionsDialog.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.2.8/platform.html
+++ b/docs/2.2.8/platform.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.2.8/platform.html
+++ b/docs/2.2.8/platform.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.2.8/platform.html
+++ b/docs/2.2.8/platform.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.2.8/platform.html
+++ b/docs/2.2.8/platform.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.2.8/projectEditor.html
+++ b/docs/2.2.8/projectEditor.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.2.8/projectEditor.html
+++ b/docs/2.2.8/projectEditor.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.2.8/projectEditor.html
+++ b/docs/2.2.8/projectEditor.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.2.8/projectEditor.html
+++ b/docs/2.2.8/projectEditor.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.2.8/quickStart.html
+++ b/docs/2.2.8/quickStart.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.2.8/quickStart.html
+++ b/docs/2.2.8/quickStart.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.2.8/quickStart.html
+++ b/docs/2.2.8/quickStart.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.2.8/quickStart.html
+++ b/docs/2.2.8/quickStart.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.2.8/quickStartSource.html
+++ b/docs/2.2.8/quickStartSource.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.2.8/quickStartSource.html
+++ b/docs/2.2.8/quickStartSource.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.2.8/quickStartSource.html
+++ b/docs/2.2.8/quickStartSource.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.2.8/quickStartSource.html
+++ b/docs/2.2.8/quickStartSource.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.2.8/releaseNotes.html
+++ b/docs/2.2.8/releaseNotes.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.2.8/releaseNotes.html
+++ b/docs/2.2.8/releaseNotes.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.2.8/releaseNotes.html
+++ b/docs/2.2.8/releaseNotes.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.2.8/releaseNotes.html
+++ b/docs/2.2.8/releaseNotes.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.2.8/samples.html
+++ b/docs/2.2.8/samples.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.2.8/samples.html
+++ b/docs/2.2.8/samples.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.2.8/samples.html
+++ b/docs/2.2.8/samples.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.2.8/samples.html
+++ b/docs/2.2.8/samples.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.2.8/setup.html
+++ b/docs/2.2.8/setup.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.2.8/setup.html
+++ b/docs/2.2.8/setup.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.2.8/setup.html
+++ b/docs/2.2.8/setup.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.2.8/setup.html
+++ b/docs/2.2.8/setup.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.2.8/stringAssert.html
+++ b/docs/2.2.8/stringAssert.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.2.8/stringAssert.html
+++ b/docs/2.2.8/stringAssert.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.2.8/stringAssert.html
+++ b/docs/2.2.8/stringAssert.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.2.8/stringAssert.html
+++ b/docs/2.2.8/stringAssert.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.2.8/suite.html
+++ b/docs/2.2.8/suite.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.2.8/suite.html
+++ b/docs/2.2.8/suite.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.2.8/suite.html
+++ b/docs/2.2.8/suite.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.2.8/suite.html
+++ b/docs/2.2.8/suite.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.2.8/teardown.html
+++ b/docs/2.2.8/teardown.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.2.8/teardown.html
+++ b/docs/2.2.8/teardown.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.2.8/teardown.html
+++ b/docs/2.2.8/teardown.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.2.8/teardown.html
+++ b/docs/2.2.8/teardown.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.2.8/test.html
+++ b/docs/2.2.8/test.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.2.8/test.html
+++ b/docs/2.2.8/test.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.2.8/test.html
+++ b/docs/2.2.8/test.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.2.8/test.html
+++ b/docs/2.2.8/test.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.2.8/testFixture.html
+++ b/docs/2.2.8/testFixture.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.2.8/testFixture.html
+++ b/docs/2.2.8/testFixture.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.2.8/testFixture.html
+++ b/docs/2.2.8/testFixture.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.2.8/testFixture.html
+++ b/docs/2.2.8/testFixture.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.2.8/testProperties.html
+++ b/docs/2.2.8/testProperties.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.2.8/testProperties.html
+++ b/docs/2.2.8/testProperties.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.2.8/testProperties.html
+++ b/docs/2.2.8/testProperties.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.2.8/testProperties.html
+++ b/docs/2.2.8/testProperties.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.2.8/typeAsserts.html
+++ b/docs/2.2.8/typeAsserts.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.2.8/typeAsserts.html
+++ b/docs/2.2.8/typeAsserts.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.2.8/typeAsserts.html
+++ b/docs/2.2.8/typeAsserts.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.2.8/typeAsserts.html
+++ b/docs/2.2.8/typeAsserts.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.2.8/upgrade.html
+++ b/docs/2.2.8/upgrade.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.2.8/upgrade.html
+++ b/docs/2.2.8/upgrade.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.2.8/upgrade.html
+++ b/docs/2.2.8/upgrade.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.2.8/upgrade.html
+++ b/docs/2.2.8/upgrade.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.2.8/utilityAsserts.html
+++ b/docs/2.2.8/utilityAsserts.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.2.8/utilityAsserts.html
+++ b/docs/2.2.8/utilityAsserts.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.2.8/utilityAsserts.html
+++ b/docs/2.2.8/utilityAsserts.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.2.8/utilityAsserts.html
+++ b/docs/2.2.8/utilityAsserts.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.2.8/vsSupport.html
+++ b/docs/2.2.8/vsSupport.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.2.8/vsSupport.html
+++ b/docs/2.2.8/vsSupport.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.2.8/vsSupport.html
+++ b/docs/2.2.8/vsSupport.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.2.8/vsSupport.html
+++ b/docs/2.2.8/vsSupport.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.2.9/assertions.html
+++ b/docs/2.2.9/assertions.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.2.9/assertions.html
+++ b/docs/2.2.9/assertions.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.2.9/assertions.html
+++ b/docs/2.2.9/assertions.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.2.9/assertions.html
+++ b/docs/2.2.9/assertions.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.2.9/attributes.html
+++ b/docs/2.2.9/attributes.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.2.9/attributes.html
+++ b/docs/2.2.9/attributes.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.2.9/attributes.html
+++ b/docs/2.2.9/attributes.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.2.9/attributes.html
+++ b/docs/2.2.9/attributes.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.2.9/category.html
+++ b/docs/2.2.9/category.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.2.9/category.html
+++ b/docs/2.2.9/category.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.2.9/category.html
+++ b/docs/2.2.9/category.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.2.9/category.html
+++ b/docs/2.2.9/category.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.2.9/comparisonAsserts.html
+++ b/docs/2.2.9/comparisonAsserts.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.2.9/comparisonAsserts.html
+++ b/docs/2.2.9/comparisonAsserts.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.2.9/comparisonAsserts.html
+++ b/docs/2.2.9/comparisonAsserts.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.2.9/comparisonAsserts.html
+++ b/docs/2.2.9/comparisonAsserts.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.2.9/conditionAsserts.html
+++ b/docs/2.2.9/conditionAsserts.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.2.9/conditionAsserts.html
+++ b/docs/2.2.9/conditionAsserts.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.2.9/conditionAsserts.html
+++ b/docs/2.2.9/conditionAsserts.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.2.9/conditionAsserts.html
+++ b/docs/2.2.9/conditionAsserts.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.2.9/configEditor.html
+++ b/docs/2.2.9/configEditor.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.2.9/configEditor.html
+++ b/docs/2.2.9/configEditor.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.2.9/configEditor.html
+++ b/docs/2.2.9/configEditor.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.2.9/configEditor.html
+++ b/docs/2.2.9/configEditor.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.2.9/configFiles.html
+++ b/docs/2.2.9/configFiles.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.2.9/configFiles.html
+++ b/docs/2.2.9/configFiles.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.2.9/configFiles.html
+++ b/docs/2.2.9/configFiles.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.2.9/configFiles.html
+++ b/docs/2.2.9/configFiles.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.2.9/consoleCommandLine.html
+++ b/docs/2.2.9/consoleCommandLine.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.2.9/consoleCommandLine.html
+++ b/docs/2.2.9/consoleCommandLine.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.2.9/consoleCommandLine.html
+++ b/docs/2.2.9/consoleCommandLine.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.2.9/consoleCommandLine.html
+++ b/docs/2.2.9/consoleCommandLine.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.2.9/contextMenu.html
+++ b/docs/2.2.9/contextMenu.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.2.9/contextMenu.html
+++ b/docs/2.2.9/contextMenu.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.2.9/contextMenu.html
+++ b/docs/2.2.9/contextMenu.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.2.9/contextMenu.html
+++ b/docs/2.2.9/contextMenu.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.2.9/docHome.html
+++ b/docs/2.2.9/docHome.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.2.9/docHome.html
+++ b/docs/2.2.9/docHome.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.2.9/docHome.html
+++ b/docs/2.2.9/docHome.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.2.9/docHome.html
+++ b/docs/2.2.9/docHome.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.2.9/equalityAsserts.html
+++ b/docs/2.2.9/equalityAsserts.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.2.9/equalityAsserts.html
+++ b/docs/2.2.9/equalityAsserts.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.2.9/equalityAsserts.html
+++ b/docs/2.2.9/equalityAsserts.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.2.9/equalityAsserts.html
+++ b/docs/2.2.9/equalityAsserts.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.2.9/exception.html
+++ b/docs/2.2.9/exception.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.2.9/exception.html
+++ b/docs/2.2.9/exception.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.2.9/exception.html
+++ b/docs/2.2.9/exception.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.2.9/exception.html
+++ b/docs/2.2.9/exception.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.2.9/explicit.html
+++ b/docs/2.2.9/explicit.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.2.9/explicit.html
+++ b/docs/2.2.9/explicit.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.2.9/explicit.html
+++ b/docs/2.2.9/explicit.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.2.9/explicit.html
+++ b/docs/2.2.9/explicit.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.2.9/features.html
+++ b/docs/2.2.9/features.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.2.9/features.html
+++ b/docs/2.2.9/features.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.2.9/features.html
+++ b/docs/2.2.9/features.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.2.9/features.html
+++ b/docs/2.2.9/features.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.2.9/fixtureSetup.html
+++ b/docs/2.2.9/fixtureSetup.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.2.9/fixtureSetup.html
+++ b/docs/2.2.9/fixtureSetup.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.2.9/fixtureSetup.html
+++ b/docs/2.2.9/fixtureSetup.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.2.9/fixtureSetup.html
+++ b/docs/2.2.9/fixtureSetup.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.2.9/fixtureTeardown.html
+++ b/docs/2.2.9/fixtureTeardown.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.2.9/fixtureTeardown.html
+++ b/docs/2.2.9/fixtureTeardown.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.2.9/fixtureTeardown.html
+++ b/docs/2.2.9/fixtureTeardown.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.2.9/fixtureTeardown.html
+++ b/docs/2.2.9/fixtureTeardown.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.2.9/getStarted.html
+++ b/docs/2.2.9/getStarted.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.2.9/getStarted.html
+++ b/docs/2.2.9/getStarted.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.2.9/getStarted.html
+++ b/docs/2.2.9/getStarted.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.2.9/getStarted.html
+++ b/docs/2.2.9/getStarted.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.2.9/guiCommandLine.html
+++ b/docs/2.2.9/guiCommandLine.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.2.9/guiCommandLine.html
+++ b/docs/2.2.9/guiCommandLine.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.2.9/guiCommandLine.html
+++ b/docs/2.2.9/guiCommandLine.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.2.9/guiCommandLine.html
+++ b/docs/2.2.9/guiCommandLine.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.2.9/identityAsserts.html
+++ b/docs/2.2.9/identityAsserts.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.2.9/identityAsserts.html
+++ b/docs/2.2.9/identityAsserts.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.2.9/identityAsserts.html
+++ b/docs/2.2.9/identityAsserts.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.2.9/identityAsserts.html
+++ b/docs/2.2.9/identityAsserts.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.2.9/ignore.html
+++ b/docs/2.2.9/ignore.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.2.9/ignore.html
+++ b/docs/2.2.9/ignore.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.2.9/ignore.html
+++ b/docs/2.2.9/ignore.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.2.9/ignore.html
+++ b/docs/2.2.9/ignore.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.2.9/installation.html
+++ b/docs/2.2.9/installation.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.2.9/installation.html
+++ b/docs/2.2.9/installation.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.2.9/installation.html
+++ b/docs/2.2.9/installation.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.2.9/installation.html
+++ b/docs/2.2.9/installation.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.2.9/license.html
+++ b/docs/2.2.9/license.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.2.9/license.html
+++ b/docs/2.2.9/license.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.2.9/license.html
+++ b/docs/2.2.9/license.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.2.9/license.html
+++ b/docs/2.2.9/license.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.2.9/mainMenu.html
+++ b/docs/2.2.9/mainMenu.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.2.9/mainMenu.html
+++ b/docs/2.2.9/mainMenu.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.2.9/mainMenu.html
+++ b/docs/2.2.9/mainMenu.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.2.9/mainMenu.html
+++ b/docs/2.2.9/mainMenu.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.2.9/multiAssembly.html
+++ b/docs/2.2.9/multiAssembly.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.2.9/multiAssembly.html
+++ b/docs/2.2.9/multiAssembly.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.2.9/multiAssembly.html
+++ b/docs/2.2.9/multiAssembly.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.2.9/multiAssembly.html
+++ b/docs/2.2.9/multiAssembly.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.2.9/nunit-console.html
+++ b/docs/2.2.9/nunit-console.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.2.9/nunit-console.html
+++ b/docs/2.2.9/nunit-console.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.2.9/nunit-console.html
+++ b/docs/2.2.9/nunit-console.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.2.9/nunit-console.html
+++ b/docs/2.2.9/nunit-console.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.2.9/nunit-gui.html
+++ b/docs/2.2.9/nunit-gui.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.2.9/nunit-gui.html
+++ b/docs/2.2.9/nunit-gui.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.2.9/nunit-gui.html
+++ b/docs/2.2.9/nunit-gui.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.2.9/nunit-gui.html
+++ b/docs/2.2.9/nunit-gui.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.2.9/optionsDialog.html
+++ b/docs/2.2.9/optionsDialog.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.2.9/optionsDialog.html
+++ b/docs/2.2.9/optionsDialog.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.2.9/optionsDialog.html
+++ b/docs/2.2.9/optionsDialog.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.2.9/optionsDialog.html
+++ b/docs/2.2.9/optionsDialog.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.2.9/platform.html
+++ b/docs/2.2.9/platform.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.2.9/platform.html
+++ b/docs/2.2.9/platform.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.2.9/platform.html
+++ b/docs/2.2.9/platform.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.2.9/platform.html
+++ b/docs/2.2.9/platform.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.2.9/projectEditor.html
+++ b/docs/2.2.9/projectEditor.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.2.9/projectEditor.html
+++ b/docs/2.2.9/projectEditor.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.2.9/projectEditor.html
+++ b/docs/2.2.9/projectEditor.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.2.9/projectEditor.html
+++ b/docs/2.2.9/projectEditor.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.2.9/quickStart.html
+++ b/docs/2.2.9/quickStart.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.2.9/quickStart.html
+++ b/docs/2.2.9/quickStart.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.2.9/quickStart.html
+++ b/docs/2.2.9/quickStart.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.2.9/quickStart.html
+++ b/docs/2.2.9/quickStart.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.2.9/quickStartSource.html
+++ b/docs/2.2.9/quickStartSource.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.2.9/quickStartSource.html
+++ b/docs/2.2.9/quickStartSource.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.2.9/quickStartSource.html
+++ b/docs/2.2.9/quickStartSource.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.2.9/quickStartSource.html
+++ b/docs/2.2.9/quickStartSource.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.2.9/releaseNotes.html
+++ b/docs/2.2.9/releaseNotes.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.2.9/releaseNotes.html
+++ b/docs/2.2.9/releaseNotes.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.2.9/releaseNotes.html
+++ b/docs/2.2.9/releaseNotes.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.2.9/releaseNotes.html
+++ b/docs/2.2.9/releaseNotes.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.2.9/samples.html
+++ b/docs/2.2.9/samples.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.2.9/samples.html
+++ b/docs/2.2.9/samples.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.2.9/samples.html
+++ b/docs/2.2.9/samples.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.2.9/samples.html
+++ b/docs/2.2.9/samples.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.2.9/setup.html
+++ b/docs/2.2.9/setup.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.2.9/setup.html
+++ b/docs/2.2.9/setup.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.2.9/setup.html
+++ b/docs/2.2.9/setup.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.2.9/setup.html
+++ b/docs/2.2.9/setup.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.2.9/stringAssert.html
+++ b/docs/2.2.9/stringAssert.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.2.9/stringAssert.html
+++ b/docs/2.2.9/stringAssert.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.2.9/stringAssert.html
+++ b/docs/2.2.9/stringAssert.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.2.9/stringAssert.html
+++ b/docs/2.2.9/stringAssert.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.2.9/suite.html
+++ b/docs/2.2.9/suite.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.2.9/suite.html
+++ b/docs/2.2.9/suite.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.2.9/suite.html
+++ b/docs/2.2.9/suite.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.2.9/suite.html
+++ b/docs/2.2.9/suite.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.2.9/teardown.html
+++ b/docs/2.2.9/teardown.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.2.9/teardown.html
+++ b/docs/2.2.9/teardown.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.2.9/teardown.html
+++ b/docs/2.2.9/teardown.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.2.9/teardown.html
+++ b/docs/2.2.9/teardown.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.2.9/test.html
+++ b/docs/2.2.9/test.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.2.9/test.html
+++ b/docs/2.2.9/test.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.2.9/test.html
+++ b/docs/2.2.9/test.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.2.9/test.html
+++ b/docs/2.2.9/test.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.2.9/testFixture.html
+++ b/docs/2.2.9/testFixture.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.2.9/testFixture.html
+++ b/docs/2.2.9/testFixture.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.2.9/testFixture.html
+++ b/docs/2.2.9/testFixture.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.2.9/testFixture.html
+++ b/docs/2.2.9/testFixture.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.2.9/testProperties.html
+++ b/docs/2.2.9/testProperties.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.2.9/testProperties.html
+++ b/docs/2.2.9/testProperties.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.2.9/testProperties.html
+++ b/docs/2.2.9/testProperties.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.2.9/testProperties.html
+++ b/docs/2.2.9/testProperties.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.2.9/typeAsserts.html
+++ b/docs/2.2.9/typeAsserts.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.2.9/typeAsserts.html
+++ b/docs/2.2.9/typeAsserts.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.2.9/typeAsserts.html
+++ b/docs/2.2.9/typeAsserts.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.2.9/typeAsserts.html
+++ b/docs/2.2.9/typeAsserts.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.2.9/upgrade.html
+++ b/docs/2.2.9/upgrade.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.2.9/upgrade.html
+++ b/docs/2.2.9/upgrade.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.2.9/upgrade.html
+++ b/docs/2.2.9/upgrade.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.2.9/upgrade.html
+++ b/docs/2.2.9/upgrade.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.2.9/utilityAsserts.html
+++ b/docs/2.2.9/utilityAsserts.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.2.9/utilityAsserts.html
+++ b/docs/2.2.9/utilityAsserts.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.2.9/utilityAsserts.html
+++ b/docs/2.2.9/utilityAsserts.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.2.9/utilityAsserts.html
+++ b/docs/2.2.9/utilityAsserts.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.2.9/vsSupport.html
+++ b/docs/2.2.9/vsSupport.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.2.9/vsSupport.html
+++ b/docs/2.2.9/vsSupport.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.2.9/vsSupport.html
+++ b/docs/2.2.9/vsSupport.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.2.9/vsSupport.html
+++ b/docs/2.2.9/vsSupport.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.2/assertions.html
+++ b/docs/2.2/assertions.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.2/assertions.html
+++ b/docs/2.2/assertions.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.2/assertions.html
+++ b/docs/2.2/assertions.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.2/assertions.html
+++ b/docs/2.2/assertions.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.2/attributes.html
+++ b/docs/2.2/attributes.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.2/attributes.html
+++ b/docs/2.2/attributes.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.2/attributes.html
+++ b/docs/2.2/attributes.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.2/attributes.html
+++ b/docs/2.2/attributes.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.2/category.html
+++ b/docs/2.2/category.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.2/category.html
+++ b/docs/2.2/category.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.2/category.html
+++ b/docs/2.2/category.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.2/category.html
+++ b/docs/2.2/category.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.2/comparisonAsserts.html
+++ b/docs/2.2/comparisonAsserts.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.2/comparisonAsserts.html
+++ b/docs/2.2/comparisonAsserts.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.2/comparisonAsserts.html
+++ b/docs/2.2/comparisonAsserts.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.2/comparisonAsserts.html
+++ b/docs/2.2/comparisonAsserts.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.2/conditionAsserts.html
+++ b/docs/2.2/conditionAsserts.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.2/conditionAsserts.html
+++ b/docs/2.2/conditionAsserts.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.2/conditionAsserts.html
+++ b/docs/2.2/conditionAsserts.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.2/conditionAsserts.html
+++ b/docs/2.2/conditionAsserts.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.2/configEditor.html
+++ b/docs/2.2/configEditor.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.2/configEditor.html
+++ b/docs/2.2/configEditor.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.2/configEditor.html
+++ b/docs/2.2/configEditor.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.2/configEditor.html
+++ b/docs/2.2/configEditor.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.2/configFiles.html
+++ b/docs/2.2/configFiles.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.2/configFiles.html
+++ b/docs/2.2/configFiles.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.2/configFiles.html
+++ b/docs/2.2/configFiles.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.2/configFiles.html
+++ b/docs/2.2/configFiles.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.2/consoleCommandLine.html
+++ b/docs/2.2/consoleCommandLine.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.2/consoleCommandLine.html
+++ b/docs/2.2/consoleCommandLine.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.2/consoleCommandLine.html
+++ b/docs/2.2/consoleCommandLine.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.2/consoleCommandLine.html
+++ b/docs/2.2/consoleCommandLine.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.2/contextMenu.html
+++ b/docs/2.2/contextMenu.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.2/contextMenu.html
+++ b/docs/2.2/contextMenu.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.2/contextMenu.html
+++ b/docs/2.2/contextMenu.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.2/contextMenu.html
+++ b/docs/2.2/contextMenu.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.2/docHome.html
+++ b/docs/2.2/docHome.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.2/docHome.html
+++ b/docs/2.2/docHome.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.2/docHome.html
+++ b/docs/2.2/docHome.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.2/docHome.html
+++ b/docs/2.2/docHome.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.2/exception.html
+++ b/docs/2.2/exception.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.2/exception.html
+++ b/docs/2.2/exception.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.2/exception.html
+++ b/docs/2.2/exception.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.2/exception.html
+++ b/docs/2.2/exception.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.2/explicit.html
+++ b/docs/2.2/explicit.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.2/explicit.html
+++ b/docs/2.2/explicit.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.2/explicit.html
+++ b/docs/2.2/explicit.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.2/explicit.html
+++ b/docs/2.2/explicit.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.2/features.html
+++ b/docs/2.2/features.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.2/features.html
+++ b/docs/2.2/features.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.2/features.html
+++ b/docs/2.2/features.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.2/features.html
+++ b/docs/2.2/features.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.2/fixtureSetup.html
+++ b/docs/2.2/fixtureSetup.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.2/fixtureSetup.html
+++ b/docs/2.2/fixtureSetup.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.2/fixtureSetup.html
+++ b/docs/2.2/fixtureSetup.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.2/fixtureSetup.html
+++ b/docs/2.2/fixtureSetup.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.2/fixtureTeardown.html
+++ b/docs/2.2/fixtureTeardown.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.2/fixtureTeardown.html
+++ b/docs/2.2/fixtureTeardown.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.2/fixtureTeardown.html
+++ b/docs/2.2/fixtureTeardown.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.2/fixtureTeardown.html
+++ b/docs/2.2/fixtureTeardown.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.2/getStarted.html
+++ b/docs/2.2/getStarted.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.2/getStarted.html
+++ b/docs/2.2/getStarted.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.2/getStarted.html
+++ b/docs/2.2/getStarted.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.2/getStarted.html
+++ b/docs/2.2/getStarted.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.2/guiCommandLine.html
+++ b/docs/2.2/guiCommandLine.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.2/guiCommandLine.html
+++ b/docs/2.2/guiCommandLine.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.2/guiCommandLine.html
+++ b/docs/2.2/guiCommandLine.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.2/guiCommandLine.html
+++ b/docs/2.2/guiCommandLine.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.2/ignore.html
+++ b/docs/2.2/ignore.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.2/ignore.html
+++ b/docs/2.2/ignore.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.2/ignore.html
+++ b/docs/2.2/ignore.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.2/ignore.html
+++ b/docs/2.2/ignore.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.2/installation.html
+++ b/docs/2.2/installation.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.2/installation.html
+++ b/docs/2.2/installation.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.2/installation.html
+++ b/docs/2.2/installation.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.2/installation.html
+++ b/docs/2.2/installation.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.2/license.html
+++ b/docs/2.2/license.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.2/license.html
+++ b/docs/2.2/license.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.2/license.html
+++ b/docs/2.2/license.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.2/license.html
+++ b/docs/2.2/license.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.2/mainMenu.html
+++ b/docs/2.2/mainMenu.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.2/mainMenu.html
+++ b/docs/2.2/mainMenu.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.2/mainMenu.html
+++ b/docs/2.2/mainMenu.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.2/mainMenu.html
+++ b/docs/2.2/mainMenu.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.2/multiAssembly.html
+++ b/docs/2.2/multiAssembly.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.2/multiAssembly.html
+++ b/docs/2.2/multiAssembly.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.2/multiAssembly.html
+++ b/docs/2.2/multiAssembly.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.2/multiAssembly.html
+++ b/docs/2.2/multiAssembly.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.2/nunit-console.html
+++ b/docs/2.2/nunit-console.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.2/nunit-console.html
+++ b/docs/2.2/nunit-console.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.2/nunit-console.html
+++ b/docs/2.2/nunit-console.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.2/nunit-console.html
+++ b/docs/2.2/nunit-console.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.2/nunit-gui.html
+++ b/docs/2.2/nunit-gui.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.2/nunit-gui.html
+++ b/docs/2.2/nunit-gui.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.2/nunit-gui.html
+++ b/docs/2.2/nunit-gui.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.2/nunit-gui.html
+++ b/docs/2.2/nunit-gui.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.2/optionsDialog.html
+++ b/docs/2.2/optionsDialog.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.2/optionsDialog.html
+++ b/docs/2.2/optionsDialog.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.2/optionsDialog.html
+++ b/docs/2.2/optionsDialog.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.2/optionsDialog.html
+++ b/docs/2.2/optionsDialog.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.2/projectEditor.html
+++ b/docs/2.2/projectEditor.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.2/projectEditor.html
+++ b/docs/2.2/projectEditor.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.2/projectEditor.html
+++ b/docs/2.2/projectEditor.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.2/projectEditor.html
+++ b/docs/2.2/projectEditor.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.2/quickStart.html
+++ b/docs/2.2/quickStart.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.2/quickStart.html
+++ b/docs/2.2/quickStart.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.2/quickStart.html
+++ b/docs/2.2/quickStart.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.2/quickStart.html
+++ b/docs/2.2/quickStart.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.2/quickStartSource.html
+++ b/docs/2.2/quickStartSource.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.2/quickStartSource.html
+++ b/docs/2.2/quickStartSource.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.2/quickStartSource.html
+++ b/docs/2.2/quickStartSource.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.2/quickStartSource.html
+++ b/docs/2.2/quickStartSource.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.2/releaseNotes.html
+++ b/docs/2.2/releaseNotes.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.2/releaseNotes.html
+++ b/docs/2.2/releaseNotes.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.2/releaseNotes.html
+++ b/docs/2.2/releaseNotes.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.2/releaseNotes.html
+++ b/docs/2.2/releaseNotes.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.2/samples.html
+++ b/docs/2.2/samples.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.2/samples.html
+++ b/docs/2.2/samples.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.2/samples.html
+++ b/docs/2.2/samples.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.2/samples.html
+++ b/docs/2.2/samples.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.2/setup.html
+++ b/docs/2.2/setup.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.2/setup.html
+++ b/docs/2.2/setup.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.2/setup.html
+++ b/docs/2.2/setup.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.2/setup.html
+++ b/docs/2.2/setup.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.2/suite.html
+++ b/docs/2.2/suite.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.2/suite.html
+++ b/docs/2.2/suite.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.2/suite.html
+++ b/docs/2.2/suite.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.2/suite.html
+++ b/docs/2.2/suite.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.2/teardown.html
+++ b/docs/2.2/teardown.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.2/teardown.html
+++ b/docs/2.2/teardown.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.2/teardown.html
+++ b/docs/2.2/teardown.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.2/teardown.html
+++ b/docs/2.2/teardown.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.2/test.html
+++ b/docs/2.2/test.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.2/test.html
+++ b/docs/2.2/test.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.2/test.html
+++ b/docs/2.2/test.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.2/test.html
+++ b/docs/2.2/test.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.2/testFixture.html
+++ b/docs/2.2/testFixture.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.2/testFixture.html
+++ b/docs/2.2/testFixture.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.2/testFixture.html
+++ b/docs/2.2/testFixture.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.2/testFixture.html
+++ b/docs/2.2/testFixture.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.2/testProperties.html
+++ b/docs/2.2/testProperties.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.2/testProperties.html
+++ b/docs/2.2/testProperties.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.2/testProperties.html
+++ b/docs/2.2/testProperties.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.2/testProperties.html
+++ b/docs/2.2/testProperties.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.2/upgrade.html
+++ b/docs/2.2/upgrade.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.2/upgrade.html
+++ b/docs/2.2/upgrade.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.2/upgrade.html
+++ b/docs/2.2/upgrade.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.2/upgrade.html
+++ b/docs/2.2/upgrade.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.2/utilityAsserts.html
+++ b/docs/2.2/utilityAsserts.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.2/utilityAsserts.html
+++ b/docs/2.2/utilityAsserts.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.2/utilityAsserts.html
+++ b/docs/2.2/utilityAsserts.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.2/utilityAsserts.html
+++ b/docs/2.2/utilityAsserts.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.2/vsSupport.html
+++ b/docs/2.2/vsSupport.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.2/vsSupport.html
+++ b/docs/2.2/vsSupport.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.2/vsSupport.html
+++ b/docs/2.2/vsSupport.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.2/vsSupport.html
+++ b/docs/2.2/vsSupport.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.4.1/addinsDialog.html
+++ b/docs/2.4.1/addinsDialog.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.4.1/addinsDialog.html
+++ b/docs/2.4.1/addinsDialog.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.4.1/addinsDialog.html
+++ b/docs/2.4.1/addinsDialog.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.4.1/addinsDialog.html
+++ b/docs/2.4.1/addinsDialog.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.4.1/assertions.html
+++ b/docs/2.4.1/assertions.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.4.1/assertions.html
+++ b/docs/2.4.1/assertions.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.4.1/assertions.html
+++ b/docs/2.4.1/assertions.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.4.1/assertions.html
+++ b/docs/2.4.1/assertions.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.4.1/attributes.html
+++ b/docs/2.4.1/attributes.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.4.1/attributes.html
+++ b/docs/2.4.1/attributes.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.4.1/attributes.html
+++ b/docs/2.4.1/attributes.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.4.1/attributes.html
+++ b/docs/2.4.1/attributes.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.4.1/category.html
+++ b/docs/2.4.1/category.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.4.1/category.html
+++ b/docs/2.4.1/category.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.4.1/category.html
+++ b/docs/2.4.1/category.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.4.1/category.html
+++ b/docs/2.4.1/category.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.4.1/classicModel.html
+++ b/docs/2.4.1/classicModel.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.4.1/classicModel.html
+++ b/docs/2.4.1/classicModel.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.4.1/classicModel.html
+++ b/docs/2.4.1/classicModel.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.4.1/classicModel.html
+++ b/docs/2.4.1/classicModel.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.4.1/collectionAssert.html
+++ b/docs/2.4.1/collectionAssert.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.4.1/collectionAssert.html
+++ b/docs/2.4.1/collectionAssert.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.4.1/collectionAssert.html
+++ b/docs/2.4.1/collectionAssert.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.4.1/collectionAssert.html
+++ b/docs/2.4.1/collectionAssert.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.4.1/collectionConstraints.html
+++ b/docs/2.4.1/collectionConstraints.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.4.1/collectionConstraints.html
+++ b/docs/2.4.1/collectionConstraints.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.4.1/collectionConstraints.html
+++ b/docs/2.4.1/collectionConstraints.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.4.1/collectionConstraints.html
+++ b/docs/2.4.1/collectionConstraints.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.4.1/comparisonAsserts.html
+++ b/docs/2.4.1/comparisonAsserts.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.4.1/comparisonAsserts.html
+++ b/docs/2.4.1/comparisonAsserts.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.4.1/comparisonAsserts.html
+++ b/docs/2.4.1/comparisonAsserts.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.4.1/comparisonAsserts.html
+++ b/docs/2.4.1/comparisonAsserts.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.4.1/comparisonConstraints.html
+++ b/docs/2.4.1/comparisonConstraints.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.4.1/comparisonConstraints.html
+++ b/docs/2.4.1/comparisonConstraints.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.4.1/comparisonConstraints.html
+++ b/docs/2.4.1/comparisonConstraints.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.4.1/comparisonConstraints.html
+++ b/docs/2.4.1/comparisonConstraints.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.4.1/compoundConstraints.html
+++ b/docs/2.4.1/compoundConstraints.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.4.1/compoundConstraints.html
+++ b/docs/2.4.1/compoundConstraints.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.4.1/compoundConstraints.html
+++ b/docs/2.4.1/compoundConstraints.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.4.1/compoundConstraints.html
+++ b/docs/2.4.1/compoundConstraints.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.4.1/conditionAsserts.html
+++ b/docs/2.4.1/conditionAsserts.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.4.1/conditionAsserts.html
+++ b/docs/2.4.1/conditionAsserts.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.4.1/conditionAsserts.html
+++ b/docs/2.4.1/conditionAsserts.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.4.1/conditionAsserts.html
+++ b/docs/2.4.1/conditionAsserts.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.4.1/conditionConstraints.html
+++ b/docs/2.4.1/conditionConstraints.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.4.1/conditionConstraints.html
+++ b/docs/2.4.1/conditionConstraints.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.4.1/conditionConstraints.html
+++ b/docs/2.4.1/conditionConstraints.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.4.1/conditionConstraints.html
+++ b/docs/2.4.1/conditionConstraints.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.4.1/configEditor.html
+++ b/docs/2.4.1/configEditor.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.4.1/configEditor.html
+++ b/docs/2.4.1/configEditor.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.4.1/configEditor.html
+++ b/docs/2.4.1/configEditor.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.4.1/configEditor.html
+++ b/docs/2.4.1/configEditor.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.4.1/configFiles.html
+++ b/docs/2.4.1/configFiles.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.4.1/configFiles.html
+++ b/docs/2.4.1/configFiles.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.4.1/configFiles.html
+++ b/docs/2.4.1/configFiles.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.4.1/configFiles.html
+++ b/docs/2.4.1/configFiles.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.4.1/consoleCommandLine.html
+++ b/docs/2.4.1/consoleCommandLine.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.4.1/consoleCommandLine.html
+++ b/docs/2.4.1/consoleCommandLine.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.4.1/consoleCommandLine.html
+++ b/docs/2.4.1/consoleCommandLine.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.4.1/consoleCommandLine.html
+++ b/docs/2.4.1/consoleCommandLine.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.4.1/constraintModel.html
+++ b/docs/2.4.1/constraintModel.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.4.1/constraintModel.html
+++ b/docs/2.4.1/constraintModel.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.4.1/constraintModel.html
+++ b/docs/2.4.1/constraintModel.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.4.1/constraintModel.html
+++ b/docs/2.4.1/constraintModel.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.4.1/contextMenu.html
+++ b/docs/2.4.1/contextMenu.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.4.1/contextMenu.html
+++ b/docs/2.4.1/contextMenu.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.4.1/contextMenu.html
+++ b/docs/2.4.1/contextMenu.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.4.1/contextMenu.html
+++ b/docs/2.4.1/contextMenu.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.4.1/customAsserts.html
+++ b/docs/2.4.1/customAsserts.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.4.1/customAsserts.html
+++ b/docs/2.4.1/customAsserts.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.4.1/customAsserts.html
+++ b/docs/2.4.1/customAsserts.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.4.1/customAsserts.html
+++ b/docs/2.4.1/customAsserts.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.4.1/customConstraints.html
+++ b/docs/2.4.1/customConstraints.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.4.1/customConstraints.html
+++ b/docs/2.4.1/customConstraints.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.4.1/customConstraints.html
+++ b/docs/2.4.1/customConstraints.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.4.1/customConstraints.html
+++ b/docs/2.4.1/customConstraints.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.4.1/description.html
+++ b/docs/2.4.1/description.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.4.1/description.html
+++ b/docs/2.4.1/description.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.4.1/description.html
+++ b/docs/2.4.1/description.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.4.1/description.html
+++ b/docs/2.4.1/description.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.4.1/docHome.html
+++ b/docs/2.4.1/docHome.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.4.1/docHome.html
+++ b/docs/2.4.1/docHome.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.4.1/docHome.html
+++ b/docs/2.4.1/docHome.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.4.1/docHome.html
+++ b/docs/2.4.1/docHome.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.4.1/equalConstraint.html
+++ b/docs/2.4.1/equalConstraint.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.4.1/equalConstraint.html
+++ b/docs/2.4.1/equalConstraint.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.4.1/equalConstraint.html
+++ b/docs/2.4.1/equalConstraint.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.4.1/equalConstraint.html
+++ b/docs/2.4.1/equalConstraint.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.4.1/equalityAsserts.html
+++ b/docs/2.4.1/equalityAsserts.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.4.1/equalityAsserts.html
+++ b/docs/2.4.1/equalityAsserts.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.4.1/equalityAsserts.html
+++ b/docs/2.4.1/equalityAsserts.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.4.1/equalityAsserts.html
+++ b/docs/2.4.1/equalityAsserts.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.4.1/exception.html
+++ b/docs/2.4.1/exception.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.4.1/exception.html
+++ b/docs/2.4.1/exception.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.4.1/exception.html
+++ b/docs/2.4.1/exception.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.4.1/exception.html
+++ b/docs/2.4.1/exception.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.4.1/explicit.html
+++ b/docs/2.4.1/explicit.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.4.1/explicit.html
+++ b/docs/2.4.1/explicit.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.4.1/explicit.html
+++ b/docs/2.4.1/explicit.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.4.1/explicit.html
+++ b/docs/2.4.1/explicit.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.4.1/extensibility.html
+++ b/docs/2.4.1/extensibility.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.4.1/extensibility.html
+++ b/docs/2.4.1/extensibility.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.4.1/extensibility.html
+++ b/docs/2.4.1/extensibility.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.4.1/extensibility.html
+++ b/docs/2.4.1/extensibility.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.4.1/features.html
+++ b/docs/2.4.1/features.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.4.1/features.html
+++ b/docs/2.4.1/features.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.4.1/features.html
+++ b/docs/2.4.1/features.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.4.1/features.html
+++ b/docs/2.4.1/features.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.4.1/fileAssert.html
+++ b/docs/2.4.1/fileAssert.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.4.1/fileAssert.html
+++ b/docs/2.4.1/fileAssert.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.4.1/fileAssert.html
+++ b/docs/2.4.1/fileAssert.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.4.1/fileAssert.html
+++ b/docs/2.4.1/fileAssert.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.4.1/fixtureSetup.html
+++ b/docs/2.4.1/fixtureSetup.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.4.1/fixtureSetup.html
+++ b/docs/2.4.1/fixtureSetup.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.4.1/fixtureSetup.html
+++ b/docs/2.4.1/fixtureSetup.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.4.1/fixtureSetup.html
+++ b/docs/2.4.1/fixtureSetup.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.4.1/fixtureTeardown.html
+++ b/docs/2.4.1/fixtureTeardown.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.4.1/fixtureTeardown.html
+++ b/docs/2.4.1/fixtureTeardown.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.4.1/fixtureTeardown.html
+++ b/docs/2.4.1/fixtureTeardown.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.4.1/fixtureTeardown.html
+++ b/docs/2.4.1/fixtureTeardown.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.4.1/getStarted.html
+++ b/docs/2.4.1/getStarted.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.4.1/getStarted.html
+++ b/docs/2.4.1/getStarted.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.4.1/getStarted.html
+++ b/docs/2.4.1/getStarted.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.4.1/getStarted.html
+++ b/docs/2.4.1/getStarted.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.4.1/guiCommandLine.html
+++ b/docs/2.4.1/guiCommandLine.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.4.1/guiCommandLine.html
+++ b/docs/2.4.1/guiCommandLine.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.4.1/guiCommandLine.html
+++ b/docs/2.4.1/guiCommandLine.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.4.1/guiCommandLine.html
+++ b/docs/2.4.1/guiCommandLine.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.4.1/identityAsserts.html
+++ b/docs/2.4.1/identityAsserts.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.4.1/identityAsserts.html
+++ b/docs/2.4.1/identityAsserts.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.4.1/identityAsserts.html
+++ b/docs/2.4.1/identityAsserts.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.4.1/identityAsserts.html
+++ b/docs/2.4.1/identityAsserts.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.4.1/ignore.html
+++ b/docs/2.4.1/ignore.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.4.1/ignore.html
+++ b/docs/2.4.1/ignore.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.4.1/ignore.html
+++ b/docs/2.4.1/ignore.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.4.1/ignore.html
+++ b/docs/2.4.1/ignore.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.4.1/installation.html
+++ b/docs/2.4.1/installation.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.4.1/installation.html
+++ b/docs/2.4.1/installation.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.4.1/installation.html
+++ b/docs/2.4.1/installation.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.4.1/installation.html
+++ b/docs/2.4.1/installation.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.4.1/license.html
+++ b/docs/2.4.1/license.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.4.1/license.html
+++ b/docs/2.4.1/license.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.4.1/license.html
+++ b/docs/2.4.1/license.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.4.1/license.html
+++ b/docs/2.4.1/license.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.4.1/mainMenu.html
+++ b/docs/2.4.1/mainMenu.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.4.1/mainMenu.html
+++ b/docs/2.4.1/mainMenu.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.4.1/mainMenu.html
+++ b/docs/2.4.1/mainMenu.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.4.1/mainMenu.html
+++ b/docs/2.4.1/mainMenu.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.4.1/multiAssembly.html
+++ b/docs/2.4.1/multiAssembly.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.4.1/multiAssembly.html
+++ b/docs/2.4.1/multiAssembly.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.4.1/multiAssembly.html
+++ b/docs/2.4.1/multiAssembly.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.4.1/multiAssembly.html
+++ b/docs/2.4.1/multiAssembly.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.4.1/nunit-console.html
+++ b/docs/2.4.1/nunit-console.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.4.1/nunit-console.html
+++ b/docs/2.4.1/nunit-console.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.4.1/nunit-console.html
+++ b/docs/2.4.1/nunit-console.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.4.1/nunit-console.html
+++ b/docs/2.4.1/nunit-console.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.4.1/nunit-gui.html
+++ b/docs/2.4.1/nunit-gui.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.4.1/nunit-gui.html
+++ b/docs/2.4.1/nunit-gui.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.4.1/nunit-gui.html
+++ b/docs/2.4.1/nunit-gui.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.4.1/nunit-gui.html
+++ b/docs/2.4.1/nunit-gui.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.4.1/nunitAddins.html
+++ b/docs/2.4.1/nunitAddins.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.4.1/nunitAddins.html
+++ b/docs/2.4.1/nunitAddins.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.4.1/nunitAddins.html
+++ b/docs/2.4.1/nunitAddins.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.4.1/nunitAddins.html
+++ b/docs/2.4.1/nunitAddins.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.4.1/optionsDialog.html
+++ b/docs/2.4.1/optionsDialog.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.4.1/optionsDialog.html
+++ b/docs/2.4.1/optionsDialog.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.4.1/optionsDialog.html
+++ b/docs/2.4.1/optionsDialog.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.4.1/optionsDialog.html
+++ b/docs/2.4.1/optionsDialog.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.4.1/platform.html
+++ b/docs/2.4.1/platform.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.4.1/platform.html
+++ b/docs/2.4.1/platform.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.4.1/platform.html
+++ b/docs/2.4.1/platform.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.4.1/platform.html
+++ b/docs/2.4.1/platform.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.4.1/projectEditor.html
+++ b/docs/2.4.1/projectEditor.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.4.1/projectEditor.html
+++ b/docs/2.4.1/projectEditor.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.4.1/projectEditor.html
+++ b/docs/2.4.1/projectEditor.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.4.1/projectEditor.html
+++ b/docs/2.4.1/projectEditor.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.4.1/property.html
+++ b/docs/2.4.1/property.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.4.1/property.html
+++ b/docs/2.4.1/property.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.4.1/property.html
+++ b/docs/2.4.1/property.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.4.1/property.html
+++ b/docs/2.4.1/property.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.4.1/quickStart.html
+++ b/docs/2.4.1/quickStart.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.4.1/quickStart.html
+++ b/docs/2.4.1/quickStart.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.4.1/quickStart.html
+++ b/docs/2.4.1/quickStart.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.4.1/quickStart.html
+++ b/docs/2.4.1/quickStart.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.4.1/quickStartSource.html
+++ b/docs/2.4.1/quickStartSource.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.4.1/quickStartSource.html
+++ b/docs/2.4.1/quickStartSource.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.4.1/quickStartSource.html
+++ b/docs/2.4.1/quickStartSource.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.4.1/quickStartSource.html
+++ b/docs/2.4.1/quickStartSource.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.4.1/releaseNotes.html
+++ b/docs/2.4.1/releaseNotes.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.4.1/releaseNotes.html
+++ b/docs/2.4.1/releaseNotes.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.4.1/releaseNotes.html
+++ b/docs/2.4.1/releaseNotes.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.4.1/releaseNotes.html
+++ b/docs/2.4.1/releaseNotes.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.4.1/sameasConstraint.html
+++ b/docs/2.4.1/sameasConstraint.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.4.1/sameasConstraint.html
+++ b/docs/2.4.1/sameasConstraint.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.4.1/sameasConstraint.html
+++ b/docs/2.4.1/sameasConstraint.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.4.1/sameasConstraint.html
+++ b/docs/2.4.1/sameasConstraint.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.4.1/samples.html
+++ b/docs/2.4.1/samples.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.4.1/samples.html
+++ b/docs/2.4.1/samples.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.4.1/samples.html
+++ b/docs/2.4.1/samples.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.4.1/samples.html
+++ b/docs/2.4.1/samples.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.4.1/setup.html
+++ b/docs/2.4.1/setup.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.4.1/setup.html
+++ b/docs/2.4.1/setup.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.4.1/setup.html
+++ b/docs/2.4.1/setup.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.4.1/setup.html
+++ b/docs/2.4.1/setup.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.4.1/setupFixture.html
+++ b/docs/2.4.1/setupFixture.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.4.1/setupFixture.html
+++ b/docs/2.4.1/setupFixture.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.4.1/setupFixture.html
+++ b/docs/2.4.1/setupFixture.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.4.1/setupFixture.html
+++ b/docs/2.4.1/setupFixture.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.4.1/stringAssert.html
+++ b/docs/2.4.1/stringAssert.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.4.1/stringAssert.html
+++ b/docs/2.4.1/stringAssert.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.4.1/stringAssert.html
+++ b/docs/2.4.1/stringAssert.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.4.1/stringAssert.html
+++ b/docs/2.4.1/stringAssert.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.4.1/stringConstraints.html
+++ b/docs/2.4.1/stringConstraints.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.4.1/stringConstraints.html
+++ b/docs/2.4.1/stringConstraints.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.4.1/stringConstraints.html
+++ b/docs/2.4.1/stringConstraints.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.4.1/stringConstraints.html
+++ b/docs/2.4.1/stringConstraints.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.4.1/suite.html
+++ b/docs/2.4.1/suite.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.4.1/suite.html
+++ b/docs/2.4.1/suite.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.4.1/suite.html
+++ b/docs/2.4.1/suite.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.4.1/suite.html
+++ b/docs/2.4.1/suite.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.4.1/teardown.html
+++ b/docs/2.4.1/teardown.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.4.1/teardown.html
+++ b/docs/2.4.1/teardown.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.4.1/teardown.html
+++ b/docs/2.4.1/teardown.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.4.1/teardown.html
+++ b/docs/2.4.1/teardown.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.4.1/test.html
+++ b/docs/2.4.1/test.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.4.1/test.html
+++ b/docs/2.4.1/test.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.4.1/test.html
+++ b/docs/2.4.1/test.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.4.1/test.html
+++ b/docs/2.4.1/test.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.4.1/testFixture.html
+++ b/docs/2.4.1/testFixture.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.4.1/testFixture.html
+++ b/docs/2.4.1/testFixture.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.4.1/testFixture.html
+++ b/docs/2.4.1/testFixture.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.4.1/testFixture.html
+++ b/docs/2.4.1/testFixture.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.4.1/testProperties.html
+++ b/docs/2.4.1/testProperties.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.4.1/testProperties.html
+++ b/docs/2.4.1/testProperties.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.4.1/testProperties.html
+++ b/docs/2.4.1/testProperties.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.4.1/testProperties.html
+++ b/docs/2.4.1/testProperties.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.4.1/typeAsserts.html
+++ b/docs/2.4.1/typeAsserts.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.4.1/typeAsserts.html
+++ b/docs/2.4.1/typeAsserts.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.4.1/typeAsserts.html
+++ b/docs/2.4.1/typeAsserts.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.4.1/typeAsserts.html
+++ b/docs/2.4.1/typeAsserts.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.4.1/typeConstraints.html
+++ b/docs/2.4.1/typeConstraints.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.4.1/typeConstraints.html
+++ b/docs/2.4.1/typeConstraints.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.4.1/typeConstraints.html
+++ b/docs/2.4.1/typeConstraints.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.4.1/typeConstraints.html
+++ b/docs/2.4.1/typeConstraints.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.4.1/upgrade.html
+++ b/docs/2.4.1/upgrade.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.4.1/upgrade.html
+++ b/docs/2.4.1/upgrade.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.4.1/upgrade.html
+++ b/docs/2.4.1/upgrade.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.4.1/upgrade.html
+++ b/docs/2.4.1/upgrade.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.4.1/utilityAsserts.html
+++ b/docs/2.4.1/utilityAsserts.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.4.1/utilityAsserts.html
+++ b/docs/2.4.1/utilityAsserts.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.4.1/utilityAsserts.html
+++ b/docs/2.4.1/utilityAsserts.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.4.1/utilityAsserts.html
+++ b/docs/2.4.1/utilityAsserts.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.4.1/vsSupport.html
+++ b/docs/2.4.1/vsSupport.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.4.1/vsSupport.html
+++ b/docs/2.4.1/vsSupport.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.4.1/vsSupport.html
+++ b/docs/2.4.1/vsSupport.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.4.1/vsSupport.html
+++ b/docs/2.4.1/vsSupport.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.4.2/addinsDialog.html
+++ b/docs/2.4.2/addinsDialog.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.4.2/addinsDialog.html
+++ b/docs/2.4.2/addinsDialog.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.4.2/addinsDialog.html
+++ b/docs/2.4.2/addinsDialog.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.4.2/addinsDialog.html
+++ b/docs/2.4.2/addinsDialog.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.4.2/assertions.html
+++ b/docs/2.4.2/assertions.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.4.2/assertions.html
+++ b/docs/2.4.2/assertions.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.4.2/assertions.html
+++ b/docs/2.4.2/assertions.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.4.2/assertions.html
+++ b/docs/2.4.2/assertions.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.4.2/attributes.html
+++ b/docs/2.4.2/attributes.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.4.2/attributes.html
+++ b/docs/2.4.2/attributes.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.4.2/attributes.html
+++ b/docs/2.4.2/attributes.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.4.2/attributes.html
+++ b/docs/2.4.2/attributes.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.4.2/category.html
+++ b/docs/2.4.2/category.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.4.2/category.html
+++ b/docs/2.4.2/category.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.4.2/category.html
+++ b/docs/2.4.2/category.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.4.2/category.html
+++ b/docs/2.4.2/category.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.4.2/classicModel.html
+++ b/docs/2.4.2/classicModel.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.4.2/classicModel.html
+++ b/docs/2.4.2/classicModel.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.4.2/classicModel.html
+++ b/docs/2.4.2/classicModel.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.4.2/classicModel.html
+++ b/docs/2.4.2/classicModel.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.4.2/collectionAssert.html
+++ b/docs/2.4.2/collectionAssert.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.4.2/collectionAssert.html
+++ b/docs/2.4.2/collectionAssert.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.4.2/collectionAssert.html
+++ b/docs/2.4.2/collectionAssert.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.4.2/collectionAssert.html
+++ b/docs/2.4.2/collectionAssert.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.4.2/collectionConstraints.html
+++ b/docs/2.4.2/collectionConstraints.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.4.2/collectionConstraints.html
+++ b/docs/2.4.2/collectionConstraints.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.4.2/collectionConstraints.html
+++ b/docs/2.4.2/collectionConstraints.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.4.2/collectionConstraints.html
+++ b/docs/2.4.2/collectionConstraints.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.4.2/comparisonAsserts.html
+++ b/docs/2.4.2/comparisonAsserts.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.4.2/comparisonAsserts.html
+++ b/docs/2.4.2/comparisonAsserts.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.4.2/comparisonAsserts.html
+++ b/docs/2.4.2/comparisonAsserts.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.4.2/comparisonAsserts.html
+++ b/docs/2.4.2/comparisonAsserts.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.4.2/comparisonConstraints.html
+++ b/docs/2.4.2/comparisonConstraints.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.4.2/comparisonConstraints.html
+++ b/docs/2.4.2/comparisonConstraints.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.4.2/comparisonConstraints.html
+++ b/docs/2.4.2/comparisonConstraints.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.4.2/comparisonConstraints.html
+++ b/docs/2.4.2/comparisonConstraints.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.4.2/compoundConstraints.html
+++ b/docs/2.4.2/compoundConstraints.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.4.2/compoundConstraints.html
+++ b/docs/2.4.2/compoundConstraints.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.4.2/compoundConstraints.html
+++ b/docs/2.4.2/compoundConstraints.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.4.2/compoundConstraints.html
+++ b/docs/2.4.2/compoundConstraints.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.4.2/conditionAsserts.html
+++ b/docs/2.4.2/conditionAsserts.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.4.2/conditionAsserts.html
+++ b/docs/2.4.2/conditionAsserts.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.4.2/conditionAsserts.html
+++ b/docs/2.4.2/conditionAsserts.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.4.2/conditionAsserts.html
+++ b/docs/2.4.2/conditionAsserts.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.4.2/conditionConstraints.html
+++ b/docs/2.4.2/conditionConstraints.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.4.2/conditionConstraints.html
+++ b/docs/2.4.2/conditionConstraints.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.4.2/conditionConstraints.html
+++ b/docs/2.4.2/conditionConstraints.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.4.2/conditionConstraints.html
+++ b/docs/2.4.2/conditionConstraints.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.4.2/configEditor.html
+++ b/docs/2.4.2/configEditor.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.4.2/configEditor.html
+++ b/docs/2.4.2/configEditor.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.4.2/configEditor.html
+++ b/docs/2.4.2/configEditor.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.4.2/configEditor.html
+++ b/docs/2.4.2/configEditor.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.4.2/configFiles.html
+++ b/docs/2.4.2/configFiles.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.4.2/configFiles.html
+++ b/docs/2.4.2/configFiles.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.4.2/configFiles.html
+++ b/docs/2.4.2/configFiles.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.4.2/configFiles.html
+++ b/docs/2.4.2/configFiles.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.4.2/consoleCommandLine.html
+++ b/docs/2.4.2/consoleCommandLine.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.4.2/consoleCommandLine.html
+++ b/docs/2.4.2/consoleCommandLine.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.4.2/consoleCommandLine.html
+++ b/docs/2.4.2/consoleCommandLine.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.4.2/consoleCommandLine.html
+++ b/docs/2.4.2/consoleCommandLine.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.4.2/constraintModel.html
+++ b/docs/2.4.2/constraintModel.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.4.2/constraintModel.html
+++ b/docs/2.4.2/constraintModel.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.4.2/constraintModel.html
+++ b/docs/2.4.2/constraintModel.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.4.2/constraintModel.html
+++ b/docs/2.4.2/constraintModel.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.4.2/contextMenu.html
+++ b/docs/2.4.2/contextMenu.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.4.2/contextMenu.html
+++ b/docs/2.4.2/contextMenu.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.4.2/contextMenu.html
+++ b/docs/2.4.2/contextMenu.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.4.2/contextMenu.html
+++ b/docs/2.4.2/contextMenu.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.4.2/culture.html
+++ b/docs/2.4.2/culture.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.4.2/culture.html
+++ b/docs/2.4.2/culture.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.4.2/culture.html
+++ b/docs/2.4.2/culture.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.4.2/culture.html
+++ b/docs/2.4.2/culture.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.4.2/customAsserts.html
+++ b/docs/2.4.2/customAsserts.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.4.2/customAsserts.html
+++ b/docs/2.4.2/customAsserts.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.4.2/customAsserts.html
+++ b/docs/2.4.2/customAsserts.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.4.2/customAsserts.html
+++ b/docs/2.4.2/customAsserts.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.4.2/customConstraints.html
+++ b/docs/2.4.2/customConstraints.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.4.2/customConstraints.html
+++ b/docs/2.4.2/customConstraints.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.4.2/customConstraints.html
+++ b/docs/2.4.2/customConstraints.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.4.2/customConstraints.html
+++ b/docs/2.4.2/customConstraints.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.4.2/description.html
+++ b/docs/2.4.2/description.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.4.2/description.html
+++ b/docs/2.4.2/description.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.4.2/description.html
+++ b/docs/2.4.2/description.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.4.2/description.html
+++ b/docs/2.4.2/description.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.4.2/docHome.html
+++ b/docs/2.4.2/docHome.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.4.2/docHome.html
+++ b/docs/2.4.2/docHome.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.4.2/docHome.html
+++ b/docs/2.4.2/docHome.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.4.2/docHome.html
+++ b/docs/2.4.2/docHome.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.4.2/equalConstraint.html
+++ b/docs/2.4.2/equalConstraint.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.4.2/equalConstraint.html
+++ b/docs/2.4.2/equalConstraint.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.4.2/equalConstraint.html
+++ b/docs/2.4.2/equalConstraint.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.4.2/equalConstraint.html
+++ b/docs/2.4.2/equalConstraint.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.4.2/equalityAsserts.html
+++ b/docs/2.4.2/equalityAsserts.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.4.2/equalityAsserts.html
+++ b/docs/2.4.2/equalityAsserts.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.4.2/equalityAsserts.html
+++ b/docs/2.4.2/equalityAsserts.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.4.2/equalityAsserts.html
+++ b/docs/2.4.2/equalityAsserts.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.4.2/exception.html
+++ b/docs/2.4.2/exception.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.4.2/exception.html
+++ b/docs/2.4.2/exception.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.4.2/exception.html
+++ b/docs/2.4.2/exception.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.4.2/exception.html
+++ b/docs/2.4.2/exception.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.4.2/explicit.html
+++ b/docs/2.4.2/explicit.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.4.2/explicit.html
+++ b/docs/2.4.2/explicit.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.4.2/explicit.html
+++ b/docs/2.4.2/explicit.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.4.2/explicit.html
+++ b/docs/2.4.2/explicit.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.4.2/extensibility.html
+++ b/docs/2.4.2/extensibility.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.4.2/extensibility.html
+++ b/docs/2.4.2/extensibility.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.4.2/extensibility.html
+++ b/docs/2.4.2/extensibility.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.4.2/extensibility.html
+++ b/docs/2.4.2/extensibility.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.4.2/features.html
+++ b/docs/2.4.2/features.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.4.2/features.html
+++ b/docs/2.4.2/features.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.4.2/features.html
+++ b/docs/2.4.2/features.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.4.2/features.html
+++ b/docs/2.4.2/features.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.4.2/fileAssert.html
+++ b/docs/2.4.2/fileAssert.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.4.2/fileAssert.html
+++ b/docs/2.4.2/fileAssert.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.4.2/fileAssert.html
+++ b/docs/2.4.2/fileAssert.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.4.2/fileAssert.html
+++ b/docs/2.4.2/fileAssert.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.4.2/fixtureSetup.html
+++ b/docs/2.4.2/fixtureSetup.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.4.2/fixtureSetup.html
+++ b/docs/2.4.2/fixtureSetup.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.4.2/fixtureSetup.html
+++ b/docs/2.4.2/fixtureSetup.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.4.2/fixtureSetup.html
+++ b/docs/2.4.2/fixtureSetup.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.4.2/fixtureTeardown.html
+++ b/docs/2.4.2/fixtureTeardown.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.4.2/fixtureTeardown.html
+++ b/docs/2.4.2/fixtureTeardown.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.4.2/fixtureTeardown.html
+++ b/docs/2.4.2/fixtureTeardown.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.4.2/fixtureTeardown.html
+++ b/docs/2.4.2/fixtureTeardown.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.4.2/getStarted.html
+++ b/docs/2.4.2/getStarted.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.4.2/getStarted.html
+++ b/docs/2.4.2/getStarted.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.4.2/getStarted.html
+++ b/docs/2.4.2/getStarted.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.4.2/getStarted.html
+++ b/docs/2.4.2/getStarted.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.4.2/guiCommandLine.html
+++ b/docs/2.4.2/guiCommandLine.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.4.2/guiCommandLine.html
+++ b/docs/2.4.2/guiCommandLine.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.4.2/guiCommandLine.html
+++ b/docs/2.4.2/guiCommandLine.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.4.2/guiCommandLine.html
+++ b/docs/2.4.2/guiCommandLine.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.4.2/identityAsserts.html
+++ b/docs/2.4.2/identityAsserts.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.4.2/identityAsserts.html
+++ b/docs/2.4.2/identityAsserts.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.4.2/identityAsserts.html
+++ b/docs/2.4.2/identityAsserts.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.4.2/identityAsserts.html
+++ b/docs/2.4.2/identityAsserts.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.4.2/ignore.html
+++ b/docs/2.4.2/ignore.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.4.2/ignore.html
+++ b/docs/2.4.2/ignore.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.4.2/ignore.html
+++ b/docs/2.4.2/ignore.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.4.2/ignore.html
+++ b/docs/2.4.2/ignore.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.4.2/installation.html
+++ b/docs/2.4.2/installation.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.4.2/installation.html
+++ b/docs/2.4.2/installation.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.4.2/installation.html
+++ b/docs/2.4.2/installation.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.4.2/installation.html
+++ b/docs/2.4.2/installation.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.4.2/license.html
+++ b/docs/2.4.2/license.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.4.2/license.html
+++ b/docs/2.4.2/license.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.4.2/license.html
+++ b/docs/2.4.2/license.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.4.2/license.html
+++ b/docs/2.4.2/license.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.4.2/listMapper.html
+++ b/docs/2.4.2/listMapper.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.4.2/listMapper.html
+++ b/docs/2.4.2/listMapper.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.4.2/listMapper.html
+++ b/docs/2.4.2/listMapper.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.4.2/listMapper.html
+++ b/docs/2.4.2/listMapper.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.4.2/mainMenu.html
+++ b/docs/2.4.2/mainMenu.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.4.2/mainMenu.html
+++ b/docs/2.4.2/mainMenu.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.4.2/mainMenu.html
+++ b/docs/2.4.2/mainMenu.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.4.2/mainMenu.html
+++ b/docs/2.4.2/mainMenu.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.4.2/multiAssembly.html
+++ b/docs/2.4.2/multiAssembly.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.4.2/multiAssembly.html
+++ b/docs/2.4.2/multiAssembly.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.4.2/multiAssembly.html
+++ b/docs/2.4.2/multiAssembly.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.4.2/multiAssembly.html
+++ b/docs/2.4.2/multiAssembly.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.4.2/nunit-console.html
+++ b/docs/2.4.2/nunit-console.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.4.2/nunit-console.html
+++ b/docs/2.4.2/nunit-console.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.4.2/nunit-console.html
+++ b/docs/2.4.2/nunit-console.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.4.2/nunit-console.html
+++ b/docs/2.4.2/nunit-console.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.4.2/nunit-gui.html
+++ b/docs/2.4.2/nunit-gui.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.4.2/nunit-gui.html
+++ b/docs/2.4.2/nunit-gui.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.4.2/nunit-gui.html
+++ b/docs/2.4.2/nunit-gui.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.4.2/nunit-gui.html
+++ b/docs/2.4.2/nunit-gui.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.4.2/nunitAddins.html
+++ b/docs/2.4.2/nunitAddins.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.4.2/nunitAddins.html
+++ b/docs/2.4.2/nunitAddins.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.4.2/nunitAddins.html
+++ b/docs/2.4.2/nunitAddins.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.4.2/nunitAddins.html
+++ b/docs/2.4.2/nunitAddins.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.4.2/optionsDialog.html
+++ b/docs/2.4.2/optionsDialog.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.4.2/optionsDialog.html
+++ b/docs/2.4.2/optionsDialog.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.4.2/optionsDialog.html
+++ b/docs/2.4.2/optionsDialog.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.4.2/optionsDialog.html
+++ b/docs/2.4.2/optionsDialog.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.4.2/platform.html
+++ b/docs/2.4.2/platform.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.4.2/platform.html
+++ b/docs/2.4.2/platform.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.4.2/platform.html
+++ b/docs/2.4.2/platform.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.4.2/platform.html
+++ b/docs/2.4.2/platform.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.4.2/projectEditor.html
+++ b/docs/2.4.2/projectEditor.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.4.2/projectEditor.html
+++ b/docs/2.4.2/projectEditor.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.4.2/projectEditor.html
+++ b/docs/2.4.2/projectEditor.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.4.2/projectEditor.html
+++ b/docs/2.4.2/projectEditor.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.4.2/property.html
+++ b/docs/2.4.2/property.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.4.2/property.html
+++ b/docs/2.4.2/property.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.4.2/property.html
+++ b/docs/2.4.2/property.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.4.2/property.html
+++ b/docs/2.4.2/property.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.4.2/propertyConstraint.html
+++ b/docs/2.4.2/propertyConstraint.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.4.2/propertyConstraint.html
+++ b/docs/2.4.2/propertyConstraint.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.4.2/propertyConstraint.html
+++ b/docs/2.4.2/propertyConstraint.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.4.2/propertyConstraint.html
+++ b/docs/2.4.2/propertyConstraint.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.4.2/quickStart.html
+++ b/docs/2.4.2/quickStart.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.4.2/quickStart.html
+++ b/docs/2.4.2/quickStart.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.4.2/quickStart.html
+++ b/docs/2.4.2/quickStart.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.4.2/quickStart.html
+++ b/docs/2.4.2/quickStart.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.4.2/quickStartSource.html
+++ b/docs/2.4.2/quickStartSource.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.4.2/quickStartSource.html
+++ b/docs/2.4.2/quickStartSource.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.4.2/quickStartSource.html
+++ b/docs/2.4.2/quickStartSource.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.4.2/quickStartSource.html
+++ b/docs/2.4.2/quickStartSource.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.4.2/releaseNotes.html
+++ b/docs/2.4.2/releaseNotes.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.4.2/releaseNotes.html
+++ b/docs/2.4.2/releaseNotes.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.4.2/releaseNotes.html
+++ b/docs/2.4.2/releaseNotes.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.4.2/releaseNotes.html
+++ b/docs/2.4.2/releaseNotes.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.4.2/sameasConstraint.html
+++ b/docs/2.4.2/sameasConstraint.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.4.2/sameasConstraint.html
+++ b/docs/2.4.2/sameasConstraint.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.4.2/sameasConstraint.html
+++ b/docs/2.4.2/sameasConstraint.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.4.2/sameasConstraint.html
+++ b/docs/2.4.2/sameasConstraint.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.4.2/samples.html
+++ b/docs/2.4.2/samples.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.4.2/samples.html
+++ b/docs/2.4.2/samples.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.4.2/samples.html
+++ b/docs/2.4.2/samples.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.4.2/samples.html
+++ b/docs/2.4.2/samples.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.4.2/setCulture.html
+++ b/docs/2.4.2/setCulture.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.4.2/setCulture.html
+++ b/docs/2.4.2/setCulture.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.4.2/setCulture.html
+++ b/docs/2.4.2/setCulture.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.4.2/setCulture.html
+++ b/docs/2.4.2/setCulture.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.4.2/setup.html
+++ b/docs/2.4.2/setup.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.4.2/setup.html
+++ b/docs/2.4.2/setup.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.4.2/setup.html
+++ b/docs/2.4.2/setup.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.4.2/setup.html
+++ b/docs/2.4.2/setup.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.4.2/setupFixture.html
+++ b/docs/2.4.2/setupFixture.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.4.2/setupFixture.html
+++ b/docs/2.4.2/setupFixture.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.4.2/setupFixture.html
+++ b/docs/2.4.2/setupFixture.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.4.2/setupFixture.html
+++ b/docs/2.4.2/setupFixture.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.4.2/stringAssert.html
+++ b/docs/2.4.2/stringAssert.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.4.2/stringAssert.html
+++ b/docs/2.4.2/stringAssert.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.4.2/stringAssert.html
+++ b/docs/2.4.2/stringAssert.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.4.2/stringAssert.html
+++ b/docs/2.4.2/stringAssert.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.4.2/stringConstraints.html
+++ b/docs/2.4.2/stringConstraints.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.4.2/stringConstraints.html
+++ b/docs/2.4.2/stringConstraints.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.4.2/stringConstraints.html
+++ b/docs/2.4.2/stringConstraints.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.4.2/stringConstraints.html
+++ b/docs/2.4.2/stringConstraints.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.4.2/suite.html
+++ b/docs/2.4.2/suite.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.4.2/suite.html
+++ b/docs/2.4.2/suite.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.4.2/suite.html
+++ b/docs/2.4.2/suite.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.4.2/suite.html
+++ b/docs/2.4.2/suite.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.4.2/teardown.html
+++ b/docs/2.4.2/teardown.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.4.2/teardown.html
+++ b/docs/2.4.2/teardown.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.4.2/teardown.html
+++ b/docs/2.4.2/teardown.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.4.2/teardown.html
+++ b/docs/2.4.2/teardown.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.4.2/test.html
+++ b/docs/2.4.2/test.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.4.2/test.html
+++ b/docs/2.4.2/test.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.4.2/test.html
+++ b/docs/2.4.2/test.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.4.2/test.html
+++ b/docs/2.4.2/test.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.4.2/testFixture.html
+++ b/docs/2.4.2/testFixture.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.4.2/testFixture.html
+++ b/docs/2.4.2/testFixture.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.4.2/testFixture.html
+++ b/docs/2.4.2/testFixture.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.4.2/testFixture.html
+++ b/docs/2.4.2/testFixture.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.4.2/testProperties.html
+++ b/docs/2.4.2/testProperties.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.4.2/testProperties.html
+++ b/docs/2.4.2/testProperties.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.4.2/testProperties.html
+++ b/docs/2.4.2/testProperties.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.4.2/testProperties.html
+++ b/docs/2.4.2/testProperties.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.4.2/typeAsserts.html
+++ b/docs/2.4.2/typeAsserts.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.4.2/typeAsserts.html
+++ b/docs/2.4.2/typeAsserts.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.4.2/typeAsserts.html
+++ b/docs/2.4.2/typeAsserts.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.4.2/typeAsserts.html
+++ b/docs/2.4.2/typeAsserts.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.4.2/typeConstraints.html
+++ b/docs/2.4.2/typeConstraints.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.4.2/typeConstraints.html
+++ b/docs/2.4.2/typeConstraints.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.4.2/typeConstraints.html
+++ b/docs/2.4.2/typeConstraints.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.4.2/typeConstraints.html
+++ b/docs/2.4.2/typeConstraints.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.4.2/upgrade.html
+++ b/docs/2.4.2/upgrade.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.4.2/upgrade.html
+++ b/docs/2.4.2/upgrade.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.4.2/upgrade.html
+++ b/docs/2.4.2/upgrade.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.4.2/upgrade.html
+++ b/docs/2.4.2/upgrade.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.4.2/utilityAsserts.html
+++ b/docs/2.4.2/utilityAsserts.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.4.2/utilityAsserts.html
+++ b/docs/2.4.2/utilityAsserts.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.4.2/utilityAsserts.html
+++ b/docs/2.4.2/utilityAsserts.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.4.2/utilityAsserts.html
+++ b/docs/2.4.2/utilityAsserts.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.4.2/vsSupport.html
+++ b/docs/2.4.2/vsSupport.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.4.2/vsSupport.html
+++ b/docs/2.4.2/vsSupport.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.4.2/vsSupport.html
+++ b/docs/2.4.2/vsSupport.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.4.2/vsSupport.html
+++ b/docs/2.4.2/vsSupport.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.4.3/addinsDialog.html
+++ b/docs/2.4.3/addinsDialog.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.4.3/addinsDialog.html
+++ b/docs/2.4.3/addinsDialog.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.4.3/addinsDialog.html
+++ b/docs/2.4.3/addinsDialog.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.4.3/addinsDialog.html
+++ b/docs/2.4.3/addinsDialog.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.4.3/assertions.html
+++ b/docs/2.4.3/assertions.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.4.3/assertions.html
+++ b/docs/2.4.3/assertions.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.4.3/assertions.html
+++ b/docs/2.4.3/assertions.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.4.3/assertions.html
+++ b/docs/2.4.3/assertions.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.4.3/attributes.html
+++ b/docs/2.4.3/attributes.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.4.3/attributes.html
+++ b/docs/2.4.3/attributes.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.4.3/attributes.html
+++ b/docs/2.4.3/attributes.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.4.3/attributes.html
+++ b/docs/2.4.3/attributes.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.4.3/category.html
+++ b/docs/2.4.3/category.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.4.3/category.html
+++ b/docs/2.4.3/category.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.4.3/category.html
+++ b/docs/2.4.3/category.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.4.3/category.html
+++ b/docs/2.4.3/category.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.4.3/classicModel.html
+++ b/docs/2.4.3/classicModel.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.4.3/classicModel.html
+++ b/docs/2.4.3/classicModel.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.4.3/classicModel.html
+++ b/docs/2.4.3/classicModel.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.4.3/classicModel.html
+++ b/docs/2.4.3/classicModel.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.4.3/collectionAssert.html
+++ b/docs/2.4.3/collectionAssert.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.4.3/collectionAssert.html
+++ b/docs/2.4.3/collectionAssert.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.4.3/collectionAssert.html
+++ b/docs/2.4.3/collectionAssert.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.4.3/collectionAssert.html
+++ b/docs/2.4.3/collectionAssert.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.4.3/collectionConstraints.html
+++ b/docs/2.4.3/collectionConstraints.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.4.3/collectionConstraints.html
+++ b/docs/2.4.3/collectionConstraints.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.4.3/collectionConstraints.html
+++ b/docs/2.4.3/collectionConstraints.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.4.3/collectionConstraints.html
+++ b/docs/2.4.3/collectionConstraints.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.4.3/comparisonAsserts.html
+++ b/docs/2.4.3/comparisonAsserts.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.4.3/comparisonAsserts.html
+++ b/docs/2.4.3/comparisonAsserts.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.4.3/comparisonAsserts.html
+++ b/docs/2.4.3/comparisonAsserts.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.4.3/comparisonAsserts.html
+++ b/docs/2.4.3/comparisonAsserts.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.4.3/comparisonConstraints.html
+++ b/docs/2.4.3/comparisonConstraints.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.4.3/comparisonConstraints.html
+++ b/docs/2.4.3/comparisonConstraints.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.4.3/comparisonConstraints.html
+++ b/docs/2.4.3/comparisonConstraints.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.4.3/comparisonConstraints.html
+++ b/docs/2.4.3/comparisonConstraints.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.4.3/compoundConstraints.html
+++ b/docs/2.4.3/compoundConstraints.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.4.3/compoundConstraints.html
+++ b/docs/2.4.3/compoundConstraints.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.4.3/compoundConstraints.html
+++ b/docs/2.4.3/compoundConstraints.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.4.3/compoundConstraints.html
+++ b/docs/2.4.3/compoundConstraints.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.4.3/conditionAsserts.html
+++ b/docs/2.4.3/conditionAsserts.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.4.3/conditionAsserts.html
+++ b/docs/2.4.3/conditionAsserts.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.4.3/conditionAsserts.html
+++ b/docs/2.4.3/conditionAsserts.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.4.3/conditionAsserts.html
+++ b/docs/2.4.3/conditionAsserts.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.4.3/conditionConstraints.html
+++ b/docs/2.4.3/conditionConstraints.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.4.3/conditionConstraints.html
+++ b/docs/2.4.3/conditionConstraints.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.4.3/conditionConstraints.html
+++ b/docs/2.4.3/conditionConstraints.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.4.3/conditionConstraints.html
+++ b/docs/2.4.3/conditionConstraints.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.4.3/configEditor.html
+++ b/docs/2.4.3/configEditor.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.4.3/configEditor.html
+++ b/docs/2.4.3/configEditor.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.4.3/configEditor.html
+++ b/docs/2.4.3/configEditor.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.4.3/configEditor.html
+++ b/docs/2.4.3/configEditor.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.4.3/configFiles.html
+++ b/docs/2.4.3/configFiles.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.4.3/configFiles.html
+++ b/docs/2.4.3/configFiles.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.4.3/configFiles.html
+++ b/docs/2.4.3/configFiles.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.4.3/configFiles.html
+++ b/docs/2.4.3/configFiles.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.4.3/consoleCommandLine.html
+++ b/docs/2.4.3/consoleCommandLine.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.4.3/consoleCommandLine.html
+++ b/docs/2.4.3/consoleCommandLine.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.4.3/consoleCommandLine.html
+++ b/docs/2.4.3/consoleCommandLine.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.4.3/consoleCommandLine.html
+++ b/docs/2.4.3/consoleCommandLine.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.4.3/constraintModel.html
+++ b/docs/2.4.3/constraintModel.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.4.3/constraintModel.html
+++ b/docs/2.4.3/constraintModel.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.4.3/constraintModel.html
+++ b/docs/2.4.3/constraintModel.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.4.3/constraintModel.html
+++ b/docs/2.4.3/constraintModel.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.4.3/contextMenu.html
+++ b/docs/2.4.3/contextMenu.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.4.3/contextMenu.html
+++ b/docs/2.4.3/contextMenu.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.4.3/contextMenu.html
+++ b/docs/2.4.3/contextMenu.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.4.3/contextMenu.html
+++ b/docs/2.4.3/contextMenu.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.4.3/culture.html
+++ b/docs/2.4.3/culture.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.4.3/culture.html
+++ b/docs/2.4.3/culture.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.4.3/culture.html
+++ b/docs/2.4.3/culture.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.4.3/culture.html
+++ b/docs/2.4.3/culture.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.4.3/customAsserts.html
+++ b/docs/2.4.3/customAsserts.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.4.3/customAsserts.html
+++ b/docs/2.4.3/customAsserts.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.4.3/customAsserts.html
+++ b/docs/2.4.3/customAsserts.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.4.3/customAsserts.html
+++ b/docs/2.4.3/customAsserts.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.4.3/customConstraints.html
+++ b/docs/2.4.3/customConstraints.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.4.3/customConstraints.html
+++ b/docs/2.4.3/customConstraints.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.4.3/customConstraints.html
+++ b/docs/2.4.3/customConstraints.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.4.3/customConstraints.html
+++ b/docs/2.4.3/customConstraints.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.4.3/description.html
+++ b/docs/2.4.3/description.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.4.3/description.html
+++ b/docs/2.4.3/description.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.4.3/description.html
+++ b/docs/2.4.3/description.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.4.3/description.html
+++ b/docs/2.4.3/description.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.4.3/docHome.html
+++ b/docs/2.4.3/docHome.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.4.3/docHome.html
+++ b/docs/2.4.3/docHome.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.4.3/docHome.html
+++ b/docs/2.4.3/docHome.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.4.3/docHome.html
+++ b/docs/2.4.3/docHome.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.4.3/equalConstraint.html
+++ b/docs/2.4.3/equalConstraint.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.4.3/equalConstraint.html
+++ b/docs/2.4.3/equalConstraint.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.4.3/equalConstraint.html
+++ b/docs/2.4.3/equalConstraint.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.4.3/equalConstraint.html
+++ b/docs/2.4.3/equalConstraint.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.4.3/equalityAsserts.html
+++ b/docs/2.4.3/equalityAsserts.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.4.3/equalityAsserts.html
+++ b/docs/2.4.3/equalityAsserts.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.4.3/equalityAsserts.html
+++ b/docs/2.4.3/equalityAsserts.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.4.3/equalityAsserts.html
+++ b/docs/2.4.3/equalityAsserts.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.4.3/exception.html
+++ b/docs/2.4.3/exception.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.4.3/exception.html
+++ b/docs/2.4.3/exception.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.4.3/exception.html
+++ b/docs/2.4.3/exception.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.4.3/exception.html
+++ b/docs/2.4.3/exception.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.4.3/explicit.html
+++ b/docs/2.4.3/explicit.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.4.3/explicit.html
+++ b/docs/2.4.3/explicit.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.4.3/explicit.html
+++ b/docs/2.4.3/explicit.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.4.3/explicit.html
+++ b/docs/2.4.3/explicit.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.4.3/extensibility.html
+++ b/docs/2.4.3/extensibility.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.4.3/extensibility.html
+++ b/docs/2.4.3/extensibility.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.4.3/extensibility.html
+++ b/docs/2.4.3/extensibility.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.4.3/extensibility.html
+++ b/docs/2.4.3/extensibility.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.4.3/features.html
+++ b/docs/2.4.3/features.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.4.3/features.html
+++ b/docs/2.4.3/features.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.4.3/features.html
+++ b/docs/2.4.3/features.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.4.3/features.html
+++ b/docs/2.4.3/features.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.4.3/fileAssert.html
+++ b/docs/2.4.3/fileAssert.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.4.3/fileAssert.html
+++ b/docs/2.4.3/fileAssert.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.4.3/fileAssert.html
+++ b/docs/2.4.3/fileAssert.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.4.3/fileAssert.html
+++ b/docs/2.4.3/fileAssert.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.4.3/fixtureSetup.html
+++ b/docs/2.4.3/fixtureSetup.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.4.3/fixtureSetup.html
+++ b/docs/2.4.3/fixtureSetup.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.4.3/fixtureSetup.html
+++ b/docs/2.4.3/fixtureSetup.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.4.3/fixtureSetup.html
+++ b/docs/2.4.3/fixtureSetup.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.4.3/fixtureTeardown.html
+++ b/docs/2.4.3/fixtureTeardown.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.4.3/fixtureTeardown.html
+++ b/docs/2.4.3/fixtureTeardown.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.4.3/fixtureTeardown.html
+++ b/docs/2.4.3/fixtureTeardown.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.4.3/fixtureTeardown.html
+++ b/docs/2.4.3/fixtureTeardown.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.4.3/getStarted.html
+++ b/docs/2.4.3/getStarted.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.4.3/getStarted.html
+++ b/docs/2.4.3/getStarted.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.4.3/getStarted.html
+++ b/docs/2.4.3/getStarted.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.4.3/getStarted.html
+++ b/docs/2.4.3/getStarted.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.4.3/guiCommandLine.html
+++ b/docs/2.4.3/guiCommandLine.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.4.3/guiCommandLine.html
+++ b/docs/2.4.3/guiCommandLine.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.4.3/guiCommandLine.html
+++ b/docs/2.4.3/guiCommandLine.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.4.3/guiCommandLine.html
+++ b/docs/2.4.3/guiCommandLine.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.4.3/identityAsserts.html
+++ b/docs/2.4.3/identityAsserts.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.4.3/identityAsserts.html
+++ b/docs/2.4.3/identityAsserts.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.4.3/identityAsserts.html
+++ b/docs/2.4.3/identityAsserts.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.4.3/identityAsserts.html
+++ b/docs/2.4.3/identityAsserts.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.4.3/ignore.html
+++ b/docs/2.4.3/ignore.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.4.3/ignore.html
+++ b/docs/2.4.3/ignore.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.4.3/ignore.html
+++ b/docs/2.4.3/ignore.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.4.3/ignore.html
+++ b/docs/2.4.3/ignore.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.4.3/installation.html
+++ b/docs/2.4.3/installation.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.4.3/installation.html
+++ b/docs/2.4.3/installation.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.4.3/installation.html
+++ b/docs/2.4.3/installation.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.4.3/installation.html
+++ b/docs/2.4.3/installation.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.4.3/license.html
+++ b/docs/2.4.3/license.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.4.3/license.html
+++ b/docs/2.4.3/license.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.4.3/license.html
+++ b/docs/2.4.3/license.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.4.3/license.html
+++ b/docs/2.4.3/license.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.4.3/listMapper.html
+++ b/docs/2.4.3/listMapper.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.4.3/listMapper.html
+++ b/docs/2.4.3/listMapper.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.4.3/listMapper.html
+++ b/docs/2.4.3/listMapper.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.4.3/listMapper.html
+++ b/docs/2.4.3/listMapper.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.4.3/mainMenu.html
+++ b/docs/2.4.3/mainMenu.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.4.3/mainMenu.html
+++ b/docs/2.4.3/mainMenu.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.4.3/mainMenu.html
+++ b/docs/2.4.3/mainMenu.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.4.3/mainMenu.html
+++ b/docs/2.4.3/mainMenu.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.4.3/multiAssembly.html
+++ b/docs/2.4.3/multiAssembly.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.4.3/multiAssembly.html
+++ b/docs/2.4.3/multiAssembly.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.4.3/multiAssembly.html
+++ b/docs/2.4.3/multiAssembly.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.4.3/multiAssembly.html
+++ b/docs/2.4.3/multiAssembly.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.4.3/nunit-console.html
+++ b/docs/2.4.3/nunit-console.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.4.3/nunit-console.html
+++ b/docs/2.4.3/nunit-console.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.4.3/nunit-console.html
+++ b/docs/2.4.3/nunit-console.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.4.3/nunit-console.html
+++ b/docs/2.4.3/nunit-console.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.4.3/nunit-gui.html
+++ b/docs/2.4.3/nunit-gui.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.4.3/nunit-gui.html
+++ b/docs/2.4.3/nunit-gui.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.4.3/nunit-gui.html
+++ b/docs/2.4.3/nunit-gui.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.4.3/nunit-gui.html
+++ b/docs/2.4.3/nunit-gui.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.4.3/nunitAddins.html
+++ b/docs/2.4.3/nunitAddins.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.4.3/nunitAddins.html
+++ b/docs/2.4.3/nunitAddins.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.4.3/nunitAddins.html
+++ b/docs/2.4.3/nunitAddins.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.4.3/nunitAddins.html
+++ b/docs/2.4.3/nunitAddins.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.4.3/optionsDialog.html
+++ b/docs/2.4.3/optionsDialog.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.4.3/optionsDialog.html
+++ b/docs/2.4.3/optionsDialog.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.4.3/optionsDialog.html
+++ b/docs/2.4.3/optionsDialog.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.4.3/optionsDialog.html
+++ b/docs/2.4.3/optionsDialog.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.4.3/platform.html
+++ b/docs/2.4.3/platform.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.4.3/platform.html
+++ b/docs/2.4.3/platform.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.4.3/platform.html
+++ b/docs/2.4.3/platform.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.4.3/platform.html
+++ b/docs/2.4.3/platform.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.4.3/projectEditor.html
+++ b/docs/2.4.3/projectEditor.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.4.3/projectEditor.html
+++ b/docs/2.4.3/projectEditor.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.4.3/projectEditor.html
+++ b/docs/2.4.3/projectEditor.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.4.3/projectEditor.html
+++ b/docs/2.4.3/projectEditor.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.4.3/property.html
+++ b/docs/2.4.3/property.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.4.3/property.html
+++ b/docs/2.4.3/property.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.4.3/property.html
+++ b/docs/2.4.3/property.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.4.3/property.html
+++ b/docs/2.4.3/property.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.4.3/propertyConstraint.html
+++ b/docs/2.4.3/propertyConstraint.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.4.3/propertyConstraint.html
+++ b/docs/2.4.3/propertyConstraint.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.4.3/propertyConstraint.html
+++ b/docs/2.4.3/propertyConstraint.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.4.3/propertyConstraint.html
+++ b/docs/2.4.3/propertyConstraint.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.4.3/quickStart.html
+++ b/docs/2.4.3/quickStart.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.4.3/quickStart.html
+++ b/docs/2.4.3/quickStart.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.4.3/quickStart.html
+++ b/docs/2.4.3/quickStart.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.4.3/quickStart.html
+++ b/docs/2.4.3/quickStart.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.4.3/quickStartSource.html
+++ b/docs/2.4.3/quickStartSource.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.4.3/quickStartSource.html
+++ b/docs/2.4.3/quickStartSource.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.4.3/quickStartSource.html
+++ b/docs/2.4.3/quickStartSource.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.4.3/quickStartSource.html
+++ b/docs/2.4.3/quickStartSource.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.4.3/releaseNotes.html
+++ b/docs/2.4.3/releaseNotes.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.4.3/releaseNotes.html
+++ b/docs/2.4.3/releaseNotes.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.4.3/releaseNotes.html
+++ b/docs/2.4.3/releaseNotes.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.4.3/releaseNotes.html
+++ b/docs/2.4.3/releaseNotes.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.4.3/sameasConstraint.html
+++ b/docs/2.4.3/sameasConstraint.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.4.3/sameasConstraint.html
+++ b/docs/2.4.3/sameasConstraint.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.4.3/sameasConstraint.html
+++ b/docs/2.4.3/sameasConstraint.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.4.3/sameasConstraint.html
+++ b/docs/2.4.3/sameasConstraint.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.4.3/samples.html
+++ b/docs/2.4.3/samples.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.4.3/samples.html
+++ b/docs/2.4.3/samples.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.4.3/samples.html
+++ b/docs/2.4.3/samples.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.4.3/samples.html
+++ b/docs/2.4.3/samples.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.4.3/setCulture.html
+++ b/docs/2.4.3/setCulture.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.4.3/setCulture.html
+++ b/docs/2.4.3/setCulture.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.4.3/setCulture.html
+++ b/docs/2.4.3/setCulture.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.4.3/setCulture.html
+++ b/docs/2.4.3/setCulture.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.4.3/setup.html
+++ b/docs/2.4.3/setup.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.4.3/setup.html
+++ b/docs/2.4.3/setup.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.4.3/setup.html
+++ b/docs/2.4.3/setup.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.4.3/setup.html
+++ b/docs/2.4.3/setup.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.4.3/setupFixture.html
+++ b/docs/2.4.3/setupFixture.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.4.3/setupFixture.html
+++ b/docs/2.4.3/setupFixture.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.4.3/setupFixture.html
+++ b/docs/2.4.3/setupFixture.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.4.3/setupFixture.html
+++ b/docs/2.4.3/setupFixture.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.4.3/stringAssert.html
+++ b/docs/2.4.3/stringAssert.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.4.3/stringAssert.html
+++ b/docs/2.4.3/stringAssert.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.4.3/stringAssert.html
+++ b/docs/2.4.3/stringAssert.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.4.3/stringAssert.html
+++ b/docs/2.4.3/stringAssert.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.4.3/stringConstraints.html
+++ b/docs/2.4.3/stringConstraints.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.4.3/stringConstraints.html
+++ b/docs/2.4.3/stringConstraints.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.4.3/stringConstraints.html
+++ b/docs/2.4.3/stringConstraints.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.4.3/stringConstraints.html
+++ b/docs/2.4.3/stringConstraints.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.4.3/suite.html
+++ b/docs/2.4.3/suite.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.4.3/suite.html
+++ b/docs/2.4.3/suite.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.4.3/suite.html
+++ b/docs/2.4.3/suite.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.4.3/suite.html
+++ b/docs/2.4.3/suite.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.4.3/teardown.html
+++ b/docs/2.4.3/teardown.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.4.3/teardown.html
+++ b/docs/2.4.3/teardown.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.4.3/teardown.html
+++ b/docs/2.4.3/teardown.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.4.3/teardown.html
+++ b/docs/2.4.3/teardown.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.4.3/test.html
+++ b/docs/2.4.3/test.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.4.3/test.html
+++ b/docs/2.4.3/test.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.4.3/test.html
+++ b/docs/2.4.3/test.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.4.3/test.html
+++ b/docs/2.4.3/test.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.4.3/testFixture.html
+++ b/docs/2.4.3/testFixture.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.4.3/testFixture.html
+++ b/docs/2.4.3/testFixture.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.4.3/testFixture.html
+++ b/docs/2.4.3/testFixture.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.4.3/testFixture.html
+++ b/docs/2.4.3/testFixture.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.4.3/testProperties.html
+++ b/docs/2.4.3/testProperties.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.4.3/testProperties.html
+++ b/docs/2.4.3/testProperties.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.4.3/testProperties.html
+++ b/docs/2.4.3/testProperties.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.4.3/testProperties.html
+++ b/docs/2.4.3/testProperties.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.4.3/typeAsserts.html
+++ b/docs/2.4.3/typeAsserts.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.4.3/typeAsserts.html
+++ b/docs/2.4.3/typeAsserts.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.4.3/typeAsserts.html
+++ b/docs/2.4.3/typeAsserts.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.4.3/typeAsserts.html
+++ b/docs/2.4.3/typeAsserts.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.4.3/typeConstraints.html
+++ b/docs/2.4.3/typeConstraints.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.4.3/typeConstraints.html
+++ b/docs/2.4.3/typeConstraints.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.4.3/typeConstraints.html
+++ b/docs/2.4.3/typeConstraints.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.4.3/typeConstraints.html
+++ b/docs/2.4.3/typeConstraints.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.4.3/upgrade.html
+++ b/docs/2.4.3/upgrade.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.4.3/upgrade.html
+++ b/docs/2.4.3/upgrade.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.4.3/upgrade.html
+++ b/docs/2.4.3/upgrade.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.4.3/upgrade.html
+++ b/docs/2.4.3/upgrade.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.4.3/utilityAsserts.html
+++ b/docs/2.4.3/utilityAsserts.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.4.3/utilityAsserts.html
+++ b/docs/2.4.3/utilityAsserts.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.4.3/utilityAsserts.html
+++ b/docs/2.4.3/utilityAsserts.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.4.3/utilityAsserts.html
+++ b/docs/2.4.3/utilityAsserts.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.4.3/vsSupport.html
+++ b/docs/2.4.3/vsSupport.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.4.3/vsSupport.html
+++ b/docs/2.4.3/vsSupport.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.4.3/vsSupport.html
+++ b/docs/2.4.3/vsSupport.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.4.3/vsSupport.html
+++ b/docs/2.4.3/vsSupport.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.4.4/addinsDialog.html
+++ b/docs/2.4.4/addinsDialog.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.4.4/addinsDialog.html
+++ b/docs/2.4.4/addinsDialog.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.4.4/addinsDialog.html
+++ b/docs/2.4.4/addinsDialog.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.4.4/addinsDialog.html
+++ b/docs/2.4.4/addinsDialog.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.4.4/assertions.html
+++ b/docs/2.4.4/assertions.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.4.4/assertions.html
+++ b/docs/2.4.4/assertions.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.4.4/assertions.html
+++ b/docs/2.4.4/assertions.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.4.4/assertions.html
+++ b/docs/2.4.4/assertions.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.4.4/attributes.html
+++ b/docs/2.4.4/attributes.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.4.4/attributes.html
+++ b/docs/2.4.4/attributes.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.4.4/attributes.html
+++ b/docs/2.4.4/attributes.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.4.4/attributes.html
+++ b/docs/2.4.4/attributes.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.4.4/category.html
+++ b/docs/2.4.4/category.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.4.4/category.html
+++ b/docs/2.4.4/category.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.4.4/category.html
+++ b/docs/2.4.4/category.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.4.4/category.html
+++ b/docs/2.4.4/category.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.4.4/classicModel.html
+++ b/docs/2.4.4/classicModel.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.4.4/classicModel.html
+++ b/docs/2.4.4/classicModel.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.4.4/classicModel.html
+++ b/docs/2.4.4/classicModel.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.4.4/classicModel.html
+++ b/docs/2.4.4/classicModel.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.4.4/collectionAssert.html
+++ b/docs/2.4.4/collectionAssert.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.4.4/collectionAssert.html
+++ b/docs/2.4.4/collectionAssert.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.4.4/collectionAssert.html
+++ b/docs/2.4.4/collectionAssert.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.4.4/collectionAssert.html
+++ b/docs/2.4.4/collectionAssert.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.4.4/collectionConstraints.html
+++ b/docs/2.4.4/collectionConstraints.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.4.4/collectionConstraints.html
+++ b/docs/2.4.4/collectionConstraints.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.4.4/collectionConstraints.html
+++ b/docs/2.4.4/collectionConstraints.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.4.4/collectionConstraints.html
+++ b/docs/2.4.4/collectionConstraints.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.4.4/comparisonAsserts.html
+++ b/docs/2.4.4/comparisonAsserts.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.4.4/comparisonAsserts.html
+++ b/docs/2.4.4/comparisonAsserts.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.4.4/comparisonAsserts.html
+++ b/docs/2.4.4/comparisonAsserts.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.4.4/comparisonAsserts.html
+++ b/docs/2.4.4/comparisonAsserts.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.4.4/comparisonConstraints.html
+++ b/docs/2.4.4/comparisonConstraints.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.4.4/comparisonConstraints.html
+++ b/docs/2.4.4/comparisonConstraints.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.4.4/comparisonConstraints.html
+++ b/docs/2.4.4/comparisonConstraints.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.4.4/comparisonConstraints.html
+++ b/docs/2.4.4/comparisonConstraints.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.4.4/compoundConstraints.html
+++ b/docs/2.4.4/compoundConstraints.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.4.4/compoundConstraints.html
+++ b/docs/2.4.4/compoundConstraints.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.4.4/compoundConstraints.html
+++ b/docs/2.4.4/compoundConstraints.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.4.4/compoundConstraints.html
+++ b/docs/2.4.4/compoundConstraints.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.4.4/conditionAsserts.html
+++ b/docs/2.4.4/conditionAsserts.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.4.4/conditionAsserts.html
+++ b/docs/2.4.4/conditionAsserts.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.4.4/conditionAsserts.html
+++ b/docs/2.4.4/conditionAsserts.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.4.4/conditionAsserts.html
+++ b/docs/2.4.4/conditionAsserts.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.4.4/conditionConstraints.html
+++ b/docs/2.4.4/conditionConstraints.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.4.4/conditionConstraints.html
+++ b/docs/2.4.4/conditionConstraints.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.4.4/conditionConstraints.html
+++ b/docs/2.4.4/conditionConstraints.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.4.4/conditionConstraints.html
+++ b/docs/2.4.4/conditionConstraints.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.4.4/configEditor.html
+++ b/docs/2.4.4/configEditor.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.4.4/configEditor.html
+++ b/docs/2.4.4/configEditor.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.4.4/configEditor.html
+++ b/docs/2.4.4/configEditor.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.4.4/configEditor.html
+++ b/docs/2.4.4/configEditor.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.4.4/configFiles.html
+++ b/docs/2.4.4/configFiles.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.4.4/configFiles.html
+++ b/docs/2.4.4/configFiles.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.4.4/configFiles.html
+++ b/docs/2.4.4/configFiles.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.4.4/configFiles.html
+++ b/docs/2.4.4/configFiles.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.4.4/consoleCommandLine.html
+++ b/docs/2.4.4/consoleCommandLine.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.4.4/consoleCommandLine.html
+++ b/docs/2.4.4/consoleCommandLine.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.4.4/consoleCommandLine.html
+++ b/docs/2.4.4/consoleCommandLine.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.4.4/consoleCommandLine.html
+++ b/docs/2.4.4/consoleCommandLine.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.4.4/constraintModel.html
+++ b/docs/2.4.4/constraintModel.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.4.4/constraintModel.html
+++ b/docs/2.4.4/constraintModel.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.4.4/constraintModel.html
+++ b/docs/2.4.4/constraintModel.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.4.4/constraintModel.html
+++ b/docs/2.4.4/constraintModel.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.4.4/contextMenu.html
+++ b/docs/2.4.4/contextMenu.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.4.4/contextMenu.html
+++ b/docs/2.4.4/contextMenu.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.4.4/contextMenu.html
+++ b/docs/2.4.4/contextMenu.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.4.4/contextMenu.html
+++ b/docs/2.4.4/contextMenu.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.4.4/culture.html
+++ b/docs/2.4.4/culture.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.4.4/culture.html
+++ b/docs/2.4.4/culture.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.4.4/culture.html
+++ b/docs/2.4.4/culture.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.4.4/culture.html
+++ b/docs/2.4.4/culture.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.4.4/customAsserts.html
+++ b/docs/2.4.4/customAsserts.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.4.4/customAsserts.html
+++ b/docs/2.4.4/customAsserts.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.4.4/customAsserts.html
+++ b/docs/2.4.4/customAsserts.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.4.4/customAsserts.html
+++ b/docs/2.4.4/customAsserts.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.4.4/customConstraints.html
+++ b/docs/2.4.4/customConstraints.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.4.4/customConstraints.html
+++ b/docs/2.4.4/customConstraints.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.4.4/customConstraints.html
+++ b/docs/2.4.4/customConstraints.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.4.4/customConstraints.html
+++ b/docs/2.4.4/customConstraints.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.4.4/description.html
+++ b/docs/2.4.4/description.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.4.4/description.html
+++ b/docs/2.4.4/description.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.4.4/description.html
+++ b/docs/2.4.4/description.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.4.4/description.html
+++ b/docs/2.4.4/description.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.4.4/docHome.html
+++ b/docs/2.4.4/docHome.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.4.4/docHome.html
+++ b/docs/2.4.4/docHome.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.4.4/docHome.html
+++ b/docs/2.4.4/docHome.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.4.4/docHome.html
+++ b/docs/2.4.4/docHome.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.4.4/equalConstraint.html
+++ b/docs/2.4.4/equalConstraint.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.4.4/equalConstraint.html
+++ b/docs/2.4.4/equalConstraint.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.4.4/equalConstraint.html
+++ b/docs/2.4.4/equalConstraint.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.4.4/equalConstraint.html
+++ b/docs/2.4.4/equalConstraint.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.4.4/equalityAsserts.html
+++ b/docs/2.4.4/equalityAsserts.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.4.4/equalityAsserts.html
+++ b/docs/2.4.4/equalityAsserts.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.4.4/equalityAsserts.html
+++ b/docs/2.4.4/equalityAsserts.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.4.4/equalityAsserts.html
+++ b/docs/2.4.4/equalityAsserts.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.4.4/exception.html
+++ b/docs/2.4.4/exception.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.4.4/exception.html
+++ b/docs/2.4.4/exception.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.4.4/exception.html
+++ b/docs/2.4.4/exception.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.4.4/exception.html
+++ b/docs/2.4.4/exception.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.4.4/explicit.html
+++ b/docs/2.4.4/explicit.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.4.4/explicit.html
+++ b/docs/2.4.4/explicit.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.4.4/explicit.html
+++ b/docs/2.4.4/explicit.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.4.4/explicit.html
+++ b/docs/2.4.4/explicit.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.4.4/extensibility.html
+++ b/docs/2.4.4/extensibility.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.4.4/extensibility.html
+++ b/docs/2.4.4/extensibility.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.4.4/extensibility.html
+++ b/docs/2.4.4/extensibility.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.4.4/extensibility.html
+++ b/docs/2.4.4/extensibility.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.4.4/features.html
+++ b/docs/2.4.4/features.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.4.4/features.html
+++ b/docs/2.4.4/features.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.4.4/features.html
+++ b/docs/2.4.4/features.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.4.4/features.html
+++ b/docs/2.4.4/features.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.4.4/fileAssert.html
+++ b/docs/2.4.4/fileAssert.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.4.4/fileAssert.html
+++ b/docs/2.4.4/fileAssert.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.4.4/fileAssert.html
+++ b/docs/2.4.4/fileAssert.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.4.4/fileAssert.html
+++ b/docs/2.4.4/fileAssert.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.4.4/fixtureSetup.html
+++ b/docs/2.4.4/fixtureSetup.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.4.4/fixtureSetup.html
+++ b/docs/2.4.4/fixtureSetup.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.4.4/fixtureSetup.html
+++ b/docs/2.4.4/fixtureSetup.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.4.4/fixtureSetup.html
+++ b/docs/2.4.4/fixtureSetup.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.4.4/fixtureTeardown.html
+++ b/docs/2.4.4/fixtureTeardown.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.4.4/fixtureTeardown.html
+++ b/docs/2.4.4/fixtureTeardown.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.4.4/fixtureTeardown.html
+++ b/docs/2.4.4/fixtureTeardown.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.4.4/fixtureTeardown.html
+++ b/docs/2.4.4/fixtureTeardown.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.4.4/getStarted.html
+++ b/docs/2.4.4/getStarted.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.4.4/getStarted.html
+++ b/docs/2.4.4/getStarted.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.4.4/getStarted.html
+++ b/docs/2.4.4/getStarted.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.4.4/getStarted.html
+++ b/docs/2.4.4/getStarted.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.4.4/guiCommandLine.html
+++ b/docs/2.4.4/guiCommandLine.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.4.4/guiCommandLine.html
+++ b/docs/2.4.4/guiCommandLine.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.4.4/guiCommandLine.html
+++ b/docs/2.4.4/guiCommandLine.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.4.4/guiCommandLine.html
+++ b/docs/2.4.4/guiCommandLine.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.4.4/identityAsserts.html
+++ b/docs/2.4.4/identityAsserts.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.4.4/identityAsserts.html
+++ b/docs/2.4.4/identityAsserts.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.4.4/identityAsserts.html
+++ b/docs/2.4.4/identityAsserts.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.4.4/identityAsserts.html
+++ b/docs/2.4.4/identityAsserts.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.4.4/ignore.html
+++ b/docs/2.4.4/ignore.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.4.4/ignore.html
+++ b/docs/2.4.4/ignore.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.4.4/ignore.html
+++ b/docs/2.4.4/ignore.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.4.4/ignore.html
+++ b/docs/2.4.4/ignore.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.4.4/installation.html
+++ b/docs/2.4.4/installation.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.4.4/installation.html
+++ b/docs/2.4.4/installation.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.4.4/installation.html
+++ b/docs/2.4.4/installation.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.4.4/installation.html
+++ b/docs/2.4.4/installation.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.4.4/license.html
+++ b/docs/2.4.4/license.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.4.4/license.html
+++ b/docs/2.4.4/license.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.4.4/license.html
+++ b/docs/2.4.4/license.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.4.4/license.html
+++ b/docs/2.4.4/license.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.4.4/listMapper.html
+++ b/docs/2.4.4/listMapper.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.4.4/listMapper.html
+++ b/docs/2.4.4/listMapper.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.4.4/listMapper.html
+++ b/docs/2.4.4/listMapper.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.4.4/listMapper.html
+++ b/docs/2.4.4/listMapper.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.4.4/mainMenu.html
+++ b/docs/2.4.4/mainMenu.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.4.4/mainMenu.html
+++ b/docs/2.4.4/mainMenu.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.4.4/mainMenu.html
+++ b/docs/2.4.4/mainMenu.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.4.4/mainMenu.html
+++ b/docs/2.4.4/mainMenu.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.4.4/multiAssembly.html
+++ b/docs/2.4.4/multiAssembly.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.4.4/multiAssembly.html
+++ b/docs/2.4.4/multiAssembly.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.4.4/multiAssembly.html
+++ b/docs/2.4.4/multiAssembly.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.4.4/multiAssembly.html
+++ b/docs/2.4.4/multiAssembly.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.4.4/nunit-console.html
+++ b/docs/2.4.4/nunit-console.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.4.4/nunit-console.html
+++ b/docs/2.4.4/nunit-console.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.4.4/nunit-console.html
+++ b/docs/2.4.4/nunit-console.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.4.4/nunit-console.html
+++ b/docs/2.4.4/nunit-console.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.4.4/nunit-gui.html
+++ b/docs/2.4.4/nunit-gui.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.4.4/nunit-gui.html
+++ b/docs/2.4.4/nunit-gui.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.4.4/nunit-gui.html
+++ b/docs/2.4.4/nunit-gui.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.4.4/nunit-gui.html
+++ b/docs/2.4.4/nunit-gui.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.4.4/nunitAddins.html
+++ b/docs/2.4.4/nunitAddins.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.4.4/nunitAddins.html
+++ b/docs/2.4.4/nunitAddins.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.4.4/nunitAddins.html
+++ b/docs/2.4.4/nunitAddins.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.4.4/nunitAddins.html
+++ b/docs/2.4.4/nunitAddins.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.4.4/optionsDialog.html
+++ b/docs/2.4.4/optionsDialog.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.4.4/optionsDialog.html
+++ b/docs/2.4.4/optionsDialog.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.4.4/optionsDialog.html
+++ b/docs/2.4.4/optionsDialog.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.4.4/optionsDialog.html
+++ b/docs/2.4.4/optionsDialog.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.4.4/platform.html
+++ b/docs/2.4.4/platform.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.4.4/platform.html
+++ b/docs/2.4.4/platform.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.4.4/platform.html
+++ b/docs/2.4.4/platform.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.4.4/platform.html
+++ b/docs/2.4.4/platform.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.4.4/projectEditor.html
+++ b/docs/2.4.4/projectEditor.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.4.4/projectEditor.html
+++ b/docs/2.4.4/projectEditor.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.4.4/projectEditor.html
+++ b/docs/2.4.4/projectEditor.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.4.4/projectEditor.html
+++ b/docs/2.4.4/projectEditor.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.4.4/property.html
+++ b/docs/2.4.4/property.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.4.4/property.html
+++ b/docs/2.4.4/property.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.4.4/property.html
+++ b/docs/2.4.4/property.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.4.4/property.html
+++ b/docs/2.4.4/property.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.4.4/propertyConstraint.html
+++ b/docs/2.4.4/propertyConstraint.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.4.4/propertyConstraint.html
+++ b/docs/2.4.4/propertyConstraint.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.4.4/propertyConstraint.html
+++ b/docs/2.4.4/propertyConstraint.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.4.4/propertyConstraint.html
+++ b/docs/2.4.4/propertyConstraint.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.4.4/quickStart.html
+++ b/docs/2.4.4/quickStart.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.4.4/quickStart.html
+++ b/docs/2.4.4/quickStart.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.4.4/quickStart.html
+++ b/docs/2.4.4/quickStart.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.4.4/quickStart.html
+++ b/docs/2.4.4/quickStart.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.4.4/quickStartSource.html
+++ b/docs/2.4.4/quickStartSource.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.4.4/quickStartSource.html
+++ b/docs/2.4.4/quickStartSource.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.4.4/quickStartSource.html
+++ b/docs/2.4.4/quickStartSource.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.4.4/quickStartSource.html
+++ b/docs/2.4.4/quickStartSource.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.4.4/releaseNotes.html
+++ b/docs/2.4.4/releaseNotes.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.4.4/releaseNotes.html
+++ b/docs/2.4.4/releaseNotes.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.4.4/releaseNotes.html
+++ b/docs/2.4.4/releaseNotes.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.4.4/releaseNotes.html
+++ b/docs/2.4.4/releaseNotes.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.4.4/sameasConstraint.html
+++ b/docs/2.4.4/sameasConstraint.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.4.4/sameasConstraint.html
+++ b/docs/2.4.4/sameasConstraint.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.4.4/sameasConstraint.html
+++ b/docs/2.4.4/sameasConstraint.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.4.4/sameasConstraint.html
+++ b/docs/2.4.4/sameasConstraint.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.4.4/samples.html
+++ b/docs/2.4.4/samples.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.4.4/samples.html
+++ b/docs/2.4.4/samples.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.4.4/samples.html
+++ b/docs/2.4.4/samples.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.4.4/samples.html
+++ b/docs/2.4.4/samples.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.4.4/setCulture.html
+++ b/docs/2.4.4/setCulture.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.4.4/setCulture.html
+++ b/docs/2.4.4/setCulture.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.4.4/setCulture.html
+++ b/docs/2.4.4/setCulture.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.4.4/setCulture.html
+++ b/docs/2.4.4/setCulture.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.4.4/setup.html
+++ b/docs/2.4.4/setup.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.4.4/setup.html
+++ b/docs/2.4.4/setup.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.4.4/setup.html
+++ b/docs/2.4.4/setup.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.4.4/setup.html
+++ b/docs/2.4.4/setup.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.4.4/setupFixture.html
+++ b/docs/2.4.4/setupFixture.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.4.4/setupFixture.html
+++ b/docs/2.4.4/setupFixture.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.4.4/setupFixture.html
+++ b/docs/2.4.4/setupFixture.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.4.4/setupFixture.html
+++ b/docs/2.4.4/setupFixture.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.4.4/stringAssert.html
+++ b/docs/2.4.4/stringAssert.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.4.4/stringAssert.html
+++ b/docs/2.4.4/stringAssert.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.4.4/stringAssert.html
+++ b/docs/2.4.4/stringAssert.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.4.4/stringAssert.html
+++ b/docs/2.4.4/stringAssert.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.4.4/stringConstraints.html
+++ b/docs/2.4.4/stringConstraints.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.4.4/stringConstraints.html
+++ b/docs/2.4.4/stringConstraints.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.4.4/stringConstraints.html
+++ b/docs/2.4.4/stringConstraints.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.4.4/stringConstraints.html
+++ b/docs/2.4.4/stringConstraints.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.4.4/suite.html
+++ b/docs/2.4.4/suite.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.4.4/suite.html
+++ b/docs/2.4.4/suite.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.4.4/suite.html
+++ b/docs/2.4.4/suite.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.4.4/suite.html
+++ b/docs/2.4.4/suite.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.4.4/teardown.html
+++ b/docs/2.4.4/teardown.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.4.4/teardown.html
+++ b/docs/2.4.4/teardown.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.4.4/teardown.html
+++ b/docs/2.4.4/teardown.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.4.4/teardown.html
+++ b/docs/2.4.4/teardown.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.4.4/test.html
+++ b/docs/2.4.4/test.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.4.4/test.html
+++ b/docs/2.4.4/test.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.4.4/test.html
+++ b/docs/2.4.4/test.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.4.4/test.html
+++ b/docs/2.4.4/test.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.4.4/testFixture.html
+++ b/docs/2.4.4/testFixture.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.4.4/testFixture.html
+++ b/docs/2.4.4/testFixture.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.4.4/testFixture.html
+++ b/docs/2.4.4/testFixture.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.4.4/testFixture.html
+++ b/docs/2.4.4/testFixture.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.4.4/testProperties.html
+++ b/docs/2.4.4/testProperties.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.4.4/testProperties.html
+++ b/docs/2.4.4/testProperties.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.4.4/testProperties.html
+++ b/docs/2.4.4/testProperties.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.4.4/testProperties.html
+++ b/docs/2.4.4/testProperties.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.4.4/typeAsserts.html
+++ b/docs/2.4.4/typeAsserts.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.4.4/typeAsserts.html
+++ b/docs/2.4.4/typeAsserts.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.4.4/typeAsserts.html
+++ b/docs/2.4.4/typeAsserts.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.4.4/typeAsserts.html
+++ b/docs/2.4.4/typeAsserts.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.4.4/typeConstraints.html
+++ b/docs/2.4.4/typeConstraints.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.4.4/typeConstraints.html
+++ b/docs/2.4.4/typeConstraints.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.4.4/typeConstraints.html
+++ b/docs/2.4.4/typeConstraints.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.4.4/typeConstraints.html
+++ b/docs/2.4.4/typeConstraints.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.4.4/upgrade.html
+++ b/docs/2.4.4/upgrade.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.4.4/upgrade.html
+++ b/docs/2.4.4/upgrade.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.4.4/upgrade.html
+++ b/docs/2.4.4/upgrade.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.4.4/upgrade.html
+++ b/docs/2.4.4/upgrade.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.4.4/utilityAsserts.html
+++ b/docs/2.4.4/utilityAsserts.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.4.4/utilityAsserts.html
+++ b/docs/2.4.4/utilityAsserts.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.4.4/utilityAsserts.html
+++ b/docs/2.4.4/utilityAsserts.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.4.4/utilityAsserts.html
+++ b/docs/2.4.4/utilityAsserts.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.4.4/vsSupport.html
+++ b/docs/2.4.4/vsSupport.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.4.4/vsSupport.html
+++ b/docs/2.4.4/vsSupport.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.4.4/vsSupport.html
+++ b/docs/2.4.4/vsSupport.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.4.4/vsSupport.html
+++ b/docs/2.4.4/vsSupport.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.4.5/addinsDialog.html
+++ b/docs/2.4.5/addinsDialog.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.4.5/addinsDialog.html
+++ b/docs/2.4.5/addinsDialog.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.4.5/addinsDialog.html
+++ b/docs/2.4.5/addinsDialog.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.4.5/addinsDialog.html
+++ b/docs/2.4.5/addinsDialog.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.4.5/assertions.html
+++ b/docs/2.4.5/assertions.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.4.5/assertions.html
+++ b/docs/2.4.5/assertions.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.4.5/assertions.html
+++ b/docs/2.4.5/assertions.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.4.5/assertions.html
+++ b/docs/2.4.5/assertions.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.4.5/attributes.html
+++ b/docs/2.4.5/attributes.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.4.5/attributes.html
+++ b/docs/2.4.5/attributes.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.4.5/attributes.html
+++ b/docs/2.4.5/attributes.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.4.5/attributes.html
+++ b/docs/2.4.5/attributes.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.4.5/category.html
+++ b/docs/2.4.5/category.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.4.5/category.html
+++ b/docs/2.4.5/category.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.4.5/category.html
+++ b/docs/2.4.5/category.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.4.5/category.html
+++ b/docs/2.4.5/category.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.4.5/classicModel.html
+++ b/docs/2.4.5/classicModel.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.4.5/classicModel.html
+++ b/docs/2.4.5/classicModel.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.4.5/classicModel.html
+++ b/docs/2.4.5/classicModel.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.4.5/classicModel.html
+++ b/docs/2.4.5/classicModel.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.4.5/collectionAssert.html
+++ b/docs/2.4.5/collectionAssert.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.4.5/collectionAssert.html
+++ b/docs/2.4.5/collectionAssert.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.4.5/collectionAssert.html
+++ b/docs/2.4.5/collectionAssert.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.4.5/collectionAssert.html
+++ b/docs/2.4.5/collectionAssert.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.4.5/collectionConstraints.html
+++ b/docs/2.4.5/collectionConstraints.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.4.5/collectionConstraints.html
+++ b/docs/2.4.5/collectionConstraints.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.4.5/collectionConstraints.html
+++ b/docs/2.4.5/collectionConstraints.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.4.5/collectionConstraints.html
+++ b/docs/2.4.5/collectionConstraints.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.4.5/comparisonAsserts.html
+++ b/docs/2.4.5/comparisonAsserts.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.4.5/comparisonAsserts.html
+++ b/docs/2.4.5/comparisonAsserts.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.4.5/comparisonAsserts.html
+++ b/docs/2.4.5/comparisonAsserts.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.4.5/comparisonAsserts.html
+++ b/docs/2.4.5/comparisonAsserts.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.4.5/comparisonConstraints.html
+++ b/docs/2.4.5/comparisonConstraints.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.4.5/comparisonConstraints.html
+++ b/docs/2.4.5/comparisonConstraints.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.4.5/comparisonConstraints.html
+++ b/docs/2.4.5/comparisonConstraints.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.4.5/comparisonConstraints.html
+++ b/docs/2.4.5/comparisonConstraints.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.4.5/compoundConstraints.html
+++ b/docs/2.4.5/compoundConstraints.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.4.5/compoundConstraints.html
+++ b/docs/2.4.5/compoundConstraints.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.4.5/compoundConstraints.html
+++ b/docs/2.4.5/compoundConstraints.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.4.5/compoundConstraints.html
+++ b/docs/2.4.5/compoundConstraints.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.4.5/conditionAsserts.html
+++ b/docs/2.4.5/conditionAsserts.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.4.5/conditionAsserts.html
+++ b/docs/2.4.5/conditionAsserts.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.4.5/conditionAsserts.html
+++ b/docs/2.4.5/conditionAsserts.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.4.5/conditionAsserts.html
+++ b/docs/2.4.5/conditionAsserts.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.4.5/conditionConstraints.html
+++ b/docs/2.4.5/conditionConstraints.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.4.5/conditionConstraints.html
+++ b/docs/2.4.5/conditionConstraints.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.4.5/conditionConstraints.html
+++ b/docs/2.4.5/conditionConstraints.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.4.5/conditionConstraints.html
+++ b/docs/2.4.5/conditionConstraints.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.4.5/configEditor.html
+++ b/docs/2.4.5/configEditor.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.4.5/configEditor.html
+++ b/docs/2.4.5/configEditor.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.4.5/configEditor.html
+++ b/docs/2.4.5/configEditor.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.4.5/configEditor.html
+++ b/docs/2.4.5/configEditor.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.4.5/configFiles.html
+++ b/docs/2.4.5/configFiles.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.4.5/configFiles.html
+++ b/docs/2.4.5/configFiles.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.4.5/configFiles.html
+++ b/docs/2.4.5/configFiles.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.4.5/configFiles.html
+++ b/docs/2.4.5/configFiles.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.4.5/consoleCommandLine.html
+++ b/docs/2.4.5/consoleCommandLine.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.4.5/consoleCommandLine.html
+++ b/docs/2.4.5/consoleCommandLine.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.4.5/consoleCommandLine.html
+++ b/docs/2.4.5/consoleCommandLine.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.4.5/consoleCommandLine.html
+++ b/docs/2.4.5/consoleCommandLine.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.4.5/constraintModel.html
+++ b/docs/2.4.5/constraintModel.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.4.5/constraintModel.html
+++ b/docs/2.4.5/constraintModel.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.4.5/constraintModel.html
+++ b/docs/2.4.5/constraintModel.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.4.5/constraintModel.html
+++ b/docs/2.4.5/constraintModel.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.4.5/contextMenu.html
+++ b/docs/2.4.5/contextMenu.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.4.5/contextMenu.html
+++ b/docs/2.4.5/contextMenu.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.4.5/contextMenu.html
+++ b/docs/2.4.5/contextMenu.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.4.5/contextMenu.html
+++ b/docs/2.4.5/contextMenu.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.4.5/culture.html
+++ b/docs/2.4.5/culture.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.4.5/culture.html
+++ b/docs/2.4.5/culture.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.4.5/culture.html
+++ b/docs/2.4.5/culture.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.4.5/culture.html
+++ b/docs/2.4.5/culture.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.4.5/customAsserts.html
+++ b/docs/2.4.5/customAsserts.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.4.5/customAsserts.html
+++ b/docs/2.4.5/customAsserts.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.4.5/customAsserts.html
+++ b/docs/2.4.5/customAsserts.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.4.5/customAsserts.html
+++ b/docs/2.4.5/customAsserts.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.4.5/customConstraints.html
+++ b/docs/2.4.5/customConstraints.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.4.5/customConstraints.html
+++ b/docs/2.4.5/customConstraints.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.4.5/customConstraints.html
+++ b/docs/2.4.5/customConstraints.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.4.5/customConstraints.html
+++ b/docs/2.4.5/customConstraints.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.4.5/description.html
+++ b/docs/2.4.5/description.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.4.5/description.html
+++ b/docs/2.4.5/description.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.4.5/description.html
+++ b/docs/2.4.5/description.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.4.5/description.html
+++ b/docs/2.4.5/description.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.4.5/docHome.html
+++ b/docs/2.4.5/docHome.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.4.5/docHome.html
+++ b/docs/2.4.5/docHome.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.4.5/docHome.html
+++ b/docs/2.4.5/docHome.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.4.5/docHome.html
+++ b/docs/2.4.5/docHome.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.4.5/equalConstraint.html
+++ b/docs/2.4.5/equalConstraint.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.4.5/equalConstraint.html
+++ b/docs/2.4.5/equalConstraint.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.4.5/equalConstraint.html
+++ b/docs/2.4.5/equalConstraint.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.4.5/equalConstraint.html
+++ b/docs/2.4.5/equalConstraint.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.4.5/equalityAsserts.html
+++ b/docs/2.4.5/equalityAsserts.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.4.5/equalityAsserts.html
+++ b/docs/2.4.5/equalityAsserts.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.4.5/equalityAsserts.html
+++ b/docs/2.4.5/equalityAsserts.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.4.5/equalityAsserts.html
+++ b/docs/2.4.5/equalityAsserts.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.4.5/exception.html
+++ b/docs/2.4.5/exception.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.4.5/exception.html
+++ b/docs/2.4.5/exception.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.4.5/exception.html
+++ b/docs/2.4.5/exception.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.4.5/exception.html
+++ b/docs/2.4.5/exception.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.4.5/explicit.html
+++ b/docs/2.4.5/explicit.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.4.5/explicit.html
+++ b/docs/2.4.5/explicit.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.4.5/explicit.html
+++ b/docs/2.4.5/explicit.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.4.5/explicit.html
+++ b/docs/2.4.5/explicit.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.4.5/extensibility.html
+++ b/docs/2.4.5/extensibility.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.4.5/extensibility.html
+++ b/docs/2.4.5/extensibility.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.4.5/extensibility.html
+++ b/docs/2.4.5/extensibility.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.4.5/extensibility.html
+++ b/docs/2.4.5/extensibility.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.4.5/features.html
+++ b/docs/2.4.5/features.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.4.5/features.html
+++ b/docs/2.4.5/features.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.4.5/features.html
+++ b/docs/2.4.5/features.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.4.5/features.html
+++ b/docs/2.4.5/features.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.4.5/fileAssert.html
+++ b/docs/2.4.5/fileAssert.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.4.5/fileAssert.html
+++ b/docs/2.4.5/fileAssert.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.4.5/fileAssert.html
+++ b/docs/2.4.5/fileAssert.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.4.5/fileAssert.html
+++ b/docs/2.4.5/fileAssert.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.4.5/fixtureSetup.html
+++ b/docs/2.4.5/fixtureSetup.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.4.5/fixtureSetup.html
+++ b/docs/2.4.5/fixtureSetup.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.4.5/fixtureSetup.html
+++ b/docs/2.4.5/fixtureSetup.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.4.5/fixtureSetup.html
+++ b/docs/2.4.5/fixtureSetup.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.4.5/fixtureTeardown.html
+++ b/docs/2.4.5/fixtureTeardown.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.4.5/fixtureTeardown.html
+++ b/docs/2.4.5/fixtureTeardown.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.4.5/fixtureTeardown.html
+++ b/docs/2.4.5/fixtureTeardown.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.4.5/fixtureTeardown.html
+++ b/docs/2.4.5/fixtureTeardown.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.4.5/getStarted.html
+++ b/docs/2.4.5/getStarted.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.4.5/getStarted.html
+++ b/docs/2.4.5/getStarted.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.4.5/getStarted.html
+++ b/docs/2.4.5/getStarted.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.4.5/getStarted.html
+++ b/docs/2.4.5/getStarted.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.4.5/guiCommandLine.html
+++ b/docs/2.4.5/guiCommandLine.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.4.5/guiCommandLine.html
+++ b/docs/2.4.5/guiCommandLine.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.4.5/guiCommandLine.html
+++ b/docs/2.4.5/guiCommandLine.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.4.5/guiCommandLine.html
+++ b/docs/2.4.5/guiCommandLine.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.4.5/identityAsserts.html
+++ b/docs/2.4.5/identityAsserts.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.4.5/identityAsserts.html
+++ b/docs/2.4.5/identityAsserts.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.4.5/identityAsserts.html
+++ b/docs/2.4.5/identityAsserts.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.4.5/identityAsserts.html
+++ b/docs/2.4.5/identityAsserts.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.4.5/ignore.html
+++ b/docs/2.4.5/ignore.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.4.5/ignore.html
+++ b/docs/2.4.5/ignore.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.4.5/ignore.html
+++ b/docs/2.4.5/ignore.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.4.5/ignore.html
+++ b/docs/2.4.5/ignore.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.4.5/installation.html
+++ b/docs/2.4.5/installation.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.4.5/installation.html
+++ b/docs/2.4.5/installation.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.4.5/installation.html
+++ b/docs/2.4.5/installation.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.4.5/installation.html
+++ b/docs/2.4.5/installation.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.4.5/license.html
+++ b/docs/2.4.5/license.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.4.5/license.html
+++ b/docs/2.4.5/license.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.4.5/license.html
+++ b/docs/2.4.5/license.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.4.5/license.html
+++ b/docs/2.4.5/license.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.4.5/listMapper.html
+++ b/docs/2.4.5/listMapper.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.4.5/listMapper.html
+++ b/docs/2.4.5/listMapper.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.4.5/listMapper.html
+++ b/docs/2.4.5/listMapper.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.4.5/listMapper.html
+++ b/docs/2.4.5/listMapper.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.4.5/mainMenu.html
+++ b/docs/2.4.5/mainMenu.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.4.5/mainMenu.html
+++ b/docs/2.4.5/mainMenu.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.4.5/mainMenu.html
+++ b/docs/2.4.5/mainMenu.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.4.5/mainMenu.html
+++ b/docs/2.4.5/mainMenu.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.4.5/multiAssembly.html
+++ b/docs/2.4.5/multiAssembly.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.4.5/multiAssembly.html
+++ b/docs/2.4.5/multiAssembly.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.4.5/multiAssembly.html
+++ b/docs/2.4.5/multiAssembly.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.4.5/multiAssembly.html
+++ b/docs/2.4.5/multiAssembly.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.4.5/nunit-console.html
+++ b/docs/2.4.5/nunit-console.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.4.5/nunit-console.html
+++ b/docs/2.4.5/nunit-console.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.4.5/nunit-console.html
+++ b/docs/2.4.5/nunit-console.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.4.5/nunit-console.html
+++ b/docs/2.4.5/nunit-console.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.4.5/nunit-gui.html
+++ b/docs/2.4.5/nunit-gui.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.4.5/nunit-gui.html
+++ b/docs/2.4.5/nunit-gui.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.4.5/nunit-gui.html
+++ b/docs/2.4.5/nunit-gui.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.4.5/nunit-gui.html
+++ b/docs/2.4.5/nunit-gui.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.4.5/nunitAddins.html
+++ b/docs/2.4.5/nunitAddins.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.4.5/nunitAddins.html
+++ b/docs/2.4.5/nunitAddins.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.4.5/nunitAddins.html
+++ b/docs/2.4.5/nunitAddins.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.4.5/nunitAddins.html
+++ b/docs/2.4.5/nunitAddins.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.4.5/optionsDialog.html
+++ b/docs/2.4.5/optionsDialog.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.4.5/optionsDialog.html
+++ b/docs/2.4.5/optionsDialog.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.4.5/optionsDialog.html
+++ b/docs/2.4.5/optionsDialog.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.4.5/optionsDialog.html
+++ b/docs/2.4.5/optionsDialog.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.4.5/platform.html
+++ b/docs/2.4.5/platform.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.4.5/platform.html
+++ b/docs/2.4.5/platform.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.4.5/platform.html
+++ b/docs/2.4.5/platform.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.4.5/platform.html
+++ b/docs/2.4.5/platform.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.4.5/projectEditor.html
+++ b/docs/2.4.5/projectEditor.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.4.5/projectEditor.html
+++ b/docs/2.4.5/projectEditor.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.4.5/projectEditor.html
+++ b/docs/2.4.5/projectEditor.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.4.5/projectEditor.html
+++ b/docs/2.4.5/projectEditor.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.4.5/property.html
+++ b/docs/2.4.5/property.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.4.5/property.html
+++ b/docs/2.4.5/property.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.4.5/property.html
+++ b/docs/2.4.5/property.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.4.5/property.html
+++ b/docs/2.4.5/property.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.4.5/propertyConstraint.html
+++ b/docs/2.4.5/propertyConstraint.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.4.5/propertyConstraint.html
+++ b/docs/2.4.5/propertyConstraint.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.4.5/propertyConstraint.html
+++ b/docs/2.4.5/propertyConstraint.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.4.5/propertyConstraint.html
+++ b/docs/2.4.5/propertyConstraint.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.4.5/quickStart.html
+++ b/docs/2.4.5/quickStart.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.4.5/quickStart.html
+++ b/docs/2.4.5/quickStart.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.4.5/quickStart.html
+++ b/docs/2.4.5/quickStart.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.4.5/quickStart.html
+++ b/docs/2.4.5/quickStart.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.4.5/quickStartSource.html
+++ b/docs/2.4.5/quickStartSource.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.4.5/quickStartSource.html
+++ b/docs/2.4.5/quickStartSource.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.4.5/quickStartSource.html
+++ b/docs/2.4.5/quickStartSource.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.4.5/quickStartSource.html
+++ b/docs/2.4.5/quickStartSource.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.4.5/releaseNotes.html
+++ b/docs/2.4.5/releaseNotes.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.4.5/releaseNotes.html
+++ b/docs/2.4.5/releaseNotes.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.4.5/releaseNotes.html
+++ b/docs/2.4.5/releaseNotes.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.4.5/releaseNotes.html
+++ b/docs/2.4.5/releaseNotes.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.4.5/sameasConstraint.html
+++ b/docs/2.4.5/sameasConstraint.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.4.5/sameasConstraint.html
+++ b/docs/2.4.5/sameasConstraint.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.4.5/sameasConstraint.html
+++ b/docs/2.4.5/sameasConstraint.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.4.5/sameasConstraint.html
+++ b/docs/2.4.5/sameasConstraint.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.4.5/samples.html
+++ b/docs/2.4.5/samples.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.4.5/samples.html
+++ b/docs/2.4.5/samples.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.4.5/samples.html
+++ b/docs/2.4.5/samples.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.4.5/samples.html
+++ b/docs/2.4.5/samples.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.4.5/setCulture.html
+++ b/docs/2.4.5/setCulture.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.4.5/setCulture.html
+++ b/docs/2.4.5/setCulture.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.4.5/setCulture.html
+++ b/docs/2.4.5/setCulture.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.4.5/setCulture.html
+++ b/docs/2.4.5/setCulture.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.4.5/setup.html
+++ b/docs/2.4.5/setup.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.4.5/setup.html
+++ b/docs/2.4.5/setup.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.4.5/setup.html
+++ b/docs/2.4.5/setup.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.4.5/setup.html
+++ b/docs/2.4.5/setup.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.4.5/setupFixture.html
+++ b/docs/2.4.5/setupFixture.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.4.5/setupFixture.html
+++ b/docs/2.4.5/setupFixture.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.4.5/setupFixture.html
+++ b/docs/2.4.5/setupFixture.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.4.5/setupFixture.html
+++ b/docs/2.4.5/setupFixture.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.4.5/stringAssert.html
+++ b/docs/2.4.5/stringAssert.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.4.5/stringAssert.html
+++ b/docs/2.4.5/stringAssert.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.4.5/stringAssert.html
+++ b/docs/2.4.5/stringAssert.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.4.5/stringAssert.html
+++ b/docs/2.4.5/stringAssert.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.4.5/stringConstraints.html
+++ b/docs/2.4.5/stringConstraints.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.4.5/stringConstraints.html
+++ b/docs/2.4.5/stringConstraints.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.4.5/stringConstraints.html
+++ b/docs/2.4.5/stringConstraints.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.4.5/stringConstraints.html
+++ b/docs/2.4.5/stringConstraints.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.4.5/suite.html
+++ b/docs/2.4.5/suite.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.4.5/suite.html
+++ b/docs/2.4.5/suite.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.4.5/suite.html
+++ b/docs/2.4.5/suite.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.4.5/suite.html
+++ b/docs/2.4.5/suite.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.4.5/teardown.html
+++ b/docs/2.4.5/teardown.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.4.5/teardown.html
+++ b/docs/2.4.5/teardown.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.4.5/teardown.html
+++ b/docs/2.4.5/teardown.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.4.5/teardown.html
+++ b/docs/2.4.5/teardown.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.4.5/test.html
+++ b/docs/2.4.5/test.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.4.5/test.html
+++ b/docs/2.4.5/test.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.4.5/test.html
+++ b/docs/2.4.5/test.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.4.5/test.html
+++ b/docs/2.4.5/test.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.4.5/testFixture.html
+++ b/docs/2.4.5/testFixture.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.4.5/testFixture.html
+++ b/docs/2.4.5/testFixture.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.4.5/testFixture.html
+++ b/docs/2.4.5/testFixture.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.4.5/testFixture.html
+++ b/docs/2.4.5/testFixture.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.4.5/testProperties.html
+++ b/docs/2.4.5/testProperties.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.4.5/testProperties.html
+++ b/docs/2.4.5/testProperties.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.4.5/testProperties.html
+++ b/docs/2.4.5/testProperties.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.4.5/testProperties.html
+++ b/docs/2.4.5/testProperties.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.4.5/typeAsserts.html
+++ b/docs/2.4.5/typeAsserts.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.4.5/typeAsserts.html
+++ b/docs/2.4.5/typeAsserts.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.4.5/typeAsserts.html
+++ b/docs/2.4.5/typeAsserts.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.4.5/typeAsserts.html
+++ b/docs/2.4.5/typeAsserts.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.4.5/typeConstraints.html
+++ b/docs/2.4.5/typeConstraints.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.4.5/typeConstraints.html
+++ b/docs/2.4.5/typeConstraints.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.4.5/typeConstraints.html
+++ b/docs/2.4.5/typeConstraints.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.4.5/typeConstraints.html
+++ b/docs/2.4.5/typeConstraints.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.4.5/upgrade.html
+++ b/docs/2.4.5/upgrade.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.4.5/upgrade.html
+++ b/docs/2.4.5/upgrade.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.4.5/upgrade.html
+++ b/docs/2.4.5/upgrade.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.4.5/upgrade.html
+++ b/docs/2.4.5/upgrade.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.4.5/utilityAsserts.html
+++ b/docs/2.4.5/utilityAsserts.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.4.5/utilityAsserts.html
+++ b/docs/2.4.5/utilityAsserts.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.4.5/utilityAsserts.html
+++ b/docs/2.4.5/utilityAsserts.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.4.5/utilityAsserts.html
+++ b/docs/2.4.5/utilityAsserts.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.4.5/vsSupport.html
+++ b/docs/2.4.5/vsSupport.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.4.5/vsSupport.html
+++ b/docs/2.4.5/vsSupport.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.4.5/vsSupport.html
+++ b/docs/2.4.5/vsSupport.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.4.5/vsSupport.html
+++ b/docs/2.4.5/vsSupport.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.4.6/addinsDialog.html
+++ b/docs/2.4.6/addinsDialog.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.4.6/addinsDialog.html
+++ b/docs/2.4.6/addinsDialog.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.4.6/addinsDialog.html
+++ b/docs/2.4.6/addinsDialog.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.4.6/addinsDialog.html
+++ b/docs/2.4.6/addinsDialog.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.4.6/assertions.html
+++ b/docs/2.4.6/assertions.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.4.6/assertions.html
+++ b/docs/2.4.6/assertions.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.4.6/assertions.html
+++ b/docs/2.4.6/assertions.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.4.6/assertions.html
+++ b/docs/2.4.6/assertions.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.4.6/attributes.html
+++ b/docs/2.4.6/attributes.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.4.6/attributes.html
+++ b/docs/2.4.6/attributes.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.4.6/attributes.html
+++ b/docs/2.4.6/attributes.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.4.6/attributes.html
+++ b/docs/2.4.6/attributes.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.4.6/category.html
+++ b/docs/2.4.6/category.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.4.6/category.html
+++ b/docs/2.4.6/category.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.4.6/category.html
+++ b/docs/2.4.6/category.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.4.6/category.html
+++ b/docs/2.4.6/category.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.4.6/classicModel.html
+++ b/docs/2.4.6/classicModel.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.4.6/classicModel.html
+++ b/docs/2.4.6/classicModel.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.4.6/classicModel.html
+++ b/docs/2.4.6/classicModel.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.4.6/classicModel.html
+++ b/docs/2.4.6/classicModel.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.4.6/collectionAssert.html
+++ b/docs/2.4.6/collectionAssert.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.4.6/collectionAssert.html
+++ b/docs/2.4.6/collectionAssert.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.4.6/collectionAssert.html
+++ b/docs/2.4.6/collectionAssert.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.4.6/collectionAssert.html
+++ b/docs/2.4.6/collectionAssert.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.4.6/collectionConstraints.html
+++ b/docs/2.4.6/collectionConstraints.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.4.6/collectionConstraints.html
+++ b/docs/2.4.6/collectionConstraints.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.4.6/collectionConstraints.html
+++ b/docs/2.4.6/collectionConstraints.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.4.6/collectionConstraints.html
+++ b/docs/2.4.6/collectionConstraints.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.4.6/comparisonAsserts.html
+++ b/docs/2.4.6/comparisonAsserts.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.4.6/comparisonAsserts.html
+++ b/docs/2.4.6/comparisonAsserts.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.4.6/comparisonAsserts.html
+++ b/docs/2.4.6/comparisonAsserts.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.4.6/comparisonAsserts.html
+++ b/docs/2.4.6/comparisonAsserts.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.4.6/comparisonConstraints.html
+++ b/docs/2.4.6/comparisonConstraints.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.4.6/comparisonConstraints.html
+++ b/docs/2.4.6/comparisonConstraints.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.4.6/comparisonConstraints.html
+++ b/docs/2.4.6/comparisonConstraints.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.4.6/comparisonConstraints.html
+++ b/docs/2.4.6/comparisonConstraints.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.4.6/compoundConstraints.html
+++ b/docs/2.4.6/compoundConstraints.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.4.6/compoundConstraints.html
+++ b/docs/2.4.6/compoundConstraints.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.4.6/compoundConstraints.html
+++ b/docs/2.4.6/compoundConstraints.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.4.6/compoundConstraints.html
+++ b/docs/2.4.6/compoundConstraints.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.4.6/conditionAsserts.html
+++ b/docs/2.4.6/conditionAsserts.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.4.6/conditionAsserts.html
+++ b/docs/2.4.6/conditionAsserts.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.4.6/conditionAsserts.html
+++ b/docs/2.4.6/conditionAsserts.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.4.6/conditionAsserts.html
+++ b/docs/2.4.6/conditionAsserts.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.4.6/conditionConstraints.html
+++ b/docs/2.4.6/conditionConstraints.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.4.6/conditionConstraints.html
+++ b/docs/2.4.6/conditionConstraints.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.4.6/conditionConstraints.html
+++ b/docs/2.4.6/conditionConstraints.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.4.6/conditionConstraints.html
+++ b/docs/2.4.6/conditionConstraints.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.4.6/configEditor.html
+++ b/docs/2.4.6/configEditor.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.4.6/configEditor.html
+++ b/docs/2.4.6/configEditor.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.4.6/configEditor.html
+++ b/docs/2.4.6/configEditor.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.4.6/configEditor.html
+++ b/docs/2.4.6/configEditor.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.4.6/configFiles.html
+++ b/docs/2.4.6/configFiles.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.4.6/configFiles.html
+++ b/docs/2.4.6/configFiles.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.4.6/configFiles.html
+++ b/docs/2.4.6/configFiles.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.4.6/configFiles.html
+++ b/docs/2.4.6/configFiles.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.4.6/consoleCommandLine.html
+++ b/docs/2.4.6/consoleCommandLine.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.4.6/consoleCommandLine.html
+++ b/docs/2.4.6/consoleCommandLine.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.4.6/consoleCommandLine.html
+++ b/docs/2.4.6/consoleCommandLine.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.4.6/consoleCommandLine.html
+++ b/docs/2.4.6/consoleCommandLine.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.4.6/constraintModel.html
+++ b/docs/2.4.6/constraintModel.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.4.6/constraintModel.html
+++ b/docs/2.4.6/constraintModel.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.4.6/constraintModel.html
+++ b/docs/2.4.6/constraintModel.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.4.6/constraintModel.html
+++ b/docs/2.4.6/constraintModel.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.4.6/contextMenu.html
+++ b/docs/2.4.6/contextMenu.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.4.6/contextMenu.html
+++ b/docs/2.4.6/contextMenu.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.4.6/contextMenu.html
+++ b/docs/2.4.6/contextMenu.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.4.6/contextMenu.html
+++ b/docs/2.4.6/contextMenu.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.4.6/culture.html
+++ b/docs/2.4.6/culture.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.4.6/culture.html
+++ b/docs/2.4.6/culture.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.4.6/culture.html
+++ b/docs/2.4.6/culture.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.4.6/culture.html
+++ b/docs/2.4.6/culture.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.4.6/customAsserts.html
+++ b/docs/2.4.6/customAsserts.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.4.6/customAsserts.html
+++ b/docs/2.4.6/customAsserts.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.4.6/customAsserts.html
+++ b/docs/2.4.6/customAsserts.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.4.6/customAsserts.html
+++ b/docs/2.4.6/customAsserts.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.4.6/customConstraints.html
+++ b/docs/2.4.6/customConstraints.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.4.6/customConstraints.html
+++ b/docs/2.4.6/customConstraints.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.4.6/customConstraints.html
+++ b/docs/2.4.6/customConstraints.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.4.6/customConstraints.html
+++ b/docs/2.4.6/customConstraints.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.4.6/description.html
+++ b/docs/2.4.6/description.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.4.6/description.html
+++ b/docs/2.4.6/description.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.4.6/description.html
+++ b/docs/2.4.6/description.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.4.6/description.html
+++ b/docs/2.4.6/description.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.4.6/docHome.html
+++ b/docs/2.4.6/docHome.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.4.6/docHome.html
+++ b/docs/2.4.6/docHome.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.4.6/docHome.html
+++ b/docs/2.4.6/docHome.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.4.6/docHome.html
+++ b/docs/2.4.6/docHome.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.4.6/equalConstraint.html
+++ b/docs/2.4.6/equalConstraint.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.4.6/equalConstraint.html
+++ b/docs/2.4.6/equalConstraint.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.4.6/equalConstraint.html
+++ b/docs/2.4.6/equalConstraint.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.4.6/equalConstraint.html
+++ b/docs/2.4.6/equalConstraint.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.4.6/equalityAsserts.html
+++ b/docs/2.4.6/equalityAsserts.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.4.6/equalityAsserts.html
+++ b/docs/2.4.6/equalityAsserts.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.4.6/equalityAsserts.html
+++ b/docs/2.4.6/equalityAsserts.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.4.6/equalityAsserts.html
+++ b/docs/2.4.6/equalityAsserts.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.4.6/exception.html
+++ b/docs/2.4.6/exception.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.4.6/exception.html
+++ b/docs/2.4.6/exception.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.4.6/exception.html
+++ b/docs/2.4.6/exception.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.4.6/exception.html
+++ b/docs/2.4.6/exception.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.4.6/explicit.html
+++ b/docs/2.4.6/explicit.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.4.6/explicit.html
+++ b/docs/2.4.6/explicit.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.4.6/explicit.html
+++ b/docs/2.4.6/explicit.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.4.6/explicit.html
+++ b/docs/2.4.6/explicit.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.4.6/extensibility.html
+++ b/docs/2.4.6/extensibility.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.4.6/extensibility.html
+++ b/docs/2.4.6/extensibility.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.4.6/extensibility.html
+++ b/docs/2.4.6/extensibility.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.4.6/extensibility.html
+++ b/docs/2.4.6/extensibility.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.4.6/features.html
+++ b/docs/2.4.6/features.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.4.6/features.html
+++ b/docs/2.4.6/features.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.4.6/features.html
+++ b/docs/2.4.6/features.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.4.6/features.html
+++ b/docs/2.4.6/features.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.4.6/fileAssert.html
+++ b/docs/2.4.6/fileAssert.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.4.6/fileAssert.html
+++ b/docs/2.4.6/fileAssert.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.4.6/fileAssert.html
+++ b/docs/2.4.6/fileAssert.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.4.6/fileAssert.html
+++ b/docs/2.4.6/fileAssert.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.4.6/fixtureSetup.html
+++ b/docs/2.4.6/fixtureSetup.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.4.6/fixtureSetup.html
+++ b/docs/2.4.6/fixtureSetup.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.4.6/fixtureSetup.html
+++ b/docs/2.4.6/fixtureSetup.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.4.6/fixtureSetup.html
+++ b/docs/2.4.6/fixtureSetup.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.4.6/fixtureTeardown.html
+++ b/docs/2.4.6/fixtureTeardown.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.4.6/fixtureTeardown.html
+++ b/docs/2.4.6/fixtureTeardown.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.4.6/fixtureTeardown.html
+++ b/docs/2.4.6/fixtureTeardown.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.4.6/fixtureTeardown.html
+++ b/docs/2.4.6/fixtureTeardown.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.4.6/getStarted.html
+++ b/docs/2.4.6/getStarted.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.4.6/getStarted.html
+++ b/docs/2.4.6/getStarted.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.4.6/getStarted.html
+++ b/docs/2.4.6/getStarted.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.4.6/getStarted.html
+++ b/docs/2.4.6/getStarted.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.4.6/guiCommandLine.html
+++ b/docs/2.4.6/guiCommandLine.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.4.6/guiCommandLine.html
+++ b/docs/2.4.6/guiCommandLine.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.4.6/guiCommandLine.html
+++ b/docs/2.4.6/guiCommandLine.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.4.6/guiCommandLine.html
+++ b/docs/2.4.6/guiCommandLine.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.4.6/identityAsserts.html
+++ b/docs/2.4.6/identityAsserts.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.4.6/identityAsserts.html
+++ b/docs/2.4.6/identityAsserts.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.4.6/identityAsserts.html
+++ b/docs/2.4.6/identityAsserts.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.4.6/identityAsserts.html
+++ b/docs/2.4.6/identityAsserts.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.4.6/ignore.html
+++ b/docs/2.4.6/ignore.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.4.6/ignore.html
+++ b/docs/2.4.6/ignore.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.4.6/ignore.html
+++ b/docs/2.4.6/ignore.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.4.6/ignore.html
+++ b/docs/2.4.6/ignore.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.4.6/installation.html
+++ b/docs/2.4.6/installation.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.4.6/installation.html
+++ b/docs/2.4.6/installation.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.4.6/installation.html
+++ b/docs/2.4.6/installation.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.4.6/installation.html
+++ b/docs/2.4.6/installation.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.4.6/license.html
+++ b/docs/2.4.6/license.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.4.6/license.html
+++ b/docs/2.4.6/license.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.4.6/license.html
+++ b/docs/2.4.6/license.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.4.6/license.html
+++ b/docs/2.4.6/license.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.4.6/listMapper.html
+++ b/docs/2.4.6/listMapper.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.4.6/listMapper.html
+++ b/docs/2.4.6/listMapper.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.4.6/listMapper.html
+++ b/docs/2.4.6/listMapper.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.4.6/listMapper.html
+++ b/docs/2.4.6/listMapper.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.4.6/mainMenu.html
+++ b/docs/2.4.6/mainMenu.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.4.6/mainMenu.html
+++ b/docs/2.4.6/mainMenu.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.4.6/mainMenu.html
+++ b/docs/2.4.6/mainMenu.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.4.6/mainMenu.html
+++ b/docs/2.4.6/mainMenu.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.4.6/multiAssembly.html
+++ b/docs/2.4.6/multiAssembly.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.4.6/multiAssembly.html
+++ b/docs/2.4.6/multiAssembly.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.4.6/multiAssembly.html
+++ b/docs/2.4.6/multiAssembly.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.4.6/multiAssembly.html
+++ b/docs/2.4.6/multiAssembly.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.4.6/nunit-console.html
+++ b/docs/2.4.6/nunit-console.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.4.6/nunit-console.html
+++ b/docs/2.4.6/nunit-console.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.4.6/nunit-console.html
+++ b/docs/2.4.6/nunit-console.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.4.6/nunit-console.html
+++ b/docs/2.4.6/nunit-console.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.4.6/nunit-gui.html
+++ b/docs/2.4.6/nunit-gui.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.4.6/nunit-gui.html
+++ b/docs/2.4.6/nunit-gui.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.4.6/nunit-gui.html
+++ b/docs/2.4.6/nunit-gui.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.4.6/nunit-gui.html
+++ b/docs/2.4.6/nunit-gui.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.4.6/nunitAddins.html
+++ b/docs/2.4.6/nunitAddins.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.4.6/nunitAddins.html
+++ b/docs/2.4.6/nunitAddins.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.4.6/nunitAddins.html
+++ b/docs/2.4.6/nunitAddins.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.4.6/nunitAddins.html
+++ b/docs/2.4.6/nunitAddins.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.4.6/optionsDialog.html
+++ b/docs/2.4.6/optionsDialog.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.4.6/optionsDialog.html
+++ b/docs/2.4.6/optionsDialog.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.4.6/optionsDialog.html
+++ b/docs/2.4.6/optionsDialog.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.4.6/optionsDialog.html
+++ b/docs/2.4.6/optionsDialog.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.4.6/platform.html
+++ b/docs/2.4.6/platform.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.4.6/platform.html
+++ b/docs/2.4.6/platform.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.4.6/platform.html
+++ b/docs/2.4.6/platform.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.4.6/platform.html
+++ b/docs/2.4.6/platform.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.4.6/projectEditor.html
+++ b/docs/2.4.6/projectEditor.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.4.6/projectEditor.html
+++ b/docs/2.4.6/projectEditor.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.4.6/projectEditor.html
+++ b/docs/2.4.6/projectEditor.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.4.6/projectEditor.html
+++ b/docs/2.4.6/projectEditor.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.4.6/property.html
+++ b/docs/2.4.6/property.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.4.6/property.html
+++ b/docs/2.4.6/property.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.4.6/property.html
+++ b/docs/2.4.6/property.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.4.6/property.html
+++ b/docs/2.4.6/property.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.4.6/propertyConstraint.html
+++ b/docs/2.4.6/propertyConstraint.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.4.6/propertyConstraint.html
+++ b/docs/2.4.6/propertyConstraint.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.4.6/propertyConstraint.html
+++ b/docs/2.4.6/propertyConstraint.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.4.6/propertyConstraint.html
+++ b/docs/2.4.6/propertyConstraint.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.4.6/quickStart.html
+++ b/docs/2.4.6/quickStart.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.4.6/quickStart.html
+++ b/docs/2.4.6/quickStart.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.4.6/quickStart.html
+++ b/docs/2.4.6/quickStart.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.4.6/quickStart.html
+++ b/docs/2.4.6/quickStart.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.4.6/quickStartSource.html
+++ b/docs/2.4.6/quickStartSource.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.4.6/quickStartSource.html
+++ b/docs/2.4.6/quickStartSource.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.4.6/quickStartSource.html
+++ b/docs/2.4.6/quickStartSource.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.4.6/quickStartSource.html
+++ b/docs/2.4.6/quickStartSource.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.4.6/releaseNotes.html
+++ b/docs/2.4.6/releaseNotes.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.4.6/releaseNotes.html
+++ b/docs/2.4.6/releaseNotes.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.4.6/releaseNotes.html
+++ b/docs/2.4.6/releaseNotes.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.4.6/releaseNotes.html
+++ b/docs/2.4.6/releaseNotes.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.4.6/sameasConstraint.html
+++ b/docs/2.4.6/sameasConstraint.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.4.6/sameasConstraint.html
+++ b/docs/2.4.6/sameasConstraint.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.4.6/sameasConstraint.html
+++ b/docs/2.4.6/sameasConstraint.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.4.6/sameasConstraint.html
+++ b/docs/2.4.6/sameasConstraint.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.4.6/samples.html
+++ b/docs/2.4.6/samples.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.4.6/samples.html
+++ b/docs/2.4.6/samples.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.4.6/samples.html
+++ b/docs/2.4.6/samples.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.4.6/samples.html
+++ b/docs/2.4.6/samples.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.4.6/setCulture.html
+++ b/docs/2.4.6/setCulture.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.4.6/setCulture.html
+++ b/docs/2.4.6/setCulture.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.4.6/setCulture.html
+++ b/docs/2.4.6/setCulture.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.4.6/setCulture.html
+++ b/docs/2.4.6/setCulture.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.4.6/setup.html
+++ b/docs/2.4.6/setup.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.4.6/setup.html
+++ b/docs/2.4.6/setup.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.4.6/setup.html
+++ b/docs/2.4.6/setup.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.4.6/setup.html
+++ b/docs/2.4.6/setup.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.4.6/setupFixture.html
+++ b/docs/2.4.6/setupFixture.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.4.6/setupFixture.html
+++ b/docs/2.4.6/setupFixture.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.4.6/setupFixture.html
+++ b/docs/2.4.6/setupFixture.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.4.6/setupFixture.html
+++ b/docs/2.4.6/setupFixture.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.4.6/stringAssert.html
+++ b/docs/2.4.6/stringAssert.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.4.6/stringAssert.html
+++ b/docs/2.4.6/stringAssert.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.4.6/stringAssert.html
+++ b/docs/2.4.6/stringAssert.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.4.6/stringAssert.html
+++ b/docs/2.4.6/stringAssert.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.4.6/stringConstraints.html
+++ b/docs/2.4.6/stringConstraints.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.4.6/stringConstraints.html
+++ b/docs/2.4.6/stringConstraints.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.4.6/stringConstraints.html
+++ b/docs/2.4.6/stringConstraints.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.4.6/stringConstraints.html
+++ b/docs/2.4.6/stringConstraints.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.4.6/suite.html
+++ b/docs/2.4.6/suite.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.4.6/suite.html
+++ b/docs/2.4.6/suite.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.4.6/suite.html
+++ b/docs/2.4.6/suite.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.4.6/suite.html
+++ b/docs/2.4.6/suite.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.4.6/teardown.html
+++ b/docs/2.4.6/teardown.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.4.6/teardown.html
+++ b/docs/2.4.6/teardown.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.4.6/teardown.html
+++ b/docs/2.4.6/teardown.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.4.6/teardown.html
+++ b/docs/2.4.6/teardown.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.4.6/test.html
+++ b/docs/2.4.6/test.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.4.6/test.html
+++ b/docs/2.4.6/test.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.4.6/test.html
+++ b/docs/2.4.6/test.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.4.6/test.html
+++ b/docs/2.4.6/test.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.4.6/testFixture.html
+++ b/docs/2.4.6/testFixture.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.4.6/testFixture.html
+++ b/docs/2.4.6/testFixture.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.4.6/testFixture.html
+++ b/docs/2.4.6/testFixture.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.4.6/testFixture.html
+++ b/docs/2.4.6/testFixture.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.4.6/testProperties.html
+++ b/docs/2.4.6/testProperties.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.4.6/testProperties.html
+++ b/docs/2.4.6/testProperties.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.4.6/testProperties.html
+++ b/docs/2.4.6/testProperties.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.4.6/testProperties.html
+++ b/docs/2.4.6/testProperties.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.4.6/typeAsserts.html
+++ b/docs/2.4.6/typeAsserts.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.4.6/typeAsserts.html
+++ b/docs/2.4.6/typeAsserts.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.4.6/typeAsserts.html
+++ b/docs/2.4.6/typeAsserts.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.4.6/typeAsserts.html
+++ b/docs/2.4.6/typeAsserts.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.4.6/typeConstraints.html
+++ b/docs/2.4.6/typeConstraints.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.4.6/typeConstraints.html
+++ b/docs/2.4.6/typeConstraints.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.4.6/typeConstraints.html
+++ b/docs/2.4.6/typeConstraints.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.4.6/typeConstraints.html
+++ b/docs/2.4.6/typeConstraints.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.4.6/upgrade.html
+++ b/docs/2.4.6/upgrade.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.4.6/upgrade.html
+++ b/docs/2.4.6/upgrade.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.4.6/upgrade.html
+++ b/docs/2.4.6/upgrade.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.4.6/upgrade.html
+++ b/docs/2.4.6/upgrade.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.4.6/utilityAsserts.html
+++ b/docs/2.4.6/utilityAsserts.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.4.6/utilityAsserts.html
+++ b/docs/2.4.6/utilityAsserts.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.4.6/utilityAsserts.html
+++ b/docs/2.4.6/utilityAsserts.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.4.6/utilityAsserts.html
+++ b/docs/2.4.6/utilityAsserts.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.4.6/vsSupport.html
+++ b/docs/2.4.6/vsSupport.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.4.6/vsSupport.html
+++ b/docs/2.4.6/vsSupport.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.4.6/vsSupport.html
+++ b/docs/2.4.6/vsSupport.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.4.6/vsSupport.html
+++ b/docs/2.4.6/vsSupport.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.4.7/addinsDialog.html
+++ b/docs/2.4.7/addinsDialog.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.4.7/addinsDialog.html
+++ b/docs/2.4.7/addinsDialog.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.4.7/addinsDialog.html
+++ b/docs/2.4.7/addinsDialog.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.4.7/addinsDialog.html
+++ b/docs/2.4.7/addinsDialog.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.4.7/assertions.html
+++ b/docs/2.4.7/assertions.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.4.7/assertions.html
+++ b/docs/2.4.7/assertions.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.4.7/assertions.html
+++ b/docs/2.4.7/assertions.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.4.7/assertions.html
+++ b/docs/2.4.7/assertions.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.4.7/attributes.html
+++ b/docs/2.4.7/attributes.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.4.7/attributes.html
+++ b/docs/2.4.7/attributes.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.4.7/attributes.html
+++ b/docs/2.4.7/attributes.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.4.7/attributes.html
+++ b/docs/2.4.7/attributes.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.4.7/category.html
+++ b/docs/2.4.7/category.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.4.7/category.html
+++ b/docs/2.4.7/category.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.4.7/category.html
+++ b/docs/2.4.7/category.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.4.7/category.html
+++ b/docs/2.4.7/category.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.4.7/classicModel.html
+++ b/docs/2.4.7/classicModel.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.4.7/classicModel.html
+++ b/docs/2.4.7/classicModel.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.4.7/classicModel.html
+++ b/docs/2.4.7/classicModel.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.4.7/classicModel.html
+++ b/docs/2.4.7/classicModel.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.4.7/collectionAssert.html
+++ b/docs/2.4.7/collectionAssert.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.4.7/collectionAssert.html
+++ b/docs/2.4.7/collectionAssert.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.4.7/collectionAssert.html
+++ b/docs/2.4.7/collectionAssert.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.4.7/collectionAssert.html
+++ b/docs/2.4.7/collectionAssert.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.4.7/collectionConstraints.html
+++ b/docs/2.4.7/collectionConstraints.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.4.7/collectionConstraints.html
+++ b/docs/2.4.7/collectionConstraints.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.4.7/collectionConstraints.html
+++ b/docs/2.4.7/collectionConstraints.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.4.7/collectionConstraints.html
+++ b/docs/2.4.7/collectionConstraints.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.4.7/comparisonAsserts.html
+++ b/docs/2.4.7/comparisonAsserts.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.4.7/comparisonAsserts.html
+++ b/docs/2.4.7/comparisonAsserts.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.4.7/comparisonAsserts.html
+++ b/docs/2.4.7/comparisonAsserts.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.4.7/comparisonAsserts.html
+++ b/docs/2.4.7/comparisonAsserts.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.4.7/comparisonConstraints.html
+++ b/docs/2.4.7/comparisonConstraints.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.4.7/comparisonConstraints.html
+++ b/docs/2.4.7/comparisonConstraints.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.4.7/comparisonConstraints.html
+++ b/docs/2.4.7/comparisonConstraints.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.4.7/comparisonConstraints.html
+++ b/docs/2.4.7/comparisonConstraints.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.4.7/compoundConstraints.html
+++ b/docs/2.4.7/compoundConstraints.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.4.7/compoundConstraints.html
+++ b/docs/2.4.7/compoundConstraints.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.4.7/compoundConstraints.html
+++ b/docs/2.4.7/compoundConstraints.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.4.7/compoundConstraints.html
+++ b/docs/2.4.7/compoundConstraints.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.4.7/conditionAsserts.html
+++ b/docs/2.4.7/conditionAsserts.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.4.7/conditionAsserts.html
+++ b/docs/2.4.7/conditionAsserts.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.4.7/conditionAsserts.html
+++ b/docs/2.4.7/conditionAsserts.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.4.7/conditionAsserts.html
+++ b/docs/2.4.7/conditionAsserts.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.4.7/conditionConstraints.html
+++ b/docs/2.4.7/conditionConstraints.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.4.7/conditionConstraints.html
+++ b/docs/2.4.7/conditionConstraints.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.4.7/conditionConstraints.html
+++ b/docs/2.4.7/conditionConstraints.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.4.7/conditionConstraints.html
+++ b/docs/2.4.7/conditionConstraints.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.4.7/configEditor.html
+++ b/docs/2.4.7/configEditor.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.4.7/configEditor.html
+++ b/docs/2.4.7/configEditor.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.4.7/configEditor.html
+++ b/docs/2.4.7/configEditor.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.4.7/configEditor.html
+++ b/docs/2.4.7/configEditor.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.4.7/configFiles.html
+++ b/docs/2.4.7/configFiles.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.4.7/configFiles.html
+++ b/docs/2.4.7/configFiles.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.4.7/configFiles.html
+++ b/docs/2.4.7/configFiles.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.4.7/configFiles.html
+++ b/docs/2.4.7/configFiles.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.4.7/consoleCommandLine.html
+++ b/docs/2.4.7/consoleCommandLine.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.4.7/consoleCommandLine.html
+++ b/docs/2.4.7/consoleCommandLine.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.4.7/consoleCommandLine.html
+++ b/docs/2.4.7/consoleCommandLine.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.4.7/consoleCommandLine.html
+++ b/docs/2.4.7/consoleCommandLine.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.4.7/constraintModel.html
+++ b/docs/2.4.7/constraintModel.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.4.7/constraintModel.html
+++ b/docs/2.4.7/constraintModel.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.4.7/constraintModel.html
+++ b/docs/2.4.7/constraintModel.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.4.7/constraintModel.html
+++ b/docs/2.4.7/constraintModel.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.4.7/contextMenu.html
+++ b/docs/2.4.7/contextMenu.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.4.7/contextMenu.html
+++ b/docs/2.4.7/contextMenu.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.4.7/contextMenu.html
+++ b/docs/2.4.7/contextMenu.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.4.7/contextMenu.html
+++ b/docs/2.4.7/contextMenu.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.4.7/culture.html
+++ b/docs/2.4.7/culture.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.4.7/culture.html
+++ b/docs/2.4.7/culture.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.4.7/culture.html
+++ b/docs/2.4.7/culture.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.4.7/culture.html
+++ b/docs/2.4.7/culture.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.4.7/customAsserts.html
+++ b/docs/2.4.7/customAsserts.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.4.7/customAsserts.html
+++ b/docs/2.4.7/customAsserts.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.4.7/customAsserts.html
+++ b/docs/2.4.7/customAsserts.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.4.7/customAsserts.html
+++ b/docs/2.4.7/customAsserts.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.4.7/customConstraints.html
+++ b/docs/2.4.7/customConstraints.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.4.7/customConstraints.html
+++ b/docs/2.4.7/customConstraints.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.4.7/customConstraints.html
+++ b/docs/2.4.7/customConstraints.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.4.7/customConstraints.html
+++ b/docs/2.4.7/customConstraints.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.4.7/description.html
+++ b/docs/2.4.7/description.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.4.7/description.html
+++ b/docs/2.4.7/description.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.4.7/description.html
+++ b/docs/2.4.7/description.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.4.7/description.html
+++ b/docs/2.4.7/description.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.4.7/docHome.html
+++ b/docs/2.4.7/docHome.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.4.7/docHome.html
+++ b/docs/2.4.7/docHome.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.4.7/docHome.html
+++ b/docs/2.4.7/docHome.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.4.7/docHome.html
+++ b/docs/2.4.7/docHome.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.4.7/equalConstraint.html
+++ b/docs/2.4.7/equalConstraint.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.4.7/equalConstraint.html
+++ b/docs/2.4.7/equalConstraint.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.4.7/equalConstraint.html
+++ b/docs/2.4.7/equalConstraint.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.4.7/equalConstraint.html
+++ b/docs/2.4.7/equalConstraint.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.4.7/equalityAsserts.html
+++ b/docs/2.4.7/equalityAsserts.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.4.7/equalityAsserts.html
+++ b/docs/2.4.7/equalityAsserts.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.4.7/equalityAsserts.html
+++ b/docs/2.4.7/equalityAsserts.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.4.7/equalityAsserts.html
+++ b/docs/2.4.7/equalityAsserts.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.4.7/exception.html
+++ b/docs/2.4.7/exception.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.4.7/exception.html
+++ b/docs/2.4.7/exception.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.4.7/exception.html
+++ b/docs/2.4.7/exception.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.4.7/exception.html
+++ b/docs/2.4.7/exception.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.4.7/explicit.html
+++ b/docs/2.4.7/explicit.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.4.7/explicit.html
+++ b/docs/2.4.7/explicit.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.4.7/explicit.html
+++ b/docs/2.4.7/explicit.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.4.7/explicit.html
+++ b/docs/2.4.7/explicit.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.4.7/extensibility.html
+++ b/docs/2.4.7/extensibility.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.4.7/extensibility.html
+++ b/docs/2.4.7/extensibility.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.4.7/extensibility.html
+++ b/docs/2.4.7/extensibility.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.4.7/extensibility.html
+++ b/docs/2.4.7/extensibility.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.4.7/features.html
+++ b/docs/2.4.7/features.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.4.7/features.html
+++ b/docs/2.4.7/features.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.4.7/features.html
+++ b/docs/2.4.7/features.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.4.7/features.html
+++ b/docs/2.4.7/features.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.4.7/fileAssert.html
+++ b/docs/2.4.7/fileAssert.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.4.7/fileAssert.html
+++ b/docs/2.4.7/fileAssert.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.4.7/fileAssert.html
+++ b/docs/2.4.7/fileAssert.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.4.7/fileAssert.html
+++ b/docs/2.4.7/fileAssert.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.4.7/fixtureSetup.html
+++ b/docs/2.4.7/fixtureSetup.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.4.7/fixtureSetup.html
+++ b/docs/2.4.7/fixtureSetup.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.4.7/fixtureSetup.html
+++ b/docs/2.4.7/fixtureSetup.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.4.7/fixtureSetup.html
+++ b/docs/2.4.7/fixtureSetup.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.4.7/fixtureTeardown.html
+++ b/docs/2.4.7/fixtureTeardown.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.4.7/fixtureTeardown.html
+++ b/docs/2.4.7/fixtureTeardown.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.4.7/fixtureTeardown.html
+++ b/docs/2.4.7/fixtureTeardown.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.4.7/fixtureTeardown.html
+++ b/docs/2.4.7/fixtureTeardown.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.4.7/getStarted.html
+++ b/docs/2.4.7/getStarted.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.4.7/getStarted.html
+++ b/docs/2.4.7/getStarted.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.4.7/getStarted.html
+++ b/docs/2.4.7/getStarted.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.4.7/getStarted.html
+++ b/docs/2.4.7/getStarted.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.4.7/guiCommandLine.html
+++ b/docs/2.4.7/guiCommandLine.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.4.7/guiCommandLine.html
+++ b/docs/2.4.7/guiCommandLine.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.4.7/guiCommandLine.html
+++ b/docs/2.4.7/guiCommandLine.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.4.7/guiCommandLine.html
+++ b/docs/2.4.7/guiCommandLine.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.4.7/identityAsserts.html
+++ b/docs/2.4.7/identityAsserts.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.4.7/identityAsserts.html
+++ b/docs/2.4.7/identityAsserts.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.4.7/identityAsserts.html
+++ b/docs/2.4.7/identityAsserts.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.4.7/identityAsserts.html
+++ b/docs/2.4.7/identityAsserts.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.4.7/ignore.html
+++ b/docs/2.4.7/ignore.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.4.7/ignore.html
+++ b/docs/2.4.7/ignore.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.4.7/ignore.html
+++ b/docs/2.4.7/ignore.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.4.7/ignore.html
+++ b/docs/2.4.7/ignore.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.4.7/installation.html
+++ b/docs/2.4.7/installation.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.4.7/installation.html
+++ b/docs/2.4.7/installation.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.4.7/installation.html
+++ b/docs/2.4.7/installation.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.4.7/installation.html
+++ b/docs/2.4.7/installation.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.4.7/license.html
+++ b/docs/2.4.7/license.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.4.7/license.html
+++ b/docs/2.4.7/license.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.4.7/license.html
+++ b/docs/2.4.7/license.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.4.7/license.html
+++ b/docs/2.4.7/license.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.4.7/listMapper.html
+++ b/docs/2.4.7/listMapper.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.4.7/listMapper.html
+++ b/docs/2.4.7/listMapper.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.4.7/listMapper.html
+++ b/docs/2.4.7/listMapper.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.4.7/listMapper.html
+++ b/docs/2.4.7/listMapper.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.4.7/mainMenu.html
+++ b/docs/2.4.7/mainMenu.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.4.7/mainMenu.html
+++ b/docs/2.4.7/mainMenu.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.4.7/mainMenu.html
+++ b/docs/2.4.7/mainMenu.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.4.7/mainMenu.html
+++ b/docs/2.4.7/mainMenu.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.4.7/multiAssembly.html
+++ b/docs/2.4.7/multiAssembly.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.4.7/multiAssembly.html
+++ b/docs/2.4.7/multiAssembly.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.4.7/multiAssembly.html
+++ b/docs/2.4.7/multiAssembly.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.4.7/multiAssembly.html
+++ b/docs/2.4.7/multiAssembly.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.4.7/nunit-console.html
+++ b/docs/2.4.7/nunit-console.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.4.7/nunit-console.html
+++ b/docs/2.4.7/nunit-console.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.4.7/nunit-console.html
+++ b/docs/2.4.7/nunit-console.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.4.7/nunit-console.html
+++ b/docs/2.4.7/nunit-console.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.4.7/nunit-gui.html
+++ b/docs/2.4.7/nunit-gui.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.4.7/nunit-gui.html
+++ b/docs/2.4.7/nunit-gui.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.4.7/nunit-gui.html
+++ b/docs/2.4.7/nunit-gui.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.4.7/nunit-gui.html
+++ b/docs/2.4.7/nunit-gui.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.4.7/nunitAddins.html
+++ b/docs/2.4.7/nunitAddins.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.4.7/nunitAddins.html
+++ b/docs/2.4.7/nunitAddins.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.4.7/nunitAddins.html
+++ b/docs/2.4.7/nunitAddins.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.4.7/nunitAddins.html
+++ b/docs/2.4.7/nunitAddins.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.4.7/optionsDialog.html
+++ b/docs/2.4.7/optionsDialog.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.4.7/optionsDialog.html
+++ b/docs/2.4.7/optionsDialog.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.4.7/optionsDialog.html
+++ b/docs/2.4.7/optionsDialog.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.4.7/optionsDialog.html
+++ b/docs/2.4.7/optionsDialog.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.4.7/platform.html
+++ b/docs/2.4.7/platform.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.4.7/platform.html
+++ b/docs/2.4.7/platform.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.4.7/platform.html
+++ b/docs/2.4.7/platform.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.4.7/platform.html
+++ b/docs/2.4.7/platform.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.4.7/projectEditor.html
+++ b/docs/2.4.7/projectEditor.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.4.7/projectEditor.html
+++ b/docs/2.4.7/projectEditor.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.4.7/projectEditor.html
+++ b/docs/2.4.7/projectEditor.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.4.7/projectEditor.html
+++ b/docs/2.4.7/projectEditor.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.4.7/property.html
+++ b/docs/2.4.7/property.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.4.7/property.html
+++ b/docs/2.4.7/property.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.4.7/property.html
+++ b/docs/2.4.7/property.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.4.7/property.html
+++ b/docs/2.4.7/property.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.4.7/propertyConstraint.html
+++ b/docs/2.4.7/propertyConstraint.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.4.7/propertyConstraint.html
+++ b/docs/2.4.7/propertyConstraint.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.4.7/propertyConstraint.html
+++ b/docs/2.4.7/propertyConstraint.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.4.7/propertyConstraint.html
+++ b/docs/2.4.7/propertyConstraint.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.4.7/quickStart.html
+++ b/docs/2.4.7/quickStart.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.4.7/quickStart.html
+++ b/docs/2.4.7/quickStart.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.4.7/quickStart.html
+++ b/docs/2.4.7/quickStart.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.4.7/quickStart.html
+++ b/docs/2.4.7/quickStart.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.4.7/quickStartSource.html
+++ b/docs/2.4.7/quickStartSource.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.4.7/quickStartSource.html
+++ b/docs/2.4.7/quickStartSource.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.4.7/quickStartSource.html
+++ b/docs/2.4.7/quickStartSource.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.4.7/quickStartSource.html
+++ b/docs/2.4.7/quickStartSource.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.4.7/releaseNotes.html
+++ b/docs/2.4.7/releaseNotes.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.4.7/releaseNotes.html
+++ b/docs/2.4.7/releaseNotes.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.4.7/releaseNotes.html
+++ b/docs/2.4.7/releaseNotes.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.4.7/releaseNotes.html
+++ b/docs/2.4.7/releaseNotes.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.4.7/sameasConstraint.html
+++ b/docs/2.4.7/sameasConstraint.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.4.7/sameasConstraint.html
+++ b/docs/2.4.7/sameasConstraint.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.4.7/sameasConstraint.html
+++ b/docs/2.4.7/sameasConstraint.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.4.7/sameasConstraint.html
+++ b/docs/2.4.7/sameasConstraint.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.4.7/samples.html
+++ b/docs/2.4.7/samples.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.4.7/samples.html
+++ b/docs/2.4.7/samples.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.4.7/samples.html
+++ b/docs/2.4.7/samples.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.4.7/samples.html
+++ b/docs/2.4.7/samples.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.4.7/setCulture.html
+++ b/docs/2.4.7/setCulture.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.4.7/setCulture.html
+++ b/docs/2.4.7/setCulture.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.4.7/setCulture.html
+++ b/docs/2.4.7/setCulture.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.4.7/setCulture.html
+++ b/docs/2.4.7/setCulture.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.4.7/setup.html
+++ b/docs/2.4.7/setup.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.4.7/setup.html
+++ b/docs/2.4.7/setup.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.4.7/setup.html
+++ b/docs/2.4.7/setup.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.4.7/setup.html
+++ b/docs/2.4.7/setup.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.4.7/setupFixture.html
+++ b/docs/2.4.7/setupFixture.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.4.7/setupFixture.html
+++ b/docs/2.4.7/setupFixture.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.4.7/setupFixture.html
+++ b/docs/2.4.7/setupFixture.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.4.7/setupFixture.html
+++ b/docs/2.4.7/setupFixture.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.4.7/stringAssert.html
+++ b/docs/2.4.7/stringAssert.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.4.7/stringAssert.html
+++ b/docs/2.4.7/stringAssert.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.4.7/stringAssert.html
+++ b/docs/2.4.7/stringAssert.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.4.7/stringAssert.html
+++ b/docs/2.4.7/stringAssert.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.4.7/stringConstraints.html
+++ b/docs/2.4.7/stringConstraints.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.4.7/stringConstraints.html
+++ b/docs/2.4.7/stringConstraints.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.4.7/stringConstraints.html
+++ b/docs/2.4.7/stringConstraints.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.4.7/stringConstraints.html
+++ b/docs/2.4.7/stringConstraints.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.4.7/suite.html
+++ b/docs/2.4.7/suite.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.4.7/suite.html
+++ b/docs/2.4.7/suite.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.4.7/suite.html
+++ b/docs/2.4.7/suite.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.4.7/suite.html
+++ b/docs/2.4.7/suite.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.4.7/teardown.html
+++ b/docs/2.4.7/teardown.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.4.7/teardown.html
+++ b/docs/2.4.7/teardown.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.4.7/teardown.html
+++ b/docs/2.4.7/teardown.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.4.7/teardown.html
+++ b/docs/2.4.7/teardown.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.4.7/test.html
+++ b/docs/2.4.7/test.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.4.7/test.html
+++ b/docs/2.4.7/test.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.4.7/test.html
+++ b/docs/2.4.7/test.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.4.7/test.html
+++ b/docs/2.4.7/test.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.4.7/testFixture.html
+++ b/docs/2.4.7/testFixture.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.4.7/testFixture.html
+++ b/docs/2.4.7/testFixture.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.4.7/testFixture.html
+++ b/docs/2.4.7/testFixture.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.4.7/testFixture.html
+++ b/docs/2.4.7/testFixture.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.4.7/testProperties.html
+++ b/docs/2.4.7/testProperties.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.4.7/testProperties.html
+++ b/docs/2.4.7/testProperties.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.4.7/testProperties.html
+++ b/docs/2.4.7/testProperties.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.4.7/testProperties.html
+++ b/docs/2.4.7/testProperties.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.4.7/typeAsserts.html
+++ b/docs/2.4.7/typeAsserts.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.4.7/typeAsserts.html
+++ b/docs/2.4.7/typeAsserts.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.4.7/typeAsserts.html
+++ b/docs/2.4.7/typeAsserts.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.4.7/typeAsserts.html
+++ b/docs/2.4.7/typeAsserts.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.4.7/typeConstraints.html
+++ b/docs/2.4.7/typeConstraints.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.4.7/typeConstraints.html
+++ b/docs/2.4.7/typeConstraints.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.4.7/typeConstraints.html
+++ b/docs/2.4.7/typeConstraints.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.4.7/typeConstraints.html
+++ b/docs/2.4.7/typeConstraints.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.4.7/upgrade.html
+++ b/docs/2.4.7/upgrade.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.4.7/upgrade.html
+++ b/docs/2.4.7/upgrade.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.4.7/upgrade.html
+++ b/docs/2.4.7/upgrade.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.4.7/upgrade.html
+++ b/docs/2.4.7/upgrade.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.4.7/utilityAsserts.html
+++ b/docs/2.4.7/utilityAsserts.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.4.7/utilityAsserts.html
+++ b/docs/2.4.7/utilityAsserts.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.4.7/utilityAsserts.html
+++ b/docs/2.4.7/utilityAsserts.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.4.7/utilityAsserts.html
+++ b/docs/2.4.7/utilityAsserts.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.4.7/vsSupport.html
+++ b/docs/2.4.7/vsSupport.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.4.7/vsSupport.html
+++ b/docs/2.4.7/vsSupport.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.4.7/vsSupport.html
+++ b/docs/2.4.7/vsSupport.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.4.7/vsSupport.html
+++ b/docs/2.4.7/vsSupport.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.4.8/addinsDialog.html
+++ b/docs/2.4.8/addinsDialog.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.4.8/addinsDialog.html
+++ b/docs/2.4.8/addinsDialog.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.4.8/addinsDialog.html
+++ b/docs/2.4.8/addinsDialog.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.4.8/addinsDialog.html
+++ b/docs/2.4.8/addinsDialog.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.4.8/assertions.html
+++ b/docs/2.4.8/assertions.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.4.8/assertions.html
+++ b/docs/2.4.8/assertions.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.4.8/assertions.html
+++ b/docs/2.4.8/assertions.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.4.8/assertions.html
+++ b/docs/2.4.8/assertions.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.4.8/attributes.html
+++ b/docs/2.4.8/attributes.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.4.8/attributes.html
+++ b/docs/2.4.8/attributes.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.4.8/attributes.html
+++ b/docs/2.4.8/attributes.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.4.8/attributes.html
+++ b/docs/2.4.8/attributes.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.4.8/category.html
+++ b/docs/2.4.8/category.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.4.8/category.html
+++ b/docs/2.4.8/category.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.4.8/category.html
+++ b/docs/2.4.8/category.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.4.8/category.html
+++ b/docs/2.4.8/category.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.4.8/classicModel.html
+++ b/docs/2.4.8/classicModel.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.4.8/classicModel.html
+++ b/docs/2.4.8/classicModel.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.4.8/classicModel.html
+++ b/docs/2.4.8/classicModel.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.4.8/classicModel.html
+++ b/docs/2.4.8/classicModel.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.4.8/collectionAssert.html
+++ b/docs/2.4.8/collectionAssert.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.4.8/collectionAssert.html
+++ b/docs/2.4.8/collectionAssert.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.4.8/collectionAssert.html
+++ b/docs/2.4.8/collectionAssert.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.4.8/collectionAssert.html
+++ b/docs/2.4.8/collectionAssert.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.4.8/collectionConstraints.html
+++ b/docs/2.4.8/collectionConstraints.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.4.8/collectionConstraints.html
+++ b/docs/2.4.8/collectionConstraints.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.4.8/collectionConstraints.html
+++ b/docs/2.4.8/collectionConstraints.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.4.8/collectionConstraints.html
+++ b/docs/2.4.8/collectionConstraints.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.4.8/comparisonAsserts.html
+++ b/docs/2.4.8/comparisonAsserts.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.4.8/comparisonAsserts.html
+++ b/docs/2.4.8/comparisonAsserts.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.4.8/comparisonAsserts.html
+++ b/docs/2.4.8/comparisonAsserts.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.4.8/comparisonAsserts.html
+++ b/docs/2.4.8/comparisonAsserts.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.4.8/comparisonConstraints.html
+++ b/docs/2.4.8/comparisonConstraints.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.4.8/comparisonConstraints.html
+++ b/docs/2.4.8/comparisonConstraints.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.4.8/comparisonConstraints.html
+++ b/docs/2.4.8/comparisonConstraints.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.4.8/comparisonConstraints.html
+++ b/docs/2.4.8/comparisonConstraints.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.4.8/compoundConstraints.html
+++ b/docs/2.4.8/compoundConstraints.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.4.8/compoundConstraints.html
+++ b/docs/2.4.8/compoundConstraints.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.4.8/compoundConstraints.html
+++ b/docs/2.4.8/compoundConstraints.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.4.8/compoundConstraints.html
+++ b/docs/2.4.8/compoundConstraints.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.4.8/conditionAsserts.html
+++ b/docs/2.4.8/conditionAsserts.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.4.8/conditionAsserts.html
+++ b/docs/2.4.8/conditionAsserts.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.4.8/conditionAsserts.html
+++ b/docs/2.4.8/conditionAsserts.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.4.8/conditionAsserts.html
+++ b/docs/2.4.8/conditionAsserts.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.4.8/conditionConstraints.html
+++ b/docs/2.4.8/conditionConstraints.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.4.8/conditionConstraints.html
+++ b/docs/2.4.8/conditionConstraints.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.4.8/conditionConstraints.html
+++ b/docs/2.4.8/conditionConstraints.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.4.8/conditionConstraints.html
+++ b/docs/2.4.8/conditionConstraints.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.4.8/configEditor.html
+++ b/docs/2.4.8/configEditor.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.4.8/configEditor.html
+++ b/docs/2.4.8/configEditor.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.4.8/configEditor.html
+++ b/docs/2.4.8/configEditor.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.4.8/configEditor.html
+++ b/docs/2.4.8/configEditor.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.4.8/configFiles.html
+++ b/docs/2.4.8/configFiles.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.4.8/configFiles.html
+++ b/docs/2.4.8/configFiles.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.4.8/configFiles.html
+++ b/docs/2.4.8/configFiles.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.4.8/configFiles.html
+++ b/docs/2.4.8/configFiles.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.4.8/consoleCommandLine.html
+++ b/docs/2.4.8/consoleCommandLine.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.4.8/consoleCommandLine.html
+++ b/docs/2.4.8/consoleCommandLine.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.4.8/consoleCommandLine.html
+++ b/docs/2.4.8/consoleCommandLine.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.4.8/consoleCommandLine.html
+++ b/docs/2.4.8/consoleCommandLine.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.4.8/constraintModel.html
+++ b/docs/2.4.8/constraintModel.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.4.8/constraintModel.html
+++ b/docs/2.4.8/constraintModel.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.4.8/constraintModel.html
+++ b/docs/2.4.8/constraintModel.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.4.8/constraintModel.html
+++ b/docs/2.4.8/constraintModel.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.4.8/contextMenu.html
+++ b/docs/2.4.8/contextMenu.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.4.8/contextMenu.html
+++ b/docs/2.4.8/contextMenu.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.4.8/contextMenu.html
+++ b/docs/2.4.8/contextMenu.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.4.8/contextMenu.html
+++ b/docs/2.4.8/contextMenu.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.4.8/culture.html
+++ b/docs/2.4.8/culture.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.4.8/culture.html
+++ b/docs/2.4.8/culture.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.4.8/culture.html
+++ b/docs/2.4.8/culture.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.4.8/culture.html
+++ b/docs/2.4.8/culture.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.4.8/customAsserts.html
+++ b/docs/2.4.8/customAsserts.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.4.8/customAsserts.html
+++ b/docs/2.4.8/customAsserts.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.4.8/customAsserts.html
+++ b/docs/2.4.8/customAsserts.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.4.8/customAsserts.html
+++ b/docs/2.4.8/customAsserts.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.4.8/customConstraints.html
+++ b/docs/2.4.8/customConstraints.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.4.8/customConstraints.html
+++ b/docs/2.4.8/customConstraints.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.4.8/customConstraints.html
+++ b/docs/2.4.8/customConstraints.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.4.8/customConstraints.html
+++ b/docs/2.4.8/customConstraints.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.4.8/description.html
+++ b/docs/2.4.8/description.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.4.8/description.html
+++ b/docs/2.4.8/description.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.4.8/description.html
+++ b/docs/2.4.8/description.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.4.8/description.html
+++ b/docs/2.4.8/description.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.4.8/docHome.html
+++ b/docs/2.4.8/docHome.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.4.8/docHome.html
+++ b/docs/2.4.8/docHome.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.4.8/docHome.html
+++ b/docs/2.4.8/docHome.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.4.8/docHome.html
+++ b/docs/2.4.8/docHome.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.4.8/equalConstraint.html
+++ b/docs/2.4.8/equalConstraint.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.4.8/equalConstraint.html
+++ b/docs/2.4.8/equalConstraint.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.4.8/equalConstraint.html
+++ b/docs/2.4.8/equalConstraint.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.4.8/equalConstraint.html
+++ b/docs/2.4.8/equalConstraint.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.4.8/equalityAsserts.html
+++ b/docs/2.4.8/equalityAsserts.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.4.8/equalityAsserts.html
+++ b/docs/2.4.8/equalityAsserts.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.4.8/equalityAsserts.html
+++ b/docs/2.4.8/equalityAsserts.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.4.8/equalityAsserts.html
+++ b/docs/2.4.8/equalityAsserts.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.4.8/exception.html
+++ b/docs/2.4.8/exception.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.4.8/exception.html
+++ b/docs/2.4.8/exception.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.4.8/exception.html
+++ b/docs/2.4.8/exception.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.4.8/exception.html
+++ b/docs/2.4.8/exception.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.4.8/explicit.html
+++ b/docs/2.4.8/explicit.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.4.8/explicit.html
+++ b/docs/2.4.8/explicit.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.4.8/explicit.html
+++ b/docs/2.4.8/explicit.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.4.8/explicit.html
+++ b/docs/2.4.8/explicit.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.4.8/extensibility.html
+++ b/docs/2.4.8/extensibility.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.4.8/extensibility.html
+++ b/docs/2.4.8/extensibility.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.4.8/extensibility.html
+++ b/docs/2.4.8/extensibility.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.4.8/extensibility.html
+++ b/docs/2.4.8/extensibility.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.4.8/features.html
+++ b/docs/2.4.8/features.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.4.8/features.html
+++ b/docs/2.4.8/features.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.4.8/features.html
+++ b/docs/2.4.8/features.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.4.8/features.html
+++ b/docs/2.4.8/features.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.4.8/fileAssert.html
+++ b/docs/2.4.8/fileAssert.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.4.8/fileAssert.html
+++ b/docs/2.4.8/fileAssert.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.4.8/fileAssert.html
+++ b/docs/2.4.8/fileAssert.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.4.8/fileAssert.html
+++ b/docs/2.4.8/fileAssert.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.4.8/fixtureSetup.html
+++ b/docs/2.4.8/fixtureSetup.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.4.8/fixtureSetup.html
+++ b/docs/2.4.8/fixtureSetup.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.4.8/fixtureSetup.html
+++ b/docs/2.4.8/fixtureSetup.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.4.8/fixtureSetup.html
+++ b/docs/2.4.8/fixtureSetup.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.4.8/fixtureTeardown.html
+++ b/docs/2.4.8/fixtureTeardown.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.4.8/fixtureTeardown.html
+++ b/docs/2.4.8/fixtureTeardown.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.4.8/fixtureTeardown.html
+++ b/docs/2.4.8/fixtureTeardown.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.4.8/fixtureTeardown.html
+++ b/docs/2.4.8/fixtureTeardown.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.4.8/getStarted.html
+++ b/docs/2.4.8/getStarted.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.4.8/getStarted.html
+++ b/docs/2.4.8/getStarted.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.4.8/getStarted.html
+++ b/docs/2.4.8/getStarted.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.4.8/getStarted.html
+++ b/docs/2.4.8/getStarted.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.4.8/guiCommandLine.html
+++ b/docs/2.4.8/guiCommandLine.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.4.8/guiCommandLine.html
+++ b/docs/2.4.8/guiCommandLine.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.4.8/guiCommandLine.html
+++ b/docs/2.4.8/guiCommandLine.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.4.8/guiCommandLine.html
+++ b/docs/2.4.8/guiCommandLine.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.4.8/identityAsserts.html
+++ b/docs/2.4.8/identityAsserts.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.4.8/identityAsserts.html
+++ b/docs/2.4.8/identityAsserts.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.4.8/identityAsserts.html
+++ b/docs/2.4.8/identityAsserts.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.4.8/identityAsserts.html
+++ b/docs/2.4.8/identityAsserts.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.4.8/ignore.html
+++ b/docs/2.4.8/ignore.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.4.8/ignore.html
+++ b/docs/2.4.8/ignore.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.4.8/ignore.html
+++ b/docs/2.4.8/ignore.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.4.8/ignore.html
+++ b/docs/2.4.8/ignore.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.4.8/installation.html
+++ b/docs/2.4.8/installation.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.4.8/installation.html
+++ b/docs/2.4.8/installation.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.4.8/installation.html
+++ b/docs/2.4.8/installation.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.4.8/installation.html
+++ b/docs/2.4.8/installation.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.4.8/license.html
+++ b/docs/2.4.8/license.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.4.8/license.html
+++ b/docs/2.4.8/license.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.4.8/license.html
+++ b/docs/2.4.8/license.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.4.8/license.html
+++ b/docs/2.4.8/license.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.4.8/listMapper.html
+++ b/docs/2.4.8/listMapper.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.4.8/listMapper.html
+++ b/docs/2.4.8/listMapper.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.4.8/listMapper.html
+++ b/docs/2.4.8/listMapper.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.4.8/listMapper.html
+++ b/docs/2.4.8/listMapper.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.4.8/mainMenu.html
+++ b/docs/2.4.8/mainMenu.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.4.8/mainMenu.html
+++ b/docs/2.4.8/mainMenu.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.4.8/mainMenu.html
+++ b/docs/2.4.8/mainMenu.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.4.8/mainMenu.html
+++ b/docs/2.4.8/mainMenu.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.4.8/multiAssembly.html
+++ b/docs/2.4.8/multiAssembly.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.4.8/multiAssembly.html
+++ b/docs/2.4.8/multiAssembly.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.4.8/multiAssembly.html
+++ b/docs/2.4.8/multiAssembly.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.4.8/multiAssembly.html
+++ b/docs/2.4.8/multiAssembly.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.4.8/nunit-console.html
+++ b/docs/2.4.8/nunit-console.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.4.8/nunit-console.html
+++ b/docs/2.4.8/nunit-console.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.4.8/nunit-console.html
+++ b/docs/2.4.8/nunit-console.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.4.8/nunit-console.html
+++ b/docs/2.4.8/nunit-console.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.4.8/nunit-gui.html
+++ b/docs/2.4.8/nunit-gui.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.4.8/nunit-gui.html
+++ b/docs/2.4.8/nunit-gui.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.4.8/nunit-gui.html
+++ b/docs/2.4.8/nunit-gui.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.4.8/nunit-gui.html
+++ b/docs/2.4.8/nunit-gui.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.4.8/nunitAddins.html
+++ b/docs/2.4.8/nunitAddins.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.4.8/nunitAddins.html
+++ b/docs/2.4.8/nunitAddins.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.4.8/nunitAddins.html
+++ b/docs/2.4.8/nunitAddins.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.4.8/nunitAddins.html
+++ b/docs/2.4.8/nunitAddins.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.4.8/optionsDialog.html
+++ b/docs/2.4.8/optionsDialog.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.4.8/optionsDialog.html
+++ b/docs/2.4.8/optionsDialog.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.4.8/optionsDialog.html
+++ b/docs/2.4.8/optionsDialog.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.4.8/optionsDialog.html
+++ b/docs/2.4.8/optionsDialog.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.4.8/platform.html
+++ b/docs/2.4.8/platform.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.4.8/platform.html
+++ b/docs/2.4.8/platform.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.4.8/platform.html
+++ b/docs/2.4.8/platform.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.4.8/platform.html
+++ b/docs/2.4.8/platform.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.4.8/projectEditor.html
+++ b/docs/2.4.8/projectEditor.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.4.8/projectEditor.html
+++ b/docs/2.4.8/projectEditor.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.4.8/projectEditor.html
+++ b/docs/2.4.8/projectEditor.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.4.8/projectEditor.html
+++ b/docs/2.4.8/projectEditor.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.4.8/property.html
+++ b/docs/2.4.8/property.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.4.8/property.html
+++ b/docs/2.4.8/property.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.4.8/property.html
+++ b/docs/2.4.8/property.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.4.8/property.html
+++ b/docs/2.4.8/property.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.4.8/propertyConstraint.html
+++ b/docs/2.4.8/propertyConstraint.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.4.8/propertyConstraint.html
+++ b/docs/2.4.8/propertyConstraint.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.4.8/propertyConstraint.html
+++ b/docs/2.4.8/propertyConstraint.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.4.8/propertyConstraint.html
+++ b/docs/2.4.8/propertyConstraint.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.4.8/quickStart.html
+++ b/docs/2.4.8/quickStart.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.4.8/quickStart.html
+++ b/docs/2.4.8/quickStart.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.4.8/quickStart.html
+++ b/docs/2.4.8/quickStart.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.4.8/quickStart.html
+++ b/docs/2.4.8/quickStart.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.4.8/quickStartSource.html
+++ b/docs/2.4.8/quickStartSource.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.4.8/quickStartSource.html
+++ b/docs/2.4.8/quickStartSource.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.4.8/quickStartSource.html
+++ b/docs/2.4.8/quickStartSource.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.4.8/quickStartSource.html
+++ b/docs/2.4.8/quickStartSource.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.4.8/releaseNotes.html
+++ b/docs/2.4.8/releaseNotes.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.4.8/releaseNotes.html
+++ b/docs/2.4.8/releaseNotes.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.4.8/releaseNotes.html
+++ b/docs/2.4.8/releaseNotes.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.4.8/releaseNotes.html
+++ b/docs/2.4.8/releaseNotes.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.4.8/sameasConstraint.html
+++ b/docs/2.4.8/sameasConstraint.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.4.8/sameasConstraint.html
+++ b/docs/2.4.8/sameasConstraint.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.4.8/sameasConstraint.html
+++ b/docs/2.4.8/sameasConstraint.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.4.8/sameasConstraint.html
+++ b/docs/2.4.8/sameasConstraint.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.4.8/samples.html
+++ b/docs/2.4.8/samples.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.4.8/samples.html
+++ b/docs/2.4.8/samples.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.4.8/samples.html
+++ b/docs/2.4.8/samples.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.4.8/samples.html
+++ b/docs/2.4.8/samples.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.4.8/setCulture.html
+++ b/docs/2.4.8/setCulture.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.4.8/setCulture.html
+++ b/docs/2.4.8/setCulture.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.4.8/setCulture.html
+++ b/docs/2.4.8/setCulture.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.4.8/setCulture.html
+++ b/docs/2.4.8/setCulture.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.4.8/setup.html
+++ b/docs/2.4.8/setup.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.4.8/setup.html
+++ b/docs/2.4.8/setup.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.4.8/setup.html
+++ b/docs/2.4.8/setup.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.4.8/setup.html
+++ b/docs/2.4.8/setup.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.4.8/setupFixture.html
+++ b/docs/2.4.8/setupFixture.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.4.8/setupFixture.html
+++ b/docs/2.4.8/setupFixture.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.4.8/setupFixture.html
+++ b/docs/2.4.8/setupFixture.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.4.8/setupFixture.html
+++ b/docs/2.4.8/setupFixture.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.4.8/stringAssert.html
+++ b/docs/2.4.8/stringAssert.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.4.8/stringAssert.html
+++ b/docs/2.4.8/stringAssert.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.4.8/stringAssert.html
+++ b/docs/2.4.8/stringAssert.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.4.8/stringAssert.html
+++ b/docs/2.4.8/stringAssert.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.4.8/stringConstraints.html
+++ b/docs/2.4.8/stringConstraints.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.4.8/stringConstraints.html
+++ b/docs/2.4.8/stringConstraints.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.4.8/stringConstraints.html
+++ b/docs/2.4.8/stringConstraints.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.4.8/stringConstraints.html
+++ b/docs/2.4.8/stringConstraints.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.4.8/suite.html
+++ b/docs/2.4.8/suite.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.4.8/suite.html
+++ b/docs/2.4.8/suite.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.4.8/suite.html
+++ b/docs/2.4.8/suite.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.4.8/suite.html
+++ b/docs/2.4.8/suite.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.4.8/teardown.html
+++ b/docs/2.4.8/teardown.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.4.8/teardown.html
+++ b/docs/2.4.8/teardown.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.4.8/teardown.html
+++ b/docs/2.4.8/teardown.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.4.8/teardown.html
+++ b/docs/2.4.8/teardown.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.4.8/test.html
+++ b/docs/2.4.8/test.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.4.8/test.html
+++ b/docs/2.4.8/test.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.4.8/test.html
+++ b/docs/2.4.8/test.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.4.8/test.html
+++ b/docs/2.4.8/test.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.4.8/testFixture.html
+++ b/docs/2.4.8/testFixture.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.4.8/testFixture.html
+++ b/docs/2.4.8/testFixture.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.4.8/testFixture.html
+++ b/docs/2.4.8/testFixture.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.4.8/testFixture.html
+++ b/docs/2.4.8/testFixture.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.4.8/testProperties.html
+++ b/docs/2.4.8/testProperties.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.4.8/testProperties.html
+++ b/docs/2.4.8/testProperties.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.4.8/testProperties.html
+++ b/docs/2.4.8/testProperties.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.4.8/testProperties.html
+++ b/docs/2.4.8/testProperties.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.4.8/typeAsserts.html
+++ b/docs/2.4.8/typeAsserts.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.4.8/typeAsserts.html
+++ b/docs/2.4.8/typeAsserts.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.4.8/typeAsserts.html
+++ b/docs/2.4.8/typeAsserts.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.4.8/typeAsserts.html
+++ b/docs/2.4.8/typeAsserts.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.4.8/typeConstraints.html
+++ b/docs/2.4.8/typeConstraints.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.4.8/typeConstraints.html
+++ b/docs/2.4.8/typeConstraints.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.4.8/typeConstraints.html
+++ b/docs/2.4.8/typeConstraints.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.4.8/typeConstraints.html
+++ b/docs/2.4.8/typeConstraints.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.4.8/upgrade.html
+++ b/docs/2.4.8/upgrade.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.4.8/upgrade.html
+++ b/docs/2.4.8/upgrade.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.4.8/upgrade.html
+++ b/docs/2.4.8/upgrade.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.4.8/upgrade.html
+++ b/docs/2.4.8/upgrade.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.4.8/utilityAsserts.html
+++ b/docs/2.4.8/utilityAsserts.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.4.8/utilityAsserts.html
+++ b/docs/2.4.8/utilityAsserts.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.4.8/utilityAsserts.html
+++ b/docs/2.4.8/utilityAsserts.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.4.8/utilityAsserts.html
+++ b/docs/2.4.8/utilityAsserts.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.4.8/vsSupport.html
+++ b/docs/2.4.8/vsSupport.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.4.8/vsSupport.html
+++ b/docs/2.4.8/vsSupport.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.4.8/vsSupport.html
+++ b/docs/2.4.8/vsSupport.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.4.8/vsSupport.html
+++ b/docs/2.4.8/vsSupport.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.4/addinsDialog.html
+++ b/docs/2.4/addinsDialog.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.4/addinsDialog.html
+++ b/docs/2.4/addinsDialog.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.4/addinsDialog.html
+++ b/docs/2.4/addinsDialog.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.4/addinsDialog.html
+++ b/docs/2.4/addinsDialog.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.4/assertions.html
+++ b/docs/2.4/assertions.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.4/assertions.html
+++ b/docs/2.4/assertions.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.4/assertions.html
+++ b/docs/2.4/assertions.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.4/assertions.html
+++ b/docs/2.4/assertions.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.4/attributes.html
+++ b/docs/2.4/attributes.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.4/attributes.html
+++ b/docs/2.4/attributes.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.4/attributes.html
+++ b/docs/2.4/attributes.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.4/attributes.html
+++ b/docs/2.4/attributes.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.4/category.html
+++ b/docs/2.4/category.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.4/category.html
+++ b/docs/2.4/category.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.4/category.html
+++ b/docs/2.4/category.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.4/category.html
+++ b/docs/2.4/category.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.4/classicModel.html
+++ b/docs/2.4/classicModel.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.4/classicModel.html
+++ b/docs/2.4/classicModel.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.4/classicModel.html
+++ b/docs/2.4/classicModel.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.4/classicModel.html
+++ b/docs/2.4/classicModel.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.4/collectionAssert.html
+++ b/docs/2.4/collectionAssert.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.4/collectionAssert.html
+++ b/docs/2.4/collectionAssert.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.4/collectionAssert.html
+++ b/docs/2.4/collectionAssert.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.4/collectionAssert.html
+++ b/docs/2.4/collectionAssert.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.4/collectionConstraints.html
+++ b/docs/2.4/collectionConstraints.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.4/collectionConstraints.html
+++ b/docs/2.4/collectionConstraints.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.4/collectionConstraints.html
+++ b/docs/2.4/collectionConstraints.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.4/collectionConstraints.html
+++ b/docs/2.4/collectionConstraints.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.4/comparisonAsserts.html
+++ b/docs/2.4/comparisonAsserts.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.4/comparisonAsserts.html
+++ b/docs/2.4/comparisonAsserts.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.4/comparisonAsserts.html
+++ b/docs/2.4/comparisonAsserts.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.4/comparisonAsserts.html
+++ b/docs/2.4/comparisonAsserts.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.4/comparisonConstraints.html
+++ b/docs/2.4/comparisonConstraints.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.4/comparisonConstraints.html
+++ b/docs/2.4/comparisonConstraints.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.4/comparisonConstraints.html
+++ b/docs/2.4/comparisonConstraints.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.4/comparisonConstraints.html
+++ b/docs/2.4/comparisonConstraints.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.4/compoundConstraints.html
+++ b/docs/2.4/compoundConstraints.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.4/compoundConstraints.html
+++ b/docs/2.4/compoundConstraints.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.4/compoundConstraints.html
+++ b/docs/2.4/compoundConstraints.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.4/compoundConstraints.html
+++ b/docs/2.4/compoundConstraints.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.4/conditionAsserts.html
+++ b/docs/2.4/conditionAsserts.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.4/conditionAsserts.html
+++ b/docs/2.4/conditionAsserts.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.4/conditionAsserts.html
+++ b/docs/2.4/conditionAsserts.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.4/conditionAsserts.html
+++ b/docs/2.4/conditionAsserts.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.4/conditionConstraints.html
+++ b/docs/2.4/conditionConstraints.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.4/conditionConstraints.html
+++ b/docs/2.4/conditionConstraints.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.4/conditionConstraints.html
+++ b/docs/2.4/conditionConstraints.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.4/conditionConstraints.html
+++ b/docs/2.4/conditionConstraints.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.4/configEditor.html
+++ b/docs/2.4/configEditor.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.4/configEditor.html
+++ b/docs/2.4/configEditor.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.4/configEditor.html
+++ b/docs/2.4/configEditor.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.4/configEditor.html
+++ b/docs/2.4/configEditor.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.4/configFiles.html
+++ b/docs/2.4/configFiles.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.4/configFiles.html
+++ b/docs/2.4/configFiles.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.4/configFiles.html
+++ b/docs/2.4/configFiles.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.4/configFiles.html
+++ b/docs/2.4/configFiles.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.4/consoleCommandLine.html
+++ b/docs/2.4/consoleCommandLine.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.4/consoleCommandLine.html
+++ b/docs/2.4/consoleCommandLine.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.4/consoleCommandLine.html
+++ b/docs/2.4/consoleCommandLine.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.4/consoleCommandLine.html
+++ b/docs/2.4/consoleCommandLine.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.4/constraintModel.html
+++ b/docs/2.4/constraintModel.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.4/constraintModel.html
+++ b/docs/2.4/constraintModel.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.4/constraintModel.html
+++ b/docs/2.4/constraintModel.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.4/constraintModel.html
+++ b/docs/2.4/constraintModel.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.4/contextMenu.html
+++ b/docs/2.4/contextMenu.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.4/contextMenu.html
+++ b/docs/2.4/contextMenu.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.4/contextMenu.html
+++ b/docs/2.4/contextMenu.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.4/contextMenu.html
+++ b/docs/2.4/contextMenu.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.4/customAsserts.html
+++ b/docs/2.4/customAsserts.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.4/customAsserts.html
+++ b/docs/2.4/customAsserts.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.4/customAsserts.html
+++ b/docs/2.4/customAsserts.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.4/customAsserts.html
+++ b/docs/2.4/customAsserts.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.4/customConstraints.html
+++ b/docs/2.4/customConstraints.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.4/customConstraints.html
+++ b/docs/2.4/customConstraints.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.4/customConstraints.html
+++ b/docs/2.4/customConstraints.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.4/customConstraints.html
+++ b/docs/2.4/customConstraints.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.4/description.html
+++ b/docs/2.4/description.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.4/description.html
+++ b/docs/2.4/description.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.4/description.html
+++ b/docs/2.4/description.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.4/description.html
+++ b/docs/2.4/description.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.4/docHome.html
+++ b/docs/2.4/docHome.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.4/docHome.html
+++ b/docs/2.4/docHome.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.4/docHome.html
+++ b/docs/2.4/docHome.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.4/docHome.html
+++ b/docs/2.4/docHome.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.4/equalConstraint.html
+++ b/docs/2.4/equalConstraint.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.4/equalConstraint.html
+++ b/docs/2.4/equalConstraint.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.4/equalConstraint.html
+++ b/docs/2.4/equalConstraint.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.4/equalConstraint.html
+++ b/docs/2.4/equalConstraint.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.4/equalityAsserts.html
+++ b/docs/2.4/equalityAsserts.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.4/equalityAsserts.html
+++ b/docs/2.4/equalityAsserts.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.4/equalityAsserts.html
+++ b/docs/2.4/equalityAsserts.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.4/equalityAsserts.html
+++ b/docs/2.4/equalityAsserts.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.4/exception.html
+++ b/docs/2.4/exception.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.4/exception.html
+++ b/docs/2.4/exception.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.4/exception.html
+++ b/docs/2.4/exception.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.4/exception.html
+++ b/docs/2.4/exception.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.4/explicit.html
+++ b/docs/2.4/explicit.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.4/explicit.html
+++ b/docs/2.4/explicit.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.4/explicit.html
+++ b/docs/2.4/explicit.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.4/explicit.html
+++ b/docs/2.4/explicit.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.4/extensibility.html
+++ b/docs/2.4/extensibility.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.4/extensibility.html
+++ b/docs/2.4/extensibility.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.4/extensibility.html
+++ b/docs/2.4/extensibility.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.4/extensibility.html
+++ b/docs/2.4/extensibility.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.4/features.html
+++ b/docs/2.4/features.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.4/features.html
+++ b/docs/2.4/features.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.4/features.html
+++ b/docs/2.4/features.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.4/features.html
+++ b/docs/2.4/features.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.4/fileAssert.html
+++ b/docs/2.4/fileAssert.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.4/fileAssert.html
+++ b/docs/2.4/fileAssert.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.4/fileAssert.html
+++ b/docs/2.4/fileAssert.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.4/fileAssert.html
+++ b/docs/2.4/fileAssert.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.4/fixtureSetup.html
+++ b/docs/2.4/fixtureSetup.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.4/fixtureSetup.html
+++ b/docs/2.4/fixtureSetup.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.4/fixtureSetup.html
+++ b/docs/2.4/fixtureSetup.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.4/fixtureSetup.html
+++ b/docs/2.4/fixtureSetup.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.4/fixtureTeardown.html
+++ b/docs/2.4/fixtureTeardown.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.4/fixtureTeardown.html
+++ b/docs/2.4/fixtureTeardown.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.4/fixtureTeardown.html
+++ b/docs/2.4/fixtureTeardown.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.4/fixtureTeardown.html
+++ b/docs/2.4/fixtureTeardown.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.4/getStarted.html
+++ b/docs/2.4/getStarted.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.4/getStarted.html
+++ b/docs/2.4/getStarted.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.4/getStarted.html
+++ b/docs/2.4/getStarted.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.4/getStarted.html
+++ b/docs/2.4/getStarted.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.4/guiCommandLine.html
+++ b/docs/2.4/guiCommandLine.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.4/guiCommandLine.html
+++ b/docs/2.4/guiCommandLine.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.4/guiCommandLine.html
+++ b/docs/2.4/guiCommandLine.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.4/guiCommandLine.html
+++ b/docs/2.4/guiCommandLine.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.4/identityAsserts.html
+++ b/docs/2.4/identityAsserts.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.4/identityAsserts.html
+++ b/docs/2.4/identityAsserts.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.4/identityAsserts.html
+++ b/docs/2.4/identityAsserts.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.4/identityAsserts.html
+++ b/docs/2.4/identityAsserts.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.4/ignore.html
+++ b/docs/2.4/ignore.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.4/ignore.html
+++ b/docs/2.4/ignore.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.4/ignore.html
+++ b/docs/2.4/ignore.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.4/ignore.html
+++ b/docs/2.4/ignore.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.4/installation.html
+++ b/docs/2.4/installation.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.4/installation.html
+++ b/docs/2.4/installation.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.4/installation.html
+++ b/docs/2.4/installation.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.4/installation.html
+++ b/docs/2.4/installation.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.4/license.html
+++ b/docs/2.4/license.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.4/license.html
+++ b/docs/2.4/license.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.4/license.html
+++ b/docs/2.4/license.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.4/license.html
+++ b/docs/2.4/license.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.4/mainMenu.html
+++ b/docs/2.4/mainMenu.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.4/mainMenu.html
+++ b/docs/2.4/mainMenu.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.4/mainMenu.html
+++ b/docs/2.4/mainMenu.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.4/mainMenu.html
+++ b/docs/2.4/mainMenu.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.4/multiAssembly.html
+++ b/docs/2.4/multiAssembly.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.4/multiAssembly.html
+++ b/docs/2.4/multiAssembly.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.4/multiAssembly.html
+++ b/docs/2.4/multiAssembly.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.4/multiAssembly.html
+++ b/docs/2.4/multiAssembly.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.4/nunit-console.html
+++ b/docs/2.4/nunit-console.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.4/nunit-console.html
+++ b/docs/2.4/nunit-console.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.4/nunit-console.html
+++ b/docs/2.4/nunit-console.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.4/nunit-console.html
+++ b/docs/2.4/nunit-console.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.4/nunit-gui.html
+++ b/docs/2.4/nunit-gui.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.4/nunit-gui.html
+++ b/docs/2.4/nunit-gui.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.4/nunit-gui.html
+++ b/docs/2.4/nunit-gui.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.4/nunit-gui.html
+++ b/docs/2.4/nunit-gui.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.4/nunitAddins.html
+++ b/docs/2.4/nunitAddins.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.4/nunitAddins.html
+++ b/docs/2.4/nunitAddins.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.4/nunitAddins.html
+++ b/docs/2.4/nunitAddins.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.4/nunitAddins.html
+++ b/docs/2.4/nunitAddins.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.4/optionsDialog.html
+++ b/docs/2.4/optionsDialog.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.4/optionsDialog.html
+++ b/docs/2.4/optionsDialog.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.4/optionsDialog.html
+++ b/docs/2.4/optionsDialog.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.4/optionsDialog.html
+++ b/docs/2.4/optionsDialog.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.4/platform.html
+++ b/docs/2.4/platform.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.4/platform.html
+++ b/docs/2.4/platform.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.4/platform.html
+++ b/docs/2.4/platform.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.4/platform.html
+++ b/docs/2.4/platform.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.4/projectEditor.html
+++ b/docs/2.4/projectEditor.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.4/projectEditor.html
+++ b/docs/2.4/projectEditor.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.4/projectEditor.html
+++ b/docs/2.4/projectEditor.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.4/projectEditor.html
+++ b/docs/2.4/projectEditor.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.4/property.html
+++ b/docs/2.4/property.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.4/property.html
+++ b/docs/2.4/property.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.4/property.html
+++ b/docs/2.4/property.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.4/property.html
+++ b/docs/2.4/property.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.4/quickStart.html
+++ b/docs/2.4/quickStart.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.4/quickStart.html
+++ b/docs/2.4/quickStart.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.4/quickStart.html
+++ b/docs/2.4/quickStart.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.4/quickStart.html
+++ b/docs/2.4/quickStart.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.4/quickStartSource.html
+++ b/docs/2.4/quickStartSource.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.4/quickStartSource.html
+++ b/docs/2.4/quickStartSource.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.4/quickStartSource.html
+++ b/docs/2.4/quickStartSource.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.4/quickStartSource.html
+++ b/docs/2.4/quickStartSource.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.4/releaseNotes.html
+++ b/docs/2.4/releaseNotes.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.4/releaseNotes.html
+++ b/docs/2.4/releaseNotes.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.4/releaseNotes.html
+++ b/docs/2.4/releaseNotes.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.4/releaseNotes.html
+++ b/docs/2.4/releaseNotes.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.4/sameasConstraint.html
+++ b/docs/2.4/sameasConstraint.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.4/sameasConstraint.html
+++ b/docs/2.4/sameasConstraint.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.4/sameasConstraint.html
+++ b/docs/2.4/sameasConstraint.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.4/sameasConstraint.html
+++ b/docs/2.4/sameasConstraint.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.4/samples.html
+++ b/docs/2.4/samples.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.4/samples.html
+++ b/docs/2.4/samples.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.4/samples.html
+++ b/docs/2.4/samples.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.4/samples.html
+++ b/docs/2.4/samples.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.4/setup.html
+++ b/docs/2.4/setup.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.4/setup.html
+++ b/docs/2.4/setup.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.4/setup.html
+++ b/docs/2.4/setup.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.4/setup.html
+++ b/docs/2.4/setup.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.4/setupFixture.html
+++ b/docs/2.4/setupFixture.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.4/setupFixture.html
+++ b/docs/2.4/setupFixture.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.4/setupFixture.html
+++ b/docs/2.4/setupFixture.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.4/setupFixture.html
+++ b/docs/2.4/setupFixture.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.4/stringAssert.html
+++ b/docs/2.4/stringAssert.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.4/stringAssert.html
+++ b/docs/2.4/stringAssert.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.4/stringAssert.html
+++ b/docs/2.4/stringAssert.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.4/stringAssert.html
+++ b/docs/2.4/stringAssert.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.4/stringConstraints.html
+++ b/docs/2.4/stringConstraints.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.4/stringConstraints.html
+++ b/docs/2.4/stringConstraints.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.4/stringConstraints.html
+++ b/docs/2.4/stringConstraints.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.4/stringConstraints.html
+++ b/docs/2.4/stringConstraints.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.4/suite.html
+++ b/docs/2.4/suite.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.4/suite.html
+++ b/docs/2.4/suite.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.4/suite.html
+++ b/docs/2.4/suite.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.4/suite.html
+++ b/docs/2.4/suite.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.4/teardown.html
+++ b/docs/2.4/teardown.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.4/teardown.html
+++ b/docs/2.4/teardown.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.4/teardown.html
+++ b/docs/2.4/teardown.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.4/teardown.html
+++ b/docs/2.4/teardown.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.4/test.html
+++ b/docs/2.4/test.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.4/test.html
+++ b/docs/2.4/test.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.4/test.html
+++ b/docs/2.4/test.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.4/test.html
+++ b/docs/2.4/test.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.4/testFixture.html
+++ b/docs/2.4/testFixture.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.4/testFixture.html
+++ b/docs/2.4/testFixture.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.4/testFixture.html
+++ b/docs/2.4/testFixture.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.4/testFixture.html
+++ b/docs/2.4/testFixture.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.4/testProperties.html
+++ b/docs/2.4/testProperties.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.4/testProperties.html
+++ b/docs/2.4/testProperties.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.4/testProperties.html
+++ b/docs/2.4/testProperties.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.4/testProperties.html
+++ b/docs/2.4/testProperties.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.4/typeAsserts.html
+++ b/docs/2.4/typeAsserts.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.4/typeAsserts.html
+++ b/docs/2.4/typeAsserts.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.4/typeAsserts.html
+++ b/docs/2.4/typeAsserts.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.4/typeAsserts.html
+++ b/docs/2.4/typeAsserts.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.4/typeConstraints.html
+++ b/docs/2.4/typeConstraints.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.4/typeConstraints.html
+++ b/docs/2.4/typeConstraints.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.4/typeConstraints.html
+++ b/docs/2.4/typeConstraints.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.4/typeConstraints.html
+++ b/docs/2.4/typeConstraints.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.4/upgrade.html
+++ b/docs/2.4/upgrade.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.4/upgrade.html
+++ b/docs/2.4/upgrade.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.4/upgrade.html
+++ b/docs/2.4/upgrade.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.4/upgrade.html
+++ b/docs/2.4/upgrade.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.4/utilityAsserts.html
+++ b/docs/2.4/utilityAsserts.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.4/utilityAsserts.html
+++ b/docs/2.4/utilityAsserts.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.4/utilityAsserts.html
+++ b/docs/2.4/utilityAsserts.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.4/utilityAsserts.html
+++ b/docs/2.4/utilityAsserts.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.4/vsSupport.html
+++ b/docs/2.4/vsSupport.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.4/vsSupport.html
+++ b/docs/2.4/vsSupport.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.4/vsSupport.html
+++ b/docs/2.4/vsSupport.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.4/vsSupport.html
+++ b/docs/2.4/vsSupport.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.1/addinsDialog.html
+++ b/docs/2.5.1/addinsDialog.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.1/addinsDialog.html
+++ b/docs/2.5.1/addinsDialog.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.1/addinsDialog.html
+++ b/docs/2.5.1/addinsDialog.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.1/addinsDialog.html
+++ b/docs/2.5.1/addinsDialog.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.1/assertions.html
+++ b/docs/2.5.1/assertions.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.1/assertions.html
+++ b/docs/2.5.1/assertions.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.1/assertions.html
+++ b/docs/2.5.1/assertions.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.1/assertions.html
+++ b/docs/2.5.1/assertions.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.1/attributes.html
+++ b/docs/2.5.1/attributes.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.1/attributes.html
+++ b/docs/2.5.1/attributes.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.1/attributes.html
+++ b/docs/2.5.1/attributes.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.1/attributes.html
+++ b/docs/2.5.1/attributes.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.1/category.html
+++ b/docs/2.5.1/category.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.1/category.html
+++ b/docs/2.5.1/category.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.1/category.html
+++ b/docs/2.5.1/category.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.1/category.html
+++ b/docs/2.5.1/category.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.1/collectionAssert.html
+++ b/docs/2.5.1/collectionAssert.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.1/collectionAssert.html
+++ b/docs/2.5.1/collectionAssert.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.1/collectionAssert.html
+++ b/docs/2.5.1/collectionAssert.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.1/collectionAssert.html
+++ b/docs/2.5.1/collectionAssert.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.1/collectionConstraints.html
+++ b/docs/2.5.1/collectionConstraints.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.1/collectionConstraints.html
+++ b/docs/2.5.1/collectionConstraints.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.1/collectionConstraints.html
+++ b/docs/2.5.1/collectionConstraints.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.1/collectionConstraints.html
+++ b/docs/2.5.1/collectionConstraints.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.1/combinatorial.html
+++ b/docs/2.5.1/combinatorial.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.1/combinatorial.html
+++ b/docs/2.5.1/combinatorial.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.1/combinatorial.html
+++ b/docs/2.5.1/combinatorial.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.1/combinatorial.html
+++ b/docs/2.5.1/combinatorial.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.1/comparisonAsserts.html
+++ b/docs/2.5.1/comparisonAsserts.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.1/comparisonAsserts.html
+++ b/docs/2.5.1/comparisonAsserts.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.1/comparisonAsserts.html
+++ b/docs/2.5.1/comparisonAsserts.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.1/comparisonAsserts.html
+++ b/docs/2.5.1/comparisonAsserts.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.1/comparisonConstraints.html
+++ b/docs/2.5.1/comparisonConstraints.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.1/comparisonConstraints.html
+++ b/docs/2.5.1/comparisonConstraints.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.1/comparisonConstraints.html
+++ b/docs/2.5.1/comparisonConstraints.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.1/comparisonConstraints.html
+++ b/docs/2.5.1/comparisonConstraints.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.1/compoundConstraints.html
+++ b/docs/2.5.1/compoundConstraints.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.1/compoundConstraints.html
+++ b/docs/2.5.1/compoundConstraints.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.1/compoundConstraints.html
+++ b/docs/2.5.1/compoundConstraints.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.1/compoundConstraints.html
+++ b/docs/2.5.1/compoundConstraints.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.1/conditionAsserts.html
+++ b/docs/2.5.1/conditionAsserts.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.1/conditionAsserts.html
+++ b/docs/2.5.1/conditionAsserts.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.1/conditionAsserts.html
+++ b/docs/2.5.1/conditionAsserts.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.1/conditionAsserts.html
+++ b/docs/2.5.1/conditionAsserts.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.1/conditionConstraints.html
+++ b/docs/2.5.1/conditionConstraints.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.1/conditionConstraints.html
+++ b/docs/2.5.1/conditionConstraints.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.1/conditionConstraints.html
+++ b/docs/2.5.1/conditionConstraints.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.1/conditionConstraints.html
+++ b/docs/2.5.1/conditionConstraints.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.1/configEditor.html
+++ b/docs/2.5.1/configEditor.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.1/configEditor.html
+++ b/docs/2.5.1/configEditor.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.1/configEditor.html
+++ b/docs/2.5.1/configEditor.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.1/configEditor.html
+++ b/docs/2.5.1/configEditor.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.1/configFiles.html
+++ b/docs/2.5.1/configFiles.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.1/configFiles.html
+++ b/docs/2.5.1/configFiles.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.1/configFiles.html
+++ b/docs/2.5.1/configFiles.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.1/configFiles.html
+++ b/docs/2.5.1/configFiles.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.1/consoleCommandLine.html
+++ b/docs/2.5.1/consoleCommandLine.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.1/consoleCommandLine.html
+++ b/docs/2.5.1/consoleCommandLine.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.1/consoleCommandLine.html
+++ b/docs/2.5.1/consoleCommandLine.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.1/consoleCommandLine.html
+++ b/docs/2.5.1/consoleCommandLine.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.1/constraintModel.html
+++ b/docs/2.5.1/constraintModel.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.1/constraintModel.html
+++ b/docs/2.5.1/constraintModel.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.1/constraintModel.html
+++ b/docs/2.5.1/constraintModel.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.1/constraintModel.html
+++ b/docs/2.5.1/constraintModel.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.1/contextMenu.html
+++ b/docs/2.5.1/contextMenu.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.1/contextMenu.html
+++ b/docs/2.5.1/contextMenu.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.1/contextMenu.html
+++ b/docs/2.5.1/contextMenu.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.1/contextMenu.html
+++ b/docs/2.5.1/contextMenu.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.1/culture.html
+++ b/docs/2.5.1/culture.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.1/culture.html
+++ b/docs/2.5.1/culture.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.1/culture.html
+++ b/docs/2.5.1/culture.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.1/culture.html
+++ b/docs/2.5.1/culture.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.1/customConstraints.html
+++ b/docs/2.5.1/customConstraints.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.1/customConstraints.html
+++ b/docs/2.5.1/customConstraints.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.1/customConstraints.html
+++ b/docs/2.5.1/customConstraints.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.1/customConstraints.html
+++ b/docs/2.5.1/customConstraints.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.1/datapoint.html
+++ b/docs/2.5.1/datapoint.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.1/datapoint.html
+++ b/docs/2.5.1/datapoint.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.1/datapoint.html
+++ b/docs/2.5.1/datapoint.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.1/datapoint.html
+++ b/docs/2.5.1/datapoint.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.1/datapointProviders.html
+++ b/docs/2.5.1/datapointProviders.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.1/datapointProviders.html
+++ b/docs/2.5.1/datapointProviders.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.1/datapointProviders.html
+++ b/docs/2.5.1/datapointProviders.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.1/datapointProviders.html
+++ b/docs/2.5.1/datapointProviders.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.1/delayedConstraint.html
+++ b/docs/2.5.1/delayedConstraint.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.1/delayedConstraint.html
+++ b/docs/2.5.1/delayedConstraint.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.1/delayedConstraint.html
+++ b/docs/2.5.1/delayedConstraint.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.1/delayedConstraint.html
+++ b/docs/2.5.1/delayedConstraint.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.1/description.html
+++ b/docs/2.5.1/description.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.1/description.html
+++ b/docs/2.5.1/description.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.1/description.html
+++ b/docs/2.5.1/description.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.1/description.html
+++ b/docs/2.5.1/description.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.1/directoryAssert.html
+++ b/docs/2.5.1/directoryAssert.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.1/directoryAssert.html
+++ b/docs/2.5.1/directoryAssert.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.1/directoryAssert.html
+++ b/docs/2.5.1/directoryAssert.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.1/directoryAssert.html
+++ b/docs/2.5.1/directoryAssert.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.1/docHome.html
+++ b/docs/2.5.1/docHome.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.1/docHome.html
+++ b/docs/2.5.1/docHome.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.1/docHome.html
+++ b/docs/2.5.1/docHome.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.1/docHome.html
+++ b/docs/2.5.1/docHome.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.1/equalConstraint.html
+++ b/docs/2.5.1/equalConstraint.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.1/equalConstraint.html
+++ b/docs/2.5.1/equalConstraint.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.1/equalConstraint.html
+++ b/docs/2.5.1/equalConstraint.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.1/equalConstraint.html
+++ b/docs/2.5.1/equalConstraint.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.1/equalityAsserts.html
+++ b/docs/2.5.1/equalityAsserts.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.1/equalityAsserts.html
+++ b/docs/2.5.1/equalityAsserts.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.1/equalityAsserts.html
+++ b/docs/2.5.1/equalityAsserts.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.1/equalityAsserts.html
+++ b/docs/2.5.1/equalityAsserts.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.1/eventListeners.html
+++ b/docs/2.5.1/eventListeners.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.1/eventListeners.html
+++ b/docs/2.5.1/eventListeners.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.1/eventListeners.html
+++ b/docs/2.5.1/eventListeners.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.1/eventListeners.html
+++ b/docs/2.5.1/eventListeners.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.1/exception.html
+++ b/docs/2.5.1/exception.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.1/exception.html
+++ b/docs/2.5.1/exception.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.1/exception.html
+++ b/docs/2.5.1/exception.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.1/exception.html
+++ b/docs/2.5.1/exception.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.1/exceptionAsserts.html
+++ b/docs/2.5.1/exceptionAsserts.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.1/exceptionAsserts.html
+++ b/docs/2.5.1/exceptionAsserts.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.1/exceptionAsserts.html
+++ b/docs/2.5.1/exceptionAsserts.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.1/exceptionAsserts.html
+++ b/docs/2.5.1/exceptionAsserts.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.1/explicit.html
+++ b/docs/2.5.1/explicit.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.1/explicit.html
+++ b/docs/2.5.1/explicit.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.1/explicit.html
+++ b/docs/2.5.1/explicit.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.1/explicit.html
+++ b/docs/2.5.1/explicit.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.1/extensibility.html
+++ b/docs/2.5.1/extensibility.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.1/extensibility.html
+++ b/docs/2.5.1/extensibility.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.1/extensibility.html
+++ b/docs/2.5.1/extensibility.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.1/extensibility.html
+++ b/docs/2.5.1/extensibility.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.1/extensionTips.html
+++ b/docs/2.5.1/extensionTips.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.1/extensionTips.html
+++ b/docs/2.5.1/extensionTips.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.1/extensionTips.html
+++ b/docs/2.5.1/extensionTips.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.1/extensionTips.html
+++ b/docs/2.5.1/extensionTips.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.1/fileAssert.html
+++ b/docs/2.5.1/fileAssert.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.1/fileAssert.html
+++ b/docs/2.5.1/fileAssert.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.1/fileAssert.html
+++ b/docs/2.5.1/fileAssert.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.1/fileAssert.html
+++ b/docs/2.5.1/fileAssert.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.1/fixtureSetup.html
+++ b/docs/2.5.1/fixtureSetup.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.1/fixtureSetup.html
+++ b/docs/2.5.1/fixtureSetup.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.1/fixtureSetup.html
+++ b/docs/2.5.1/fixtureSetup.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.1/fixtureSetup.html
+++ b/docs/2.5.1/fixtureSetup.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.1/fixtureTeardown.html
+++ b/docs/2.5.1/fixtureTeardown.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.1/fixtureTeardown.html
+++ b/docs/2.5.1/fixtureTeardown.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.1/fixtureTeardown.html
+++ b/docs/2.5.1/fixtureTeardown.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.1/fixtureTeardown.html
+++ b/docs/2.5.1/fixtureTeardown.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.1/getStarted.html
+++ b/docs/2.5.1/getStarted.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.1/getStarted.html
+++ b/docs/2.5.1/getStarted.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.1/getStarted.html
+++ b/docs/2.5.1/getStarted.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.1/getStarted.html
+++ b/docs/2.5.1/getStarted.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.1/guiCommandLine.html
+++ b/docs/2.5.1/guiCommandLine.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.1/guiCommandLine.html
+++ b/docs/2.5.1/guiCommandLine.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.1/guiCommandLine.html
+++ b/docs/2.5.1/guiCommandLine.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.1/guiCommandLine.html
+++ b/docs/2.5.1/guiCommandLine.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.1/identityAsserts.html
+++ b/docs/2.5.1/identityAsserts.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.1/identityAsserts.html
+++ b/docs/2.5.1/identityAsserts.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.1/identityAsserts.html
+++ b/docs/2.5.1/identityAsserts.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.1/identityAsserts.html
+++ b/docs/2.5.1/identityAsserts.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.1/ignore.html
+++ b/docs/2.5.1/ignore.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.1/ignore.html
+++ b/docs/2.5.1/ignore.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.1/ignore.html
+++ b/docs/2.5.1/ignore.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.1/ignore.html
+++ b/docs/2.5.1/ignore.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.1/installation.html
+++ b/docs/2.5.1/installation.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.1/installation.html
+++ b/docs/2.5.1/installation.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.1/installation.html
+++ b/docs/2.5.1/installation.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.1/installation.html
+++ b/docs/2.5.1/installation.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.1/license.html
+++ b/docs/2.5.1/license.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.1/license.html
+++ b/docs/2.5.1/license.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.1/license.html
+++ b/docs/2.5.1/license.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.1/license.html
+++ b/docs/2.5.1/license.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.1/listMapper.html
+++ b/docs/2.5.1/listMapper.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.1/listMapper.html
+++ b/docs/2.5.1/listMapper.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.1/listMapper.html
+++ b/docs/2.5.1/listMapper.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.1/listMapper.html
+++ b/docs/2.5.1/listMapper.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.1/mainMenu.html
+++ b/docs/2.5.1/mainMenu.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.1/mainMenu.html
+++ b/docs/2.5.1/mainMenu.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.1/mainMenu.html
+++ b/docs/2.5.1/mainMenu.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.1/mainMenu.html
+++ b/docs/2.5.1/mainMenu.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.1/maxtime.html
+++ b/docs/2.5.1/maxtime.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.1/maxtime.html
+++ b/docs/2.5.1/maxtime.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.1/maxtime.html
+++ b/docs/2.5.1/maxtime.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.1/maxtime.html
+++ b/docs/2.5.1/maxtime.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.1/multiAssembly.html
+++ b/docs/2.5.1/multiAssembly.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.1/multiAssembly.html
+++ b/docs/2.5.1/multiAssembly.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.1/multiAssembly.html
+++ b/docs/2.5.1/multiAssembly.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.1/multiAssembly.html
+++ b/docs/2.5.1/multiAssembly.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.1/nunit-console.html
+++ b/docs/2.5.1/nunit-console.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.1/nunit-console.html
+++ b/docs/2.5.1/nunit-console.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.1/nunit-console.html
+++ b/docs/2.5.1/nunit-console.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.1/nunit-console.html
+++ b/docs/2.5.1/nunit-console.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.1/nunit-gui.html
+++ b/docs/2.5.1/nunit-gui.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.1/nunit-gui.html
+++ b/docs/2.5.1/nunit-gui.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.1/nunit-gui.html
+++ b/docs/2.5.1/nunit-gui.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.1/nunit-gui.html
+++ b/docs/2.5.1/nunit-gui.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.1/nunitAddins.html
+++ b/docs/2.5.1/nunitAddins.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.1/nunitAddins.html
+++ b/docs/2.5.1/nunitAddins.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.1/nunitAddins.html
+++ b/docs/2.5.1/nunitAddins.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.1/nunitAddins.html
+++ b/docs/2.5.1/nunitAddins.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.1/pairwise.html
+++ b/docs/2.5.1/pairwise.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.1/pairwise.html
+++ b/docs/2.5.1/pairwise.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.1/pairwise.html
+++ b/docs/2.5.1/pairwise.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.1/pairwise.html
+++ b/docs/2.5.1/pairwise.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.1/parameterizedTests.html
+++ b/docs/2.5.1/parameterizedTests.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.1/parameterizedTests.html
+++ b/docs/2.5.1/parameterizedTests.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.1/parameterizedTests.html
+++ b/docs/2.5.1/parameterizedTests.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.1/parameterizedTests.html
+++ b/docs/2.5.1/parameterizedTests.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.1/pathConstraints.html
+++ b/docs/2.5.1/pathConstraints.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.1/pathConstraints.html
+++ b/docs/2.5.1/pathConstraints.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.1/pathConstraints.html
+++ b/docs/2.5.1/pathConstraints.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.1/pathConstraints.html
+++ b/docs/2.5.1/pathConstraints.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.1/platform.html
+++ b/docs/2.5.1/platform.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.1/platform.html
+++ b/docs/2.5.1/platform.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.1/platform.html
+++ b/docs/2.5.1/platform.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.1/platform.html
+++ b/docs/2.5.1/platform.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.1/pnunit.html
+++ b/docs/2.5.1/pnunit.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.1/pnunit.html
+++ b/docs/2.5.1/pnunit.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.1/pnunit.html
+++ b/docs/2.5.1/pnunit.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.1/pnunit.html
+++ b/docs/2.5.1/pnunit.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.1/projectEditor.html
+++ b/docs/2.5.1/projectEditor.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.1/projectEditor.html
+++ b/docs/2.5.1/projectEditor.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.1/projectEditor.html
+++ b/docs/2.5.1/projectEditor.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.1/projectEditor.html
+++ b/docs/2.5.1/projectEditor.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.1/property.html
+++ b/docs/2.5.1/property.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.1/property.html
+++ b/docs/2.5.1/property.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.1/property.html
+++ b/docs/2.5.1/property.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.1/property.html
+++ b/docs/2.5.1/property.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.1/propertyConstraint.html
+++ b/docs/2.5.1/propertyConstraint.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.1/propertyConstraint.html
+++ b/docs/2.5.1/propertyConstraint.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.1/propertyConstraint.html
+++ b/docs/2.5.1/propertyConstraint.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.1/propertyConstraint.html
+++ b/docs/2.5.1/propertyConstraint.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.1/quickStart.html
+++ b/docs/2.5.1/quickStart.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.1/quickStart.html
+++ b/docs/2.5.1/quickStart.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.1/quickStart.html
+++ b/docs/2.5.1/quickStart.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.1/quickStart.html
+++ b/docs/2.5.1/quickStart.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.1/quickStartSource.html
+++ b/docs/2.5.1/quickStartSource.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.1/quickStartSource.html
+++ b/docs/2.5.1/quickStartSource.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.1/quickStartSource.html
+++ b/docs/2.5.1/quickStartSource.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.1/quickStartSource.html
+++ b/docs/2.5.1/quickStartSource.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.1/random.html
+++ b/docs/2.5.1/random.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.1/random.html
+++ b/docs/2.5.1/random.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.1/random.html
+++ b/docs/2.5.1/random.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.1/random.html
+++ b/docs/2.5.1/random.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.1/range.html
+++ b/docs/2.5.1/range.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.1/range.html
+++ b/docs/2.5.1/range.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.1/range.html
+++ b/docs/2.5.1/range.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.1/range.html
+++ b/docs/2.5.1/range.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.1/releaseNotes.html
+++ b/docs/2.5.1/releaseNotes.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.1/releaseNotes.html
+++ b/docs/2.5.1/releaseNotes.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.1/releaseNotes.html
+++ b/docs/2.5.1/releaseNotes.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.1/releaseNotes.html
+++ b/docs/2.5.1/releaseNotes.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.1/repeat.html
+++ b/docs/2.5.1/repeat.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.1/repeat.html
+++ b/docs/2.5.1/repeat.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.1/repeat.html
+++ b/docs/2.5.1/repeat.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.1/repeat.html
+++ b/docs/2.5.1/repeat.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.1/requiredAddin.html
+++ b/docs/2.5.1/requiredAddin.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.1/requiredAddin.html
+++ b/docs/2.5.1/requiredAddin.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.1/requiredAddin.html
+++ b/docs/2.5.1/requiredAddin.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.1/requiredAddin.html
+++ b/docs/2.5.1/requiredAddin.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.1/requiresMTA.html
+++ b/docs/2.5.1/requiresMTA.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.1/requiresMTA.html
+++ b/docs/2.5.1/requiresMTA.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.1/requiresMTA.html
+++ b/docs/2.5.1/requiresMTA.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.1/requiresMTA.html
+++ b/docs/2.5.1/requiresMTA.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.1/requiresSTA.html
+++ b/docs/2.5.1/requiresSTA.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.1/requiresSTA.html
+++ b/docs/2.5.1/requiresSTA.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.1/requiresSTA.html
+++ b/docs/2.5.1/requiresSTA.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.1/requiresSTA.html
+++ b/docs/2.5.1/requiresSTA.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.1/requiresThread.html
+++ b/docs/2.5.1/requiresThread.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.1/requiresThread.html
+++ b/docs/2.5.1/requiresThread.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.1/requiresThread.html
+++ b/docs/2.5.1/requiresThread.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.1/requiresThread.html
+++ b/docs/2.5.1/requiresThread.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.1/sameasConstraint.html
+++ b/docs/2.5.1/sameasConstraint.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.1/sameasConstraint.html
+++ b/docs/2.5.1/sameasConstraint.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.1/sameasConstraint.html
+++ b/docs/2.5.1/sameasConstraint.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.1/sameasConstraint.html
+++ b/docs/2.5.1/sameasConstraint.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.1/samples.html
+++ b/docs/2.5.1/samples.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.1/samples.html
+++ b/docs/2.5.1/samples.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.1/samples.html
+++ b/docs/2.5.1/samples.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.1/samples.html
+++ b/docs/2.5.1/samples.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.1/sequential.html
+++ b/docs/2.5.1/sequential.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.1/sequential.html
+++ b/docs/2.5.1/sequential.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.1/sequential.html
+++ b/docs/2.5.1/sequential.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.1/sequential.html
+++ b/docs/2.5.1/sequential.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.1/setCulture.html
+++ b/docs/2.5.1/setCulture.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.1/setCulture.html
+++ b/docs/2.5.1/setCulture.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.1/setCulture.html
+++ b/docs/2.5.1/setCulture.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.1/setCulture.html
+++ b/docs/2.5.1/setCulture.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.1/settingsDialog.html
+++ b/docs/2.5.1/settingsDialog.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.1/settingsDialog.html
+++ b/docs/2.5.1/settingsDialog.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.1/settingsDialog.html
+++ b/docs/2.5.1/settingsDialog.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.1/settingsDialog.html
+++ b/docs/2.5.1/settingsDialog.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.1/setup.html
+++ b/docs/2.5.1/setup.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.1/setup.html
+++ b/docs/2.5.1/setup.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.1/setup.html
+++ b/docs/2.5.1/setup.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.1/setup.html
+++ b/docs/2.5.1/setup.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.1/setupFixture.html
+++ b/docs/2.5.1/setupFixture.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.1/setupFixture.html
+++ b/docs/2.5.1/setupFixture.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.1/setupFixture.html
+++ b/docs/2.5.1/setupFixture.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.1/setupFixture.html
+++ b/docs/2.5.1/setupFixture.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.1/stringAssert.html
+++ b/docs/2.5.1/stringAssert.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.1/stringAssert.html
+++ b/docs/2.5.1/stringAssert.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.1/stringAssert.html
+++ b/docs/2.5.1/stringAssert.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.1/stringAssert.html
+++ b/docs/2.5.1/stringAssert.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.1/stringConstraints.html
+++ b/docs/2.5.1/stringConstraints.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.1/stringConstraints.html
+++ b/docs/2.5.1/stringConstraints.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.1/stringConstraints.html
+++ b/docs/2.5.1/stringConstraints.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.1/stringConstraints.html
+++ b/docs/2.5.1/stringConstraints.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.1/suite.html
+++ b/docs/2.5.1/suite.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.1/suite.html
+++ b/docs/2.5.1/suite.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.1/suite.html
+++ b/docs/2.5.1/suite.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.1/suite.html
+++ b/docs/2.5.1/suite.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.1/suiteBuilders.html
+++ b/docs/2.5.1/suiteBuilders.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.1/suiteBuilders.html
+++ b/docs/2.5.1/suiteBuilders.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.1/suiteBuilders.html
+++ b/docs/2.5.1/suiteBuilders.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.1/suiteBuilders.html
+++ b/docs/2.5.1/suiteBuilders.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.1/teardown.html
+++ b/docs/2.5.1/teardown.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.1/teardown.html
+++ b/docs/2.5.1/teardown.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.1/teardown.html
+++ b/docs/2.5.1/teardown.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.1/teardown.html
+++ b/docs/2.5.1/teardown.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.1/test.html
+++ b/docs/2.5.1/test.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.1/test.html
+++ b/docs/2.5.1/test.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.1/test.html
+++ b/docs/2.5.1/test.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.1/test.html
+++ b/docs/2.5.1/test.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.1/testCase.html
+++ b/docs/2.5.1/testCase.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.1/testCase.html
+++ b/docs/2.5.1/testCase.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.1/testCase.html
+++ b/docs/2.5.1/testCase.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.1/testCase.html
+++ b/docs/2.5.1/testCase.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.1/testCaseSource.html
+++ b/docs/2.5.1/testCaseSource.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.1/testCaseSource.html
+++ b/docs/2.5.1/testCaseSource.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.1/testCaseSource.html
+++ b/docs/2.5.1/testCaseSource.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.1/testCaseSource.html
+++ b/docs/2.5.1/testCaseSource.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.1/testDecorators.html
+++ b/docs/2.5.1/testDecorators.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.1/testDecorators.html
+++ b/docs/2.5.1/testDecorators.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.1/testDecorators.html
+++ b/docs/2.5.1/testDecorators.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.1/testDecorators.html
+++ b/docs/2.5.1/testDecorators.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.1/testFixture.html
+++ b/docs/2.5.1/testFixture.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.1/testFixture.html
+++ b/docs/2.5.1/testFixture.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.1/testFixture.html
+++ b/docs/2.5.1/testFixture.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.1/testFixture.html
+++ b/docs/2.5.1/testFixture.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.1/testProperties.html
+++ b/docs/2.5.1/testProperties.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.1/testProperties.html
+++ b/docs/2.5.1/testProperties.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.1/testProperties.html
+++ b/docs/2.5.1/testProperties.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.1/testProperties.html
+++ b/docs/2.5.1/testProperties.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.1/testcaseBuilders.html
+++ b/docs/2.5.1/testcaseBuilders.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.1/testcaseBuilders.html
+++ b/docs/2.5.1/testcaseBuilders.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.1/testcaseBuilders.html
+++ b/docs/2.5.1/testcaseBuilders.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.1/testcaseBuilders.html
+++ b/docs/2.5.1/testcaseBuilders.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.1/testcaseProviders.html
+++ b/docs/2.5.1/testcaseProviders.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.1/testcaseProviders.html
+++ b/docs/2.5.1/testcaseProviders.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.1/testcaseProviders.html
+++ b/docs/2.5.1/testcaseProviders.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.1/testcaseProviders.html
+++ b/docs/2.5.1/testcaseProviders.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.1/theory.html
+++ b/docs/2.5.1/theory.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.1/theory.html
+++ b/docs/2.5.1/theory.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.1/theory.html
+++ b/docs/2.5.1/theory.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.1/theory.html
+++ b/docs/2.5.1/theory.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.1/throwsConstraint.html
+++ b/docs/2.5.1/throwsConstraint.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.1/throwsConstraint.html
+++ b/docs/2.5.1/throwsConstraint.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.1/throwsConstraint.html
+++ b/docs/2.5.1/throwsConstraint.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.1/throwsConstraint.html
+++ b/docs/2.5.1/throwsConstraint.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.1/timeout.html
+++ b/docs/2.5.1/timeout.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.1/timeout.html
+++ b/docs/2.5.1/timeout.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.1/timeout.html
+++ b/docs/2.5.1/timeout.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.1/timeout.html
+++ b/docs/2.5.1/timeout.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.1/typeAsserts.html
+++ b/docs/2.5.1/typeAsserts.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.1/typeAsserts.html
+++ b/docs/2.5.1/typeAsserts.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.1/typeAsserts.html
+++ b/docs/2.5.1/typeAsserts.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.1/typeAsserts.html
+++ b/docs/2.5.1/typeAsserts.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.1/typeConstraints.html
+++ b/docs/2.5.1/typeConstraints.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.1/typeConstraints.html
+++ b/docs/2.5.1/typeConstraints.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.1/typeConstraints.html
+++ b/docs/2.5.1/typeConstraints.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.1/typeConstraints.html
+++ b/docs/2.5.1/typeConstraints.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.1/upgrade.html
+++ b/docs/2.5.1/upgrade.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.1/upgrade.html
+++ b/docs/2.5.1/upgrade.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.1/upgrade.html
+++ b/docs/2.5.1/upgrade.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.1/upgrade.html
+++ b/docs/2.5.1/upgrade.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.1/utilityAsserts.html
+++ b/docs/2.5.1/utilityAsserts.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.1/utilityAsserts.html
+++ b/docs/2.5.1/utilityAsserts.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.1/utilityAsserts.html
+++ b/docs/2.5.1/utilityAsserts.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.1/utilityAsserts.html
+++ b/docs/2.5.1/utilityAsserts.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.1/valueSource.html
+++ b/docs/2.5.1/valueSource.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.1/valueSource.html
+++ b/docs/2.5.1/valueSource.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.1/valueSource.html
+++ b/docs/2.5.1/valueSource.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.1/valueSource.html
+++ b/docs/2.5.1/valueSource.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.1/values.html
+++ b/docs/2.5.1/values.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.1/values.html
+++ b/docs/2.5.1/values.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.1/values.html
+++ b/docs/2.5.1/values.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.1/values.html
+++ b/docs/2.5.1/values.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.1/vsSupport.html
+++ b/docs/2.5.1/vsSupport.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.1/vsSupport.html
+++ b/docs/2.5.1/vsSupport.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.1/vsSupport.html
+++ b/docs/2.5.1/vsSupport.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.1/vsSupport.html
+++ b/docs/2.5.1/vsSupport.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.10/addinsDialog.html
+++ b/docs/2.5.10/addinsDialog.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.10/addinsDialog.html
+++ b/docs/2.5.10/addinsDialog.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.10/addinsDialog.html
+++ b/docs/2.5.10/addinsDialog.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.10/addinsDialog.html
+++ b/docs/2.5.10/addinsDialog.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.10/assemblyIsolation.html
+++ b/docs/2.5.10/assemblyIsolation.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.10/assemblyIsolation.html
+++ b/docs/2.5.10/assemblyIsolation.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.10/assemblyIsolation.html
+++ b/docs/2.5.10/assemblyIsolation.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.10/assemblyIsolation.html
+++ b/docs/2.5.10/assemblyIsolation.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.10/assertions.html
+++ b/docs/2.5.10/assertions.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.10/assertions.html
+++ b/docs/2.5.10/assertions.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.10/assertions.html
+++ b/docs/2.5.10/assertions.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.10/assertions.html
+++ b/docs/2.5.10/assertions.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.10/attributes.html
+++ b/docs/2.5.10/attributes.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.10/attributes.html
+++ b/docs/2.5.10/attributes.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.10/attributes.html
+++ b/docs/2.5.10/attributes.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.10/attributes.html
+++ b/docs/2.5.10/attributes.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.10/category.html
+++ b/docs/2.5.10/category.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.10/category.html
+++ b/docs/2.5.10/category.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.10/category.html
+++ b/docs/2.5.10/category.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.10/category.html
+++ b/docs/2.5.10/category.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.10/collectionAssert.html
+++ b/docs/2.5.10/collectionAssert.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.10/collectionAssert.html
+++ b/docs/2.5.10/collectionAssert.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.10/collectionAssert.html
+++ b/docs/2.5.10/collectionAssert.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.10/collectionAssert.html
+++ b/docs/2.5.10/collectionAssert.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.10/collectionConstraints.html
+++ b/docs/2.5.10/collectionConstraints.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.10/collectionConstraints.html
+++ b/docs/2.5.10/collectionConstraints.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.10/collectionConstraints.html
+++ b/docs/2.5.10/collectionConstraints.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.10/collectionConstraints.html
+++ b/docs/2.5.10/collectionConstraints.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.10/combinatorial.html
+++ b/docs/2.5.10/combinatorial.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.10/combinatorial.html
+++ b/docs/2.5.10/combinatorial.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.10/combinatorial.html
+++ b/docs/2.5.10/combinatorial.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.10/combinatorial.html
+++ b/docs/2.5.10/combinatorial.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.10/comparisonAsserts.html
+++ b/docs/2.5.10/comparisonAsserts.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.10/comparisonAsserts.html
+++ b/docs/2.5.10/comparisonAsserts.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.10/comparisonAsserts.html
+++ b/docs/2.5.10/comparisonAsserts.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.10/comparisonAsserts.html
+++ b/docs/2.5.10/comparisonAsserts.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.10/comparisonConstraints.html
+++ b/docs/2.5.10/comparisonConstraints.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.10/comparisonConstraints.html
+++ b/docs/2.5.10/comparisonConstraints.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.10/comparisonConstraints.html
+++ b/docs/2.5.10/comparisonConstraints.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.10/comparisonConstraints.html
+++ b/docs/2.5.10/comparisonConstraints.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.10/compoundConstraints.html
+++ b/docs/2.5.10/compoundConstraints.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.10/compoundConstraints.html
+++ b/docs/2.5.10/compoundConstraints.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.10/compoundConstraints.html
+++ b/docs/2.5.10/compoundConstraints.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.10/compoundConstraints.html
+++ b/docs/2.5.10/compoundConstraints.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.10/conditionAsserts.html
+++ b/docs/2.5.10/conditionAsserts.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.10/conditionAsserts.html
+++ b/docs/2.5.10/conditionAsserts.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.10/conditionAsserts.html
+++ b/docs/2.5.10/conditionAsserts.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.10/conditionAsserts.html
+++ b/docs/2.5.10/conditionAsserts.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.10/conditionConstraints.html
+++ b/docs/2.5.10/conditionConstraints.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.10/conditionConstraints.html
+++ b/docs/2.5.10/conditionConstraints.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.10/conditionConstraints.html
+++ b/docs/2.5.10/conditionConstraints.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.10/conditionConstraints.html
+++ b/docs/2.5.10/conditionConstraints.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.10/configEditor.html
+++ b/docs/2.5.10/configEditor.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.10/configEditor.html
+++ b/docs/2.5.10/configEditor.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.10/configEditor.html
+++ b/docs/2.5.10/configEditor.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.10/configEditor.html
+++ b/docs/2.5.10/configEditor.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.10/configFiles.html
+++ b/docs/2.5.10/configFiles.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.10/configFiles.html
+++ b/docs/2.5.10/configFiles.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.10/configFiles.html
+++ b/docs/2.5.10/configFiles.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.10/configFiles.html
+++ b/docs/2.5.10/configFiles.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.10/consoleCommandLine.html
+++ b/docs/2.5.10/consoleCommandLine.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.10/consoleCommandLine.html
+++ b/docs/2.5.10/consoleCommandLine.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.10/consoleCommandLine.html
+++ b/docs/2.5.10/consoleCommandLine.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.10/consoleCommandLine.html
+++ b/docs/2.5.10/consoleCommandLine.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.10/constraintModel.html
+++ b/docs/2.5.10/constraintModel.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.10/constraintModel.html
+++ b/docs/2.5.10/constraintModel.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.10/constraintModel.html
+++ b/docs/2.5.10/constraintModel.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.10/constraintModel.html
+++ b/docs/2.5.10/constraintModel.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.10/contextMenu.html
+++ b/docs/2.5.10/contextMenu.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.10/contextMenu.html
+++ b/docs/2.5.10/contextMenu.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.10/contextMenu.html
+++ b/docs/2.5.10/contextMenu.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.10/contextMenu.html
+++ b/docs/2.5.10/contextMenu.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.10/culture.html
+++ b/docs/2.5.10/culture.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.10/culture.html
+++ b/docs/2.5.10/culture.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.10/culture.html
+++ b/docs/2.5.10/culture.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.10/culture.html
+++ b/docs/2.5.10/culture.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.10/customConstraints.html
+++ b/docs/2.5.10/customConstraints.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.10/customConstraints.html
+++ b/docs/2.5.10/customConstraints.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.10/customConstraints.html
+++ b/docs/2.5.10/customConstraints.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.10/customConstraints.html
+++ b/docs/2.5.10/customConstraints.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.10/datapoint.html
+++ b/docs/2.5.10/datapoint.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.10/datapoint.html
+++ b/docs/2.5.10/datapoint.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.10/datapoint.html
+++ b/docs/2.5.10/datapoint.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.10/datapoint.html
+++ b/docs/2.5.10/datapoint.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.10/datapointProviders.html
+++ b/docs/2.5.10/datapointProviders.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.10/datapointProviders.html
+++ b/docs/2.5.10/datapointProviders.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.10/datapointProviders.html
+++ b/docs/2.5.10/datapointProviders.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.10/datapointProviders.html
+++ b/docs/2.5.10/datapointProviders.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.10/delayedConstraint.html
+++ b/docs/2.5.10/delayedConstraint.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.10/delayedConstraint.html
+++ b/docs/2.5.10/delayedConstraint.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.10/delayedConstraint.html
+++ b/docs/2.5.10/delayedConstraint.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.10/delayedConstraint.html
+++ b/docs/2.5.10/delayedConstraint.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.10/description.html
+++ b/docs/2.5.10/description.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.10/description.html
+++ b/docs/2.5.10/description.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.10/description.html
+++ b/docs/2.5.10/description.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.10/description.html
+++ b/docs/2.5.10/description.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.10/directoryAssert.html
+++ b/docs/2.5.10/directoryAssert.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.10/directoryAssert.html
+++ b/docs/2.5.10/directoryAssert.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.10/directoryAssert.html
+++ b/docs/2.5.10/directoryAssert.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.10/directoryAssert.html
+++ b/docs/2.5.10/directoryAssert.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.10/docHome.html
+++ b/docs/2.5.10/docHome.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.10/docHome.html
+++ b/docs/2.5.10/docHome.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.10/docHome.html
+++ b/docs/2.5.10/docHome.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.10/docHome.html
+++ b/docs/2.5.10/docHome.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.10/equalConstraint.html
+++ b/docs/2.5.10/equalConstraint.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.10/equalConstraint.html
+++ b/docs/2.5.10/equalConstraint.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.10/equalConstraint.html
+++ b/docs/2.5.10/equalConstraint.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.10/equalConstraint.html
+++ b/docs/2.5.10/equalConstraint.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.10/equalityAsserts.html
+++ b/docs/2.5.10/equalityAsserts.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.10/equalityAsserts.html
+++ b/docs/2.5.10/equalityAsserts.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.10/equalityAsserts.html
+++ b/docs/2.5.10/equalityAsserts.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.10/equalityAsserts.html
+++ b/docs/2.5.10/equalityAsserts.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.10/eventListeners.html
+++ b/docs/2.5.10/eventListeners.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.10/eventListeners.html
+++ b/docs/2.5.10/eventListeners.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.10/eventListeners.html
+++ b/docs/2.5.10/eventListeners.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.10/eventListeners.html
+++ b/docs/2.5.10/eventListeners.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.10/exception.html
+++ b/docs/2.5.10/exception.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.10/exception.html
+++ b/docs/2.5.10/exception.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.10/exception.html
+++ b/docs/2.5.10/exception.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.10/exception.html
+++ b/docs/2.5.10/exception.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.10/exceptionAsserts.html
+++ b/docs/2.5.10/exceptionAsserts.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.10/exceptionAsserts.html
+++ b/docs/2.5.10/exceptionAsserts.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.10/exceptionAsserts.html
+++ b/docs/2.5.10/exceptionAsserts.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.10/exceptionAsserts.html
+++ b/docs/2.5.10/exceptionAsserts.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.10/explicit.html
+++ b/docs/2.5.10/explicit.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.10/explicit.html
+++ b/docs/2.5.10/explicit.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.10/explicit.html
+++ b/docs/2.5.10/explicit.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.10/explicit.html
+++ b/docs/2.5.10/explicit.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.10/extensibility.html
+++ b/docs/2.5.10/extensibility.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.10/extensibility.html
+++ b/docs/2.5.10/extensibility.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.10/extensibility.html
+++ b/docs/2.5.10/extensibility.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.10/extensibility.html
+++ b/docs/2.5.10/extensibility.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.10/extensionTips.html
+++ b/docs/2.5.10/extensionTips.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.10/extensionTips.html
+++ b/docs/2.5.10/extensionTips.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.10/extensionTips.html
+++ b/docs/2.5.10/extensionTips.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.10/extensionTips.html
+++ b/docs/2.5.10/extensionTips.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.10/fileAssert.html
+++ b/docs/2.5.10/fileAssert.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.10/fileAssert.html
+++ b/docs/2.5.10/fileAssert.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.10/fileAssert.html
+++ b/docs/2.5.10/fileAssert.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.10/fileAssert.html
+++ b/docs/2.5.10/fileAssert.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.10/fixtureSetup.html
+++ b/docs/2.5.10/fixtureSetup.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.10/fixtureSetup.html
+++ b/docs/2.5.10/fixtureSetup.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.10/fixtureSetup.html
+++ b/docs/2.5.10/fixtureSetup.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.10/fixtureSetup.html
+++ b/docs/2.5.10/fixtureSetup.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.10/fixtureTeardown.html
+++ b/docs/2.5.10/fixtureTeardown.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.10/fixtureTeardown.html
+++ b/docs/2.5.10/fixtureTeardown.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.10/fixtureTeardown.html
+++ b/docs/2.5.10/fixtureTeardown.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.10/fixtureTeardown.html
+++ b/docs/2.5.10/fixtureTeardown.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.10/getStarted.html
+++ b/docs/2.5.10/getStarted.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.10/getStarted.html
+++ b/docs/2.5.10/getStarted.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.10/getStarted.html
+++ b/docs/2.5.10/getStarted.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.10/getStarted.html
+++ b/docs/2.5.10/getStarted.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.10/guiCommandLine.html
+++ b/docs/2.5.10/guiCommandLine.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.10/guiCommandLine.html
+++ b/docs/2.5.10/guiCommandLine.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.10/guiCommandLine.html
+++ b/docs/2.5.10/guiCommandLine.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.10/guiCommandLine.html
+++ b/docs/2.5.10/guiCommandLine.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.10/identityAsserts.html
+++ b/docs/2.5.10/identityAsserts.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.10/identityAsserts.html
+++ b/docs/2.5.10/identityAsserts.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.10/identityAsserts.html
+++ b/docs/2.5.10/identityAsserts.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.10/identityAsserts.html
+++ b/docs/2.5.10/identityAsserts.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.10/ignore.html
+++ b/docs/2.5.10/ignore.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.10/ignore.html
+++ b/docs/2.5.10/ignore.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.10/ignore.html
+++ b/docs/2.5.10/ignore.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.10/ignore.html
+++ b/docs/2.5.10/ignore.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.10/installation.html
+++ b/docs/2.5.10/installation.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.10/installation.html
+++ b/docs/2.5.10/installation.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.10/installation.html
+++ b/docs/2.5.10/installation.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.10/installation.html
+++ b/docs/2.5.10/installation.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.10/license.html
+++ b/docs/2.5.10/license.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.10/license.html
+++ b/docs/2.5.10/license.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.10/license.html
+++ b/docs/2.5.10/license.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.10/license.html
+++ b/docs/2.5.10/license.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.10/listMapper.html
+++ b/docs/2.5.10/listMapper.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.10/listMapper.html
+++ b/docs/2.5.10/listMapper.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.10/listMapper.html
+++ b/docs/2.5.10/listMapper.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.10/listMapper.html
+++ b/docs/2.5.10/listMapper.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.10/mainMenu.html
+++ b/docs/2.5.10/mainMenu.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.10/mainMenu.html
+++ b/docs/2.5.10/mainMenu.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.10/mainMenu.html
+++ b/docs/2.5.10/mainMenu.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.10/mainMenu.html
+++ b/docs/2.5.10/mainMenu.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.10/maxtime.html
+++ b/docs/2.5.10/maxtime.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.10/maxtime.html
+++ b/docs/2.5.10/maxtime.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.10/maxtime.html
+++ b/docs/2.5.10/maxtime.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.10/maxtime.html
+++ b/docs/2.5.10/maxtime.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.10/multiAssembly.html
+++ b/docs/2.5.10/multiAssembly.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.10/multiAssembly.html
+++ b/docs/2.5.10/multiAssembly.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.10/multiAssembly.html
+++ b/docs/2.5.10/multiAssembly.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.10/multiAssembly.html
+++ b/docs/2.5.10/multiAssembly.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.10/nunit-agent.html
+++ b/docs/2.5.10/nunit-agent.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.10/nunit-agent.html
+++ b/docs/2.5.10/nunit-agent.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.10/nunit-agent.html
+++ b/docs/2.5.10/nunit-agent.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.10/nunit-agent.html
+++ b/docs/2.5.10/nunit-agent.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.10/nunit-console.html
+++ b/docs/2.5.10/nunit-console.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.10/nunit-console.html
+++ b/docs/2.5.10/nunit-console.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.10/nunit-console.html
+++ b/docs/2.5.10/nunit-console.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.10/nunit-console.html
+++ b/docs/2.5.10/nunit-console.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.10/nunit-gui.html
+++ b/docs/2.5.10/nunit-gui.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.10/nunit-gui.html
+++ b/docs/2.5.10/nunit-gui.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.10/nunit-gui.html
+++ b/docs/2.5.10/nunit-gui.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.10/nunit-gui.html
+++ b/docs/2.5.10/nunit-gui.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.10/nunitAddins.html
+++ b/docs/2.5.10/nunitAddins.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.10/nunitAddins.html
+++ b/docs/2.5.10/nunitAddins.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.10/nunitAddins.html
+++ b/docs/2.5.10/nunitAddins.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.10/nunitAddins.html
+++ b/docs/2.5.10/nunitAddins.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.10/pairwise.html
+++ b/docs/2.5.10/pairwise.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.10/pairwise.html
+++ b/docs/2.5.10/pairwise.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.10/pairwise.html
+++ b/docs/2.5.10/pairwise.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.10/pairwise.html
+++ b/docs/2.5.10/pairwise.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.10/parameterizedTests.html
+++ b/docs/2.5.10/parameterizedTests.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.10/parameterizedTests.html
+++ b/docs/2.5.10/parameterizedTests.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.10/parameterizedTests.html
+++ b/docs/2.5.10/parameterizedTests.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.10/parameterizedTests.html
+++ b/docs/2.5.10/parameterizedTests.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.10/pathConstraints.html
+++ b/docs/2.5.10/pathConstraints.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.10/pathConstraints.html
+++ b/docs/2.5.10/pathConstraints.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.10/pathConstraints.html
+++ b/docs/2.5.10/pathConstraints.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.10/pathConstraints.html
+++ b/docs/2.5.10/pathConstraints.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.10/platform.html
+++ b/docs/2.5.10/platform.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.10/platform.html
+++ b/docs/2.5.10/platform.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.10/platform.html
+++ b/docs/2.5.10/platform.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.10/platform.html
+++ b/docs/2.5.10/platform.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.10/pnunit.html
+++ b/docs/2.5.10/pnunit.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.10/pnunit.html
+++ b/docs/2.5.10/pnunit.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.10/pnunit.html
+++ b/docs/2.5.10/pnunit.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.10/pnunit.html
+++ b/docs/2.5.10/pnunit.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.10/projectEditor.html
+++ b/docs/2.5.10/projectEditor.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.10/projectEditor.html
+++ b/docs/2.5.10/projectEditor.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.10/projectEditor.html
+++ b/docs/2.5.10/projectEditor.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.10/projectEditor.html
+++ b/docs/2.5.10/projectEditor.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.10/property.html
+++ b/docs/2.5.10/property.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.10/property.html
+++ b/docs/2.5.10/property.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.10/property.html
+++ b/docs/2.5.10/property.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.10/property.html
+++ b/docs/2.5.10/property.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.10/propertyConstraint.html
+++ b/docs/2.5.10/propertyConstraint.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.10/propertyConstraint.html
+++ b/docs/2.5.10/propertyConstraint.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.10/propertyConstraint.html
+++ b/docs/2.5.10/propertyConstraint.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.10/propertyConstraint.html
+++ b/docs/2.5.10/propertyConstraint.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.10/quickStart.html
+++ b/docs/2.5.10/quickStart.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.10/quickStart.html
+++ b/docs/2.5.10/quickStart.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.10/quickStart.html
+++ b/docs/2.5.10/quickStart.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.10/quickStart.html
+++ b/docs/2.5.10/quickStart.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.10/quickStartSource.html
+++ b/docs/2.5.10/quickStartSource.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.10/quickStartSource.html
+++ b/docs/2.5.10/quickStartSource.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.10/quickStartSource.html
+++ b/docs/2.5.10/quickStartSource.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.10/quickStartSource.html
+++ b/docs/2.5.10/quickStartSource.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.10/random.html
+++ b/docs/2.5.10/random.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.10/random.html
+++ b/docs/2.5.10/random.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.10/random.html
+++ b/docs/2.5.10/random.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.10/random.html
+++ b/docs/2.5.10/random.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.10/range.html
+++ b/docs/2.5.10/range.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.10/range.html
+++ b/docs/2.5.10/range.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.10/range.html
+++ b/docs/2.5.10/range.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.10/range.html
+++ b/docs/2.5.10/range.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.10/releaseNotes.html
+++ b/docs/2.5.10/releaseNotes.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.10/releaseNotes.html
+++ b/docs/2.5.10/releaseNotes.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.10/releaseNotes.html
+++ b/docs/2.5.10/releaseNotes.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.10/releaseNotes.html
+++ b/docs/2.5.10/releaseNotes.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.10/repeat.html
+++ b/docs/2.5.10/repeat.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.10/repeat.html
+++ b/docs/2.5.10/repeat.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.10/repeat.html
+++ b/docs/2.5.10/repeat.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.10/repeat.html
+++ b/docs/2.5.10/repeat.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.10/requiredAddin.html
+++ b/docs/2.5.10/requiredAddin.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.10/requiredAddin.html
+++ b/docs/2.5.10/requiredAddin.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.10/requiredAddin.html
+++ b/docs/2.5.10/requiredAddin.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.10/requiredAddin.html
+++ b/docs/2.5.10/requiredAddin.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.10/requiresMTA.html
+++ b/docs/2.5.10/requiresMTA.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.10/requiresMTA.html
+++ b/docs/2.5.10/requiresMTA.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.10/requiresMTA.html
+++ b/docs/2.5.10/requiresMTA.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.10/requiresMTA.html
+++ b/docs/2.5.10/requiresMTA.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.10/requiresSTA.html
+++ b/docs/2.5.10/requiresSTA.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.10/requiresSTA.html
+++ b/docs/2.5.10/requiresSTA.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.10/requiresSTA.html
+++ b/docs/2.5.10/requiresSTA.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.10/requiresSTA.html
+++ b/docs/2.5.10/requiresSTA.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.10/requiresThread.html
+++ b/docs/2.5.10/requiresThread.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.10/requiresThread.html
+++ b/docs/2.5.10/requiresThread.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.10/requiresThread.html
+++ b/docs/2.5.10/requiresThread.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.10/requiresThread.html
+++ b/docs/2.5.10/requiresThread.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.10/reusableConstraint.html
+++ b/docs/2.5.10/reusableConstraint.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.10/reusableConstraint.html
+++ b/docs/2.5.10/reusableConstraint.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.10/reusableConstraint.html
+++ b/docs/2.5.10/reusableConstraint.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.10/reusableConstraint.html
+++ b/docs/2.5.10/reusableConstraint.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.10/runningTests.html
+++ b/docs/2.5.10/runningTests.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.10/runningTests.html
+++ b/docs/2.5.10/runningTests.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.10/runningTests.html
+++ b/docs/2.5.10/runningTests.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.10/runningTests.html
+++ b/docs/2.5.10/runningTests.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.10/runtimeSelection.html
+++ b/docs/2.5.10/runtimeSelection.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.10/runtimeSelection.html
+++ b/docs/2.5.10/runtimeSelection.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.10/runtimeSelection.html
+++ b/docs/2.5.10/runtimeSelection.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.10/runtimeSelection.html
+++ b/docs/2.5.10/runtimeSelection.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.10/sameasConstraint.html
+++ b/docs/2.5.10/sameasConstraint.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.10/sameasConstraint.html
+++ b/docs/2.5.10/sameasConstraint.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.10/sameasConstraint.html
+++ b/docs/2.5.10/sameasConstraint.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.10/sameasConstraint.html
+++ b/docs/2.5.10/sameasConstraint.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.10/samples.html
+++ b/docs/2.5.10/samples.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.10/samples.html
+++ b/docs/2.5.10/samples.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.10/samples.html
+++ b/docs/2.5.10/samples.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.10/samples.html
+++ b/docs/2.5.10/samples.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.10/sequential.html
+++ b/docs/2.5.10/sequential.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.10/sequential.html
+++ b/docs/2.5.10/sequential.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.10/sequential.html
+++ b/docs/2.5.10/sequential.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.10/sequential.html
+++ b/docs/2.5.10/sequential.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.10/setCulture.html
+++ b/docs/2.5.10/setCulture.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.10/setCulture.html
+++ b/docs/2.5.10/setCulture.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.10/setCulture.html
+++ b/docs/2.5.10/setCulture.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.10/setCulture.html
+++ b/docs/2.5.10/setCulture.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.10/setUICulture.html
+++ b/docs/2.5.10/setUICulture.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.10/setUICulture.html
+++ b/docs/2.5.10/setUICulture.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.10/setUICulture.html
+++ b/docs/2.5.10/setUICulture.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.10/setUICulture.html
+++ b/docs/2.5.10/setUICulture.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.10/settingsDialog.html
+++ b/docs/2.5.10/settingsDialog.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.10/settingsDialog.html
+++ b/docs/2.5.10/settingsDialog.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.10/settingsDialog.html
+++ b/docs/2.5.10/settingsDialog.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.10/settingsDialog.html
+++ b/docs/2.5.10/settingsDialog.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.10/setup.html
+++ b/docs/2.5.10/setup.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.10/setup.html
+++ b/docs/2.5.10/setup.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.10/setup.html
+++ b/docs/2.5.10/setup.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.10/setup.html
+++ b/docs/2.5.10/setup.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.10/setupFixture.html
+++ b/docs/2.5.10/setupFixture.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.10/setupFixture.html
+++ b/docs/2.5.10/setupFixture.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.10/setupFixture.html
+++ b/docs/2.5.10/setupFixture.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.10/setupFixture.html
+++ b/docs/2.5.10/setupFixture.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.10/stringAssert.html
+++ b/docs/2.5.10/stringAssert.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.10/stringAssert.html
+++ b/docs/2.5.10/stringAssert.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.10/stringAssert.html
+++ b/docs/2.5.10/stringAssert.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.10/stringAssert.html
+++ b/docs/2.5.10/stringAssert.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.10/stringConstraints.html
+++ b/docs/2.5.10/stringConstraints.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.10/stringConstraints.html
+++ b/docs/2.5.10/stringConstraints.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.10/stringConstraints.html
+++ b/docs/2.5.10/stringConstraints.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.10/stringConstraints.html
+++ b/docs/2.5.10/stringConstraints.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.10/suite.html
+++ b/docs/2.5.10/suite.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.10/suite.html
+++ b/docs/2.5.10/suite.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.10/suite.html
+++ b/docs/2.5.10/suite.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.10/suite.html
+++ b/docs/2.5.10/suite.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.10/suiteBuilders.html
+++ b/docs/2.5.10/suiteBuilders.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.10/suiteBuilders.html
+++ b/docs/2.5.10/suiteBuilders.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.10/suiteBuilders.html
+++ b/docs/2.5.10/suiteBuilders.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.10/suiteBuilders.html
+++ b/docs/2.5.10/suiteBuilders.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.10/teardown.html
+++ b/docs/2.5.10/teardown.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.10/teardown.html
+++ b/docs/2.5.10/teardown.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.10/teardown.html
+++ b/docs/2.5.10/teardown.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.10/teardown.html
+++ b/docs/2.5.10/teardown.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.10/test.html
+++ b/docs/2.5.10/test.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.10/test.html
+++ b/docs/2.5.10/test.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.10/test.html
+++ b/docs/2.5.10/test.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.10/test.html
+++ b/docs/2.5.10/test.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.10/testCase.html
+++ b/docs/2.5.10/testCase.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.10/testCase.html
+++ b/docs/2.5.10/testCase.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.10/testCase.html
+++ b/docs/2.5.10/testCase.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.10/testCase.html
+++ b/docs/2.5.10/testCase.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.10/testCaseSource.html
+++ b/docs/2.5.10/testCaseSource.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.10/testCaseSource.html
+++ b/docs/2.5.10/testCaseSource.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.10/testCaseSource.html
+++ b/docs/2.5.10/testCaseSource.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.10/testCaseSource.html
+++ b/docs/2.5.10/testCaseSource.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.10/testDecorators.html
+++ b/docs/2.5.10/testDecorators.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.10/testDecorators.html
+++ b/docs/2.5.10/testDecorators.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.10/testDecorators.html
+++ b/docs/2.5.10/testDecorators.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.10/testDecorators.html
+++ b/docs/2.5.10/testDecorators.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.10/testFixture.html
+++ b/docs/2.5.10/testFixture.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.10/testFixture.html
+++ b/docs/2.5.10/testFixture.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.10/testFixture.html
+++ b/docs/2.5.10/testFixture.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.10/testFixture.html
+++ b/docs/2.5.10/testFixture.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.10/testProperties.html
+++ b/docs/2.5.10/testProperties.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.10/testProperties.html
+++ b/docs/2.5.10/testProperties.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.10/testProperties.html
+++ b/docs/2.5.10/testProperties.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.10/testProperties.html
+++ b/docs/2.5.10/testProperties.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.10/testcaseBuilders.html
+++ b/docs/2.5.10/testcaseBuilders.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.10/testcaseBuilders.html
+++ b/docs/2.5.10/testcaseBuilders.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.10/testcaseBuilders.html
+++ b/docs/2.5.10/testcaseBuilders.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.10/testcaseBuilders.html
+++ b/docs/2.5.10/testcaseBuilders.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.10/testcaseProviders.html
+++ b/docs/2.5.10/testcaseProviders.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.10/testcaseProviders.html
+++ b/docs/2.5.10/testcaseProviders.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.10/testcaseProviders.html
+++ b/docs/2.5.10/testcaseProviders.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.10/testcaseProviders.html
+++ b/docs/2.5.10/testcaseProviders.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.10/theory.html
+++ b/docs/2.5.10/theory.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.10/theory.html
+++ b/docs/2.5.10/theory.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.10/theory.html
+++ b/docs/2.5.10/theory.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.10/theory.html
+++ b/docs/2.5.10/theory.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.10/throwsConstraint.html
+++ b/docs/2.5.10/throwsConstraint.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.10/throwsConstraint.html
+++ b/docs/2.5.10/throwsConstraint.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.10/throwsConstraint.html
+++ b/docs/2.5.10/throwsConstraint.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.10/throwsConstraint.html
+++ b/docs/2.5.10/throwsConstraint.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.10/timeout.html
+++ b/docs/2.5.10/timeout.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.10/timeout.html
+++ b/docs/2.5.10/timeout.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.10/timeout.html
+++ b/docs/2.5.10/timeout.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.10/timeout.html
+++ b/docs/2.5.10/timeout.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.10/typeAsserts.html
+++ b/docs/2.5.10/typeAsserts.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.10/typeAsserts.html
+++ b/docs/2.5.10/typeAsserts.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.10/typeAsserts.html
+++ b/docs/2.5.10/typeAsserts.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.10/typeAsserts.html
+++ b/docs/2.5.10/typeAsserts.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.10/typeConstraints.html
+++ b/docs/2.5.10/typeConstraints.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.10/typeConstraints.html
+++ b/docs/2.5.10/typeConstraints.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.10/typeConstraints.html
+++ b/docs/2.5.10/typeConstraints.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.10/typeConstraints.html
+++ b/docs/2.5.10/typeConstraints.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.10/upgrade.html
+++ b/docs/2.5.10/upgrade.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.10/upgrade.html
+++ b/docs/2.5.10/upgrade.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.10/upgrade.html
+++ b/docs/2.5.10/upgrade.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.10/upgrade.html
+++ b/docs/2.5.10/upgrade.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.10/utilityAsserts.html
+++ b/docs/2.5.10/utilityAsserts.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.10/utilityAsserts.html
+++ b/docs/2.5.10/utilityAsserts.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.10/utilityAsserts.html
+++ b/docs/2.5.10/utilityAsserts.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.10/utilityAsserts.html
+++ b/docs/2.5.10/utilityAsserts.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.10/valueSource.html
+++ b/docs/2.5.10/valueSource.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.10/valueSource.html
+++ b/docs/2.5.10/valueSource.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.10/valueSource.html
+++ b/docs/2.5.10/valueSource.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.10/valueSource.html
+++ b/docs/2.5.10/valueSource.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.10/values.html
+++ b/docs/2.5.10/values.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.10/values.html
+++ b/docs/2.5.10/values.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.10/values.html
+++ b/docs/2.5.10/values.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.10/values.html
+++ b/docs/2.5.10/values.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.10/vsSupport.html
+++ b/docs/2.5.10/vsSupport.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.10/vsSupport.html
+++ b/docs/2.5.10/vsSupport.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.10/vsSupport.html
+++ b/docs/2.5.10/vsSupport.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.10/vsSupport.html
+++ b/docs/2.5.10/vsSupport.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.2/addinsDialog.html
+++ b/docs/2.5.2/addinsDialog.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.2/addinsDialog.html
+++ b/docs/2.5.2/addinsDialog.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.2/addinsDialog.html
+++ b/docs/2.5.2/addinsDialog.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.2/addinsDialog.html
+++ b/docs/2.5.2/addinsDialog.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.2/assertions.html
+++ b/docs/2.5.2/assertions.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.2/assertions.html
+++ b/docs/2.5.2/assertions.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.2/assertions.html
+++ b/docs/2.5.2/assertions.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.2/assertions.html
+++ b/docs/2.5.2/assertions.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.2/attributes.html
+++ b/docs/2.5.2/attributes.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.2/attributes.html
+++ b/docs/2.5.2/attributes.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.2/attributes.html
+++ b/docs/2.5.2/attributes.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.2/attributes.html
+++ b/docs/2.5.2/attributes.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.2/category.html
+++ b/docs/2.5.2/category.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.2/category.html
+++ b/docs/2.5.2/category.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.2/category.html
+++ b/docs/2.5.2/category.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.2/category.html
+++ b/docs/2.5.2/category.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.2/collectionAssert.html
+++ b/docs/2.5.2/collectionAssert.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.2/collectionAssert.html
+++ b/docs/2.5.2/collectionAssert.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.2/collectionAssert.html
+++ b/docs/2.5.2/collectionAssert.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.2/collectionAssert.html
+++ b/docs/2.5.2/collectionAssert.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.2/collectionConstraints.html
+++ b/docs/2.5.2/collectionConstraints.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.2/collectionConstraints.html
+++ b/docs/2.5.2/collectionConstraints.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.2/collectionConstraints.html
+++ b/docs/2.5.2/collectionConstraints.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.2/collectionConstraints.html
+++ b/docs/2.5.2/collectionConstraints.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.2/combinatorial.html
+++ b/docs/2.5.2/combinatorial.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.2/combinatorial.html
+++ b/docs/2.5.2/combinatorial.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.2/combinatorial.html
+++ b/docs/2.5.2/combinatorial.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.2/combinatorial.html
+++ b/docs/2.5.2/combinatorial.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.2/comparisonAsserts.html
+++ b/docs/2.5.2/comparisonAsserts.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.2/comparisonAsserts.html
+++ b/docs/2.5.2/comparisonAsserts.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.2/comparisonAsserts.html
+++ b/docs/2.5.2/comparisonAsserts.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.2/comparisonAsserts.html
+++ b/docs/2.5.2/comparisonAsserts.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.2/comparisonConstraints.html
+++ b/docs/2.5.2/comparisonConstraints.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.2/comparisonConstraints.html
+++ b/docs/2.5.2/comparisonConstraints.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.2/comparisonConstraints.html
+++ b/docs/2.5.2/comparisonConstraints.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.2/comparisonConstraints.html
+++ b/docs/2.5.2/comparisonConstraints.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.2/compoundConstraints.html
+++ b/docs/2.5.2/compoundConstraints.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.2/compoundConstraints.html
+++ b/docs/2.5.2/compoundConstraints.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.2/compoundConstraints.html
+++ b/docs/2.5.2/compoundConstraints.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.2/compoundConstraints.html
+++ b/docs/2.5.2/compoundConstraints.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.2/conditionAsserts.html
+++ b/docs/2.5.2/conditionAsserts.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.2/conditionAsserts.html
+++ b/docs/2.5.2/conditionAsserts.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.2/conditionAsserts.html
+++ b/docs/2.5.2/conditionAsserts.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.2/conditionAsserts.html
+++ b/docs/2.5.2/conditionAsserts.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.2/conditionConstraints.html
+++ b/docs/2.5.2/conditionConstraints.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.2/conditionConstraints.html
+++ b/docs/2.5.2/conditionConstraints.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.2/conditionConstraints.html
+++ b/docs/2.5.2/conditionConstraints.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.2/conditionConstraints.html
+++ b/docs/2.5.2/conditionConstraints.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.2/configEditor.html
+++ b/docs/2.5.2/configEditor.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.2/configEditor.html
+++ b/docs/2.5.2/configEditor.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.2/configEditor.html
+++ b/docs/2.5.2/configEditor.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.2/configEditor.html
+++ b/docs/2.5.2/configEditor.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.2/configFiles.html
+++ b/docs/2.5.2/configFiles.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.2/configFiles.html
+++ b/docs/2.5.2/configFiles.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.2/configFiles.html
+++ b/docs/2.5.2/configFiles.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.2/configFiles.html
+++ b/docs/2.5.2/configFiles.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.2/consoleCommandLine.html
+++ b/docs/2.5.2/consoleCommandLine.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.2/consoleCommandLine.html
+++ b/docs/2.5.2/consoleCommandLine.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.2/consoleCommandLine.html
+++ b/docs/2.5.2/consoleCommandLine.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.2/consoleCommandLine.html
+++ b/docs/2.5.2/consoleCommandLine.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.2/constraintModel.html
+++ b/docs/2.5.2/constraintModel.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.2/constraintModel.html
+++ b/docs/2.5.2/constraintModel.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.2/constraintModel.html
+++ b/docs/2.5.2/constraintModel.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.2/constraintModel.html
+++ b/docs/2.5.2/constraintModel.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.2/contextMenu.html
+++ b/docs/2.5.2/contextMenu.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.2/contextMenu.html
+++ b/docs/2.5.2/contextMenu.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.2/contextMenu.html
+++ b/docs/2.5.2/contextMenu.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.2/contextMenu.html
+++ b/docs/2.5.2/contextMenu.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.2/culture.html
+++ b/docs/2.5.2/culture.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.2/culture.html
+++ b/docs/2.5.2/culture.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.2/culture.html
+++ b/docs/2.5.2/culture.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.2/culture.html
+++ b/docs/2.5.2/culture.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.2/customConstraints.html
+++ b/docs/2.5.2/customConstraints.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.2/customConstraints.html
+++ b/docs/2.5.2/customConstraints.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.2/customConstraints.html
+++ b/docs/2.5.2/customConstraints.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.2/customConstraints.html
+++ b/docs/2.5.2/customConstraints.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.2/datapoint.html
+++ b/docs/2.5.2/datapoint.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.2/datapoint.html
+++ b/docs/2.5.2/datapoint.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.2/datapoint.html
+++ b/docs/2.5.2/datapoint.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.2/datapoint.html
+++ b/docs/2.5.2/datapoint.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.2/datapointProviders.html
+++ b/docs/2.5.2/datapointProviders.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.2/datapointProviders.html
+++ b/docs/2.5.2/datapointProviders.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.2/datapointProviders.html
+++ b/docs/2.5.2/datapointProviders.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.2/datapointProviders.html
+++ b/docs/2.5.2/datapointProviders.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.2/delayedConstraint.html
+++ b/docs/2.5.2/delayedConstraint.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.2/delayedConstraint.html
+++ b/docs/2.5.2/delayedConstraint.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.2/delayedConstraint.html
+++ b/docs/2.5.2/delayedConstraint.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.2/delayedConstraint.html
+++ b/docs/2.5.2/delayedConstraint.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.2/description.html
+++ b/docs/2.5.2/description.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.2/description.html
+++ b/docs/2.5.2/description.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.2/description.html
+++ b/docs/2.5.2/description.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.2/description.html
+++ b/docs/2.5.2/description.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.2/directoryAssert.html
+++ b/docs/2.5.2/directoryAssert.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.2/directoryAssert.html
+++ b/docs/2.5.2/directoryAssert.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.2/directoryAssert.html
+++ b/docs/2.5.2/directoryAssert.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.2/directoryAssert.html
+++ b/docs/2.5.2/directoryAssert.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.2/docHome.html
+++ b/docs/2.5.2/docHome.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.2/docHome.html
+++ b/docs/2.5.2/docHome.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.2/docHome.html
+++ b/docs/2.5.2/docHome.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.2/docHome.html
+++ b/docs/2.5.2/docHome.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.2/equalConstraint.html
+++ b/docs/2.5.2/equalConstraint.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.2/equalConstraint.html
+++ b/docs/2.5.2/equalConstraint.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.2/equalConstraint.html
+++ b/docs/2.5.2/equalConstraint.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.2/equalConstraint.html
+++ b/docs/2.5.2/equalConstraint.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.2/equalityAsserts.html
+++ b/docs/2.5.2/equalityAsserts.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.2/equalityAsserts.html
+++ b/docs/2.5.2/equalityAsserts.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.2/equalityAsserts.html
+++ b/docs/2.5.2/equalityAsserts.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.2/equalityAsserts.html
+++ b/docs/2.5.2/equalityAsserts.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.2/eventListeners.html
+++ b/docs/2.5.2/eventListeners.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.2/eventListeners.html
+++ b/docs/2.5.2/eventListeners.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.2/eventListeners.html
+++ b/docs/2.5.2/eventListeners.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.2/eventListeners.html
+++ b/docs/2.5.2/eventListeners.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.2/exception.html
+++ b/docs/2.5.2/exception.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.2/exception.html
+++ b/docs/2.5.2/exception.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.2/exception.html
+++ b/docs/2.5.2/exception.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.2/exception.html
+++ b/docs/2.5.2/exception.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.2/exceptionAsserts.html
+++ b/docs/2.5.2/exceptionAsserts.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.2/exceptionAsserts.html
+++ b/docs/2.5.2/exceptionAsserts.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.2/exceptionAsserts.html
+++ b/docs/2.5.2/exceptionAsserts.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.2/exceptionAsserts.html
+++ b/docs/2.5.2/exceptionAsserts.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.2/explicit.html
+++ b/docs/2.5.2/explicit.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.2/explicit.html
+++ b/docs/2.5.2/explicit.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.2/explicit.html
+++ b/docs/2.5.2/explicit.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.2/explicit.html
+++ b/docs/2.5.2/explicit.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.2/extensibility.html
+++ b/docs/2.5.2/extensibility.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.2/extensibility.html
+++ b/docs/2.5.2/extensibility.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.2/extensibility.html
+++ b/docs/2.5.2/extensibility.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.2/extensibility.html
+++ b/docs/2.5.2/extensibility.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.2/extensionTips.html
+++ b/docs/2.5.2/extensionTips.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.2/extensionTips.html
+++ b/docs/2.5.2/extensionTips.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.2/extensionTips.html
+++ b/docs/2.5.2/extensionTips.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.2/extensionTips.html
+++ b/docs/2.5.2/extensionTips.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.2/fileAssert.html
+++ b/docs/2.5.2/fileAssert.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.2/fileAssert.html
+++ b/docs/2.5.2/fileAssert.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.2/fileAssert.html
+++ b/docs/2.5.2/fileAssert.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.2/fileAssert.html
+++ b/docs/2.5.2/fileAssert.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.2/fixtureSetup.html
+++ b/docs/2.5.2/fixtureSetup.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.2/fixtureSetup.html
+++ b/docs/2.5.2/fixtureSetup.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.2/fixtureSetup.html
+++ b/docs/2.5.2/fixtureSetup.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.2/fixtureSetup.html
+++ b/docs/2.5.2/fixtureSetup.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.2/fixtureTeardown.html
+++ b/docs/2.5.2/fixtureTeardown.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.2/fixtureTeardown.html
+++ b/docs/2.5.2/fixtureTeardown.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.2/fixtureTeardown.html
+++ b/docs/2.5.2/fixtureTeardown.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.2/fixtureTeardown.html
+++ b/docs/2.5.2/fixtureTeardown.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.2/getStarted.html
+++ b/docs/2.5.2/getStarted.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.2/getStarted.html
+++ b/docs/2.5.2/getStarted.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.2/getStarted.html
+++ b/docs/2.5.2/getStarted.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.2/getStarted.html
+++ b/docs/2.5.2/getStarted.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.2/guiCommandLine.html
+++ b/docs/2.5.2/guiCommandLine.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.2/guiCommandLine.html
+++ b/docs/2.5.2/guiCommandLine.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.2/guiCommandLine.html
+++ b/docs/2.5.2/guiCommandLine.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.2/guiCommandLine.html
+++ b/docs/2.5.2/guiCommandLine.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.2/identityAsserts.html
+++ b/docs/2.5.2/identityAsserts.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.2/identityAsserts.html
+++ b/docs/2.5.2/identityAsserts.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.2/identityAsserts.html
+++ b/docs/2.5.2/identityAsserts.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.2/identityAsserts.html
+++ b/docs/2.5.2/identityAsserts.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.2/ignore.html
+++ b/docs/2.5.2/ignore.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.2/ignore.html
+++ b/docs/2.5.2/ignore.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.2/ignore.html
+++ b/docs/2.5.2/ignore.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.2/ignore.html
+++ b/docs/2.5.2/ignore.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.2/installation.html
+++ b/docs/2.5.2/installation.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.2/installation.html
+++ b/docs/2.5.2/installation.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.2/installation.html
+++ b/docs/2.5.2/installation.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.2/installation.html
+++ b/docs/2.5.2/installation.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.2/license.html
+++ b/docs/2.5.2/license.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.2/license.html
+++ b/docs/2.5.2/license.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.2/license.html
+++ b/docs/2.5.2/license.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.2/license.html
+++ b/docs/2.5.2/license.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.2/listMapper.html
+++ b/docs/2.5.2/listMapper.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.2/listMapper.html
+++ b/docs/2.5.2/listMapper.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.2/listMapper.html
+++ b/docs/2.5.2/listMapper.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.2/listMapper.html
+++ b/docs/2.5.2/listMapper.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.2/mainMenu.html
+++ b/docs/2.5.2/mainMenu.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.2/mainMenu.html
+++ b/docs/2.5.2/mainMenu.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.2/mainMenu.html
+++ b/docs/2.5.2/mainMenu.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.2/mainMenu.html
+++ b/docs/2.5.2/mainMenu.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.2/maxtime.html
+++ b/docs/2.5.2/maxtime.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.2/maxtime.html
+++ b/docs/2.5.2/maxtime.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.2/maxtime.html
+++ b/docs/2.5.2/maxtime.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.2/maxtime.html
+++ b/docs/2.5.2/maxtime.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.2/multiAssembly.html
+++ b/docs/2.5.2/multiAssembly.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.2/multiAssembly.html
+++ b/docs/2.5.2/multiAssembly.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.2/multiAssembly.html
+++ b/docs/2.5.2/multiAssembly.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.2/multiAssembly.html
+++ b/docs/2.5.2/multiAssembly.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.2/nunit-console.html
+++ b/docs/2.5.2/nunit-console.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.2/nunit-console.html
+++ b/docs/2.5.2/nunit-console.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.2/nunit-console.html
+++ b/docs/2.5.2/nunit-console.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.2/nunit-console.html
+++ b/docs/2.5.2/nunit-console.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.2/nunit-gui.html
+++ b/docs/2.5.2/nunit-gui.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.2/nunit-gui.html
+++ b/docs/2.5.2/nunit-gui.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.2/nunit-gui.html
+++ b/docs/2.5.2/nunit-gui.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.2/nunit-gui.html
+++ b/docs/2.5.2/nunit-gui.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.2/nunitAddins.html
+++ b/docs/2.5.2/nunitAddins.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.2/nunitAddins.html
+++ b/docs/2.5.2/nunitAddins.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.2/nunitAddins.html
+++ b/docs/2.5.2/nunitAddins.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.2/nunitAddins.html
+++ b/docs/2.5.2/nunitAddins.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.2/pairwise.html
+++ b/docs/2.5.2/pairwise.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.2/pairwise.html
+++ b/docs/2.5.2/pairwise.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.2/pairwise.html
+++ b/docs/2.5.2/pairwise.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.2/pairwise.html
+++ b/docs/2.5.2/pairwise.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.2/parameterizedTests.html
+++ b/docs/2.5.2/parameterizedTests.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.2/parameterizedTests.html
+++ b/docs/2.5.2/parameterizedTests.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.2/parameterizedTests.html
+++ b/docs/2.5.2/parameterizedTests.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.2/parameterizedTests.html
+++ b/docs/2.5.2/parameterizedTests.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.2/pathConstraints.html
+++ b/docs/2.5.2/pathConstraints.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.2/pathConstraints.html
+++ b/docs/2.5.2/pathConstraints.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.2/pathConstraints.html
+++ b/docs/2.5.2/pathConstraints.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.2/pathConstraints.html
+++ b/docs/2.5.2/pathConstraints.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.2/platform.html
+++ b/docs/2.5.2/platform.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.2/platform.html
+++ b/docs/2.5.2/platform.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.2/platform.html
+++ b/docs/2.5.2/platform.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.2/platform.html
+++ b/docs/2.5.2/platform.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.2/pnunit.html
+++ b/docs/2.5.2/pnunit.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.2/pnunit.html
+++ b/docs/2.5.2/pnunit.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.2/pnunit.html
+++ b/docs/2.5.2/pnunit.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.2/pnunit.html
+++ b/docs/2.5.2/pnunit.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.2/projectEditor.html
+++ b/docs/2.5.2/projectEditor.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.2/projectEditor.html
+++ b/docs/2.5.2/projectEditor.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.2/projectEditor.html
+++ b/docs/2.5.2/projectEditor.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.2/projectEditor.html
+++ b/docs/2.5.2/projectEditor.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.2/property.html
+++ b/docs/2.5.2/property.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.2/property.html
+++ b/docs/2.5.2/property.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.2/property.html
+++ b/docs/2.5.2/property.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.2/property.html
+++ b/docs/2.5.2/property.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.2/propertyConstraint.html
+++ b/docs/2.5.2/propertyConstraint.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.2/propertyConstraint.html
+++ b/docs/2.5.2/propertyConstraint.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.2/propertyConstraint.html
+++ b/docs/2.5.2/propertyConstraint.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.2/propertyConstraint.html
+++ b/docs/2.5.2/propertyConstraint.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.2/quickStart.html
+++ b/docs/2.5.2/quickStart.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.2/quickStart.html
+++ b/docs/2.5.2/quickStart.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.2/quickStart.html
+++ b/docs/2.5.2/quickStart.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.2/quickStart.html
+++ b/docs/2.5.2/quickStart.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.2/quickStartSource.html
+++ b/docs/2.5.2/quickStartSource.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.2/quickStartSource.html
+++ b/docs/2.5.2/quickStartSource.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.2/quickStartSource.html
+++ b/docs/2.5.2/quickStartSource.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.2/quickStartSource.html
+++ b/docs/2.5.2/quickStartSource.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.2/random.html
+++ b/docs/2.5.2/random.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.2/random.html
+++ b/docs/2.5.2/random.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.2/random.html
+++ b/docs/2.5.2/random.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.2/random.html
+++ b/docs/2.5.2/random.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.2/range.html
+++ b/docs/2.5.2/range.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.2/range.html
+++ b/docs/2.5.2/range.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.2/range.html
+++ b/docs/2.5.2/range.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.2/range.html
+++ b/docs/2.5.2/range.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.2/releaseNotes.html
+++ b/docs/2.5.2/releaseNotes.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.2/releaseNotes.html
+++ b/docs/2.5.2/releaseNotes.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.2/releaseNotes.html
+++ b/docs/2.5.2/releaseNotes.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.2/releaseNotes.html
+++ b/docs/2.5.2/releaseNotes.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.2/repeat.html
+++ b/docs/2.5.2/repeat.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.2/repeat.html
+++ b/docs/2.5.2/repeat.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.2/repeat.html
+++ b/docs/2.5.2/repeat.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.2/repeat.html
+++ b/docs/2.5.2/repeat.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.2/requiredAddin.html
+++ b/docs/2.5.2/requiredAddin.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.2/requiredAddin.html
+++ b/docs/2.5.2/requiredAddin.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.2/requiredAddin.html
+++ b/docs/2.5.2/requiredAddin.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.2/requiredAddin.html
+++ b/docs/2.5.2/requiredAddin.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.2/requiresMTA.html
+++ b/docs/2.5.2/requiresMTA.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.2/requiresMTA.html
+++ b/docs/2.5.2/requiresMTA.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.2/requiresMTA.html
+++ b/docs/2.5.2/requiresMTA.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.2/requiresMTA.html
+++ b/docs/2.5.2/requiresMTA.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.2/requiresSTA.html
+++ b/docs/2.5.2/requiresSTA.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.2/requiresSTA.html
+++ b/docs/2.5.2/requiresSTA.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.2/requiresSTA.html
+++ b/docs/2.5.2/requiresSTA.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.2/requiresSTA.html
+++ b/docs/2.5.2/requiresSTA.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.2/requiresThread.html
+++ b/docs/2.5.2/requiresThread.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.2/requiresThread.html
+++ b/docs/2.5.2/requiresThread.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.2/requiresThread.html
+++ b/docs/2.5.2/requiresThread.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.2/requiresThread.html
+++ b/docs/2.5.2/requiresThread.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.2/sameasConstraint.html
+++ b/docs/2.5.2/sameasConstraint.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.2/sameasConstraint.html
+++ b/docs/2.5.2/sameasConstraint.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.2/sameasConstraint.html
+++ b/docs/2.5.2/sameasConstraint.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.2/sameasConstraint.html
+++ b/docs/2.5.2/sameasConstraint.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.2/samples.html
+++ b/docs/2.5.2/samples.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.2/samples.html
+++ b/docs/2.5.2/samples.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.2/samples.html
+++ b/docs/2.5.2/samples.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.2/samples.html
+++ b/docs/2.5.2/samples.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.2/sequential.html
+++ b/docs/2.5.2/sequential.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.2/sequential.html
+++ b/docs/2.5.2/sequential.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.2/sequential.html
+++ b/docs/2.5.2/sequential.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.2/sequential.html
+++ b/docs/2.5.2/sequential.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.2/setCulture.html
+++ b/docs/2.5.2/setCulture.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.2/setCulture.html
+++ b/docs/2.5.2/setCulture.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.2/setCulture.html
+++ b/docs/2.5.2/setCulture.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.2/setCulture.html
+++ b/docs/2.5.2/setCulture.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.2/setUICulture.html
+++ b/docs/2.5.2/setUICulture.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.2/setUICulture.html
+++ b/docs/2.5.2/setUICulture.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.2/setUICulture.html
+++ b/docs/2.5.2/setUICulture.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.2/setUICulture.html
+++ b/docs/2.5.2/setUICulture.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.2/settingsDialog.html
+++ b/docs/2.5.2/settingsDialog.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.2/settingsDialog.html
+++ b/docs/2.5.2/settingsDialog.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.2/settingsDialog.html
+++ b/docs/2.5.2/settingsDialog.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.2/settingsDialog.html
+++ b/docs/2.5.2/settingsDialog.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.2/setup.html
+++ b/docs/2.5.2/setup.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.2/setup.html
+++ b/docs/2.5.2/setup.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.2/setup.html
+++ b/docs/2.5.2/setup.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.2/setup.html
+++ b/docs/2.5.2/setup.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.2/setupFixture.html
+++ b/docs/2.5.2/setupFixture.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.2/setupFixture.html
+++ b/docs/2.5.2/setupFixture.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.2/setupFixture.html
+++ b/docs/2.5.2/setupFixture.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.2/setupFixture.html
+++ b/docs/2.5.2/setupFixture.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.2/stringAssert.html
+++ b/docs/2.5.2/stringAssert.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.2/stringAssert.html
+++ b/docs/2.5.2/stringAssert.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.2/stringAssert.html
+++ b/docs/2.5.2/stringAssert.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.2/stringAssert.html
+++ b/docs/2.5.2/stringAssert.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.2/stringConstraints.html
+++ b/docs/2.5.2/stringConstraints.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.2/stringConstraints.html
+++ b/docs/2.5.2/stringConstraints.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.2/stringConstraints.html
+++ b/docs/2.5.2/stringConstraints.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.2/stringConstraints.html
+++ b/docs/2.5.2/stringConstraints.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.2/suite.html
+++ b/docs/2.5.2/suite.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.2/suite.html
+++ b/docs/2.5.2/suite.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.2/suite.html
+++ b/docs/2.5.2/suite.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.2/suite.html
+++ b/docs/2.5.2/suite.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.2/suiteBuilders.html
+++ b/docs/2.5.2/suiteBuilders.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.2/suiteBuilders.html
+++ b/docs/2.5.2/suiteBuilders.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.2/suiteBuilders.html
+++ b/docs/2.5.2/suiteBuilders.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.2/suiteBuilders.html
+++ b/docs/2.5.2/suiteBuilders.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.2/teardown.html
+++ b/docs/2.5.2/teardown.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.2/teardown.html
+++ b/docs/2.5.2/teardown.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.2/teardown.html
+++ b/docs/2.5.2/teardown.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.2/teardown.html
+++ b/docs/2.5.2/teardown.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.2/test.html
+++ b/docs/2.5.2/test.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.2/test.html
+++ b/docs/2.5.2/test.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.2/test.html
+++ b/docs/2.5.2/test.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.2/test.html
+++ b/docs/2.5.2/test.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.2/testCase.html
+++ b/docs/2.5.2/testCase.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.2/testCase.html
+++ b/docs/2.5.2/testCase.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.2/testCase.html
+++ b/docs/2.5.2/testCase.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.2/testCase.html
+++ b/docs/2.5.2/testCase.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.2/testCaseSource.html
+++ b/docs/2.5.2/testCaseSource.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.2/testCaseSource.html
+++ b/docs/2.5.2/testCaseSource.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.2/testCaseSource.html
+++ b/docs/2.5.2/testCaseSource.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.2/testCaseSource.html
+++ b/docs/2.5.2/testCaseSource.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.2/testDecorators.html
+++ b/docs/2.5.2/testDecorators.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.2/testDecorators.html
+++ b/docs/2.5.2/testDecorators.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.2/testDecorators.html
+++ b/docs/2.5.2/testDecorators.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.2/testDecorators.html
+++ b/docs/2.5.2/testDecorators.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.2/testFixture.html
+++ b/docs/2.5.2/testFixture.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.2/testFixture.html
+++ b/docs/2.5.2/testFixture.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.2/testFixture.html
+++ b/docs/2.5.2/testFixture.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.2/testFixture.html
+++ b/docs/2.5.2/testFixture.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.2/testProperties.html
+++ b/docs/2.5.2/testProperties.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.2/testProperties.html
+++ b/docs/2.5.2/testProperties.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.2/testProperties.html
+++ b/docs/2.5.2/testProperties.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.2/testProperties.html
+++ b/docs/2.5.2/testProperties.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.2/testcaseBuilders.html
+++ b/docs/2.5.2/testcaseBuilders.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.2/testcaseBuilders.html
+++ b/docs/2.5.2/testcaseBuilders.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.2/testcaseBuilders.html
+++ b/docs/2.5.2/testcaseBuilders.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.2/testcaseBuilders.html
+++ b/docs/2.5.2/testcaseBuilders.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.2/testcaseProviders.html
+++ b/docs/2.5.2/testcaseProviders.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.2/testcaseProviders.html
+++ b/docs/2.5.2/testcaseProviders.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.2/testcaseProviders.html
+++ b/docs/2.5.2/testcaseProviders.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.2/testcaseProviders.html
+++ b/docs/2.5.2/testcaseProviders.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.2/theory.html
+++ b/docs/2.5.2/theory.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.2/theory.html
+++ b/docs/2.5.2/theory.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.2/theory.html
+++ b/docs/2.5.2/theory.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.2/theory.html
+++ b/docs/2.5.2/theory.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.2/throwsConstraint.html
+++ b/docs/2.5.2/throwsConstraint.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.2/throwsConstraint.html
+++ b/docs/2.5.2/throwsConstraint.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.2/throwsConstraint.html
+++ b/docs/2.5.2/throwsConstraint.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.2/throwsConstraint.html
+++ b/docs/2.5.2/throwsConstraint.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.2/timeout.html
+++ b/docs/2.5.2/timeout.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.2/timeout.html
+++ b/docs/2.5.2/timeout.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.2/timeout.html
+++ b/docs/2.5.2/timeout.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.2/timeout.html
+++ b/docs/2.5.2/timeout.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.2/typeAsserts.html
+++ b/docs/2.5.2/typeAsserts.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.2/typeAsserts.html
+++ b/docs/2.5.2/typeAsserts.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.2/typeAsserts.html
+++ b/docs/2.5.2/typeAsserts.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.2/typeAsserts.html
+++ b/docs/2.5.2/typeAsserts.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.2/typeConstraints.html
+++ b/docs/2.5.2/typeConstraints.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.2/typeConstraints.html
+++ b/docs/2.5.2/typeConstraints.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.2/typeConstraints.html
+++ b/docs/2.5.2/typeConstraints.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.2/typeConstraints.html
+++ b/docs/2.5.2/typeConstraints.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.2/upgrade.html
+++ b/docs/2.5.2/upgrade.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.2/upgrade.html
+++ b/docs/2.5.2/upgrade.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.2/upgrade.html
+++ b/docs/2.5.2/upgrade.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.2/upgrade.html
+++ b/docs/2.5.2/upgrade.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.2/utilityAsserts.html
+++ b/docs/2.5.2/utilityAsserts.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.2/utilityAsserts.html
+++ b/docs/2.5.2/utilityAsserts.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.2/utilityAsserts.html
+++ b/docs/2.5.2/utilityAsserts.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.2/utilityAsserts.html
+++ b/docs/2.5.2/utilityAsserts.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.2/valueSource.html
+++ b/docs/2.5.2/valueSource.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.2/valueSource.html
+++ b/docs/2.5.2/valueSource.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.2/valueSource.html
+++ b/docs/2.5.2/valueSource.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.2/valueSource.html
+++ b/docs/2.5.2/valueSource.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.2/values.html
+++ b/docs/2.5.2/values.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.2/values.html
+++ b/docs/2.5.2/values.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.2/values.html
+++ b/docs/2.5.2/values.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.2/values.html
+++ b/docs/2.5.2/values.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.2/vsSupport.html
+++ b/docs/2.5.2/vsSupport.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.2/vsSupport.html
+++ b/docs/2.5.2/vsSupport.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.2/vsSupport.html
+++ b/docs/2.5.2/vsSupport.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.2/vsSupport.html
+++ b/docs/2.5.2/vsSupport.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.3/addinsDialog.html
+++ b/docs/2.5.3/addinsDialog.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.3/addinsDialog.html
+++ b/docs/2.5.3/addinsDialog.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.3/addinsDialog.html
+++ b/docs/2.5.3/addinsDialog.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.3/addinsDialog.html
+++ b/docs/2.5.3/addinsDialog.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.3/assertions.html
+++ b/docs/2.5.3/assertions.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.3/assertions.html
+++ b/docs/2.5.3/assertions.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.3/assertions.html
+++ b/docs/2.5.3/assertions.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.3/assertions.html
+++ b/docs/2.5.3/assertions.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.3/attributes.html
+++ b/docs/2.5.3/attributes.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.3/attributes.html
+++ b/docs/2.5.3/attributes.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.3/attributes.html
+++ b/docs/2.5.3/attributes.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.3/attributes.html
+++ b/docs/2.5.3/attributes.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.3/category.html
+++ b/docs/2.5.3/category.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.3/category.html
+++ b/docs/2.5.3/category.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.3/category.html
+++ b/docs/2.5.3/category.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.3/category.html
+++ b/docs/2.5.3/category.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.3/collectionAssert.html
+++ b/docs/2.5.3/collectionAssert.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.3/collectionAssert.html
+++ b/docs/2.5.3/collectionAssert.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.3/collectionAssert.html
+++ b/docs/2.5.3/collectionAssert.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.3/collectionAssert.html
+++ b/docs/2.5.3/collectionAssert.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.3/collectionConstraints.html
+++ b/docs/2.5.3/collectionConstraints.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.3/collectionConstraints.html
+++ b/docs/2.5.3/collectionConstraints.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.3/collectionConstraints.html
+++ b/docs/2.5.3/collectionConstraints.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.3/collectionConstraints.html
+++ b/docs/2.5.3/collectionConstraints.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.3/combinatorial.html
+++ b/docs/2.5.3/combinatorial.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.3/combinatorial.html
+++ b/docs/2.5.3/combinatorial.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.3/combinatorial.html
+++ b/docs/2.5.3/combinatorial.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.3/combinatorial.html
+++ b/docs/2.5.3/combinatorial.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.3/comparisonAsserts.html
+++ b/docs/2.5.3/comparisonAsserts.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.3/comparisonAsserts.html
+++ b/docs/2.5.3/comparisonAsserts.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.3/comparisonAsserts.html
+++ b/docs/2.5.3/comparisonAsserts.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.3/comparisonAsserts.html
+++ b/docs/2.5.3/comparisonAsserts.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.3/comparisonConstraints.html
+++ b/docs/2.5.3/comparisonConstraints.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.3/comparisonConstraints.html
+++ b/docs/2.5.3/comparisonConstraints.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.3/comparisonConstraints.html
+++ b/docs/2.5.3/comparisonConstraints.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.3/comparisonConstraints.html
+++ b/docs/2.5.3/comparisonConstraints.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.3/compoundConstraints.html
+++ b/docs/2.5.3/compoundConstraints.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.3/compoundConstraints.html
+++ b/docs/2.5.3/compoundConstraints.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.3/compoundConstraints.html
+++ b/docs/2.5.3/compoundConstraints.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.3/compoundConstraints.html
+++ b/docs/2.5.3/compoundConstraints.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.3/conditionAsserts.html
+++ b/docs/2.5.3/conditionAsserts.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.3/conditionAsserts.html
+++ b/docs/2.5.3/conditionAsserts.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.3/conditionAsserts.html
+++ b/docs/2.5.3/conditionAsserts.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.3/conditionAsserts.html
+++ b/docs/2.5.3/conditionAsserts.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.3/conditionConstraints.html
+++ b/docs/2.5.3/conditionConstraints.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.3/conditionConstraints.html
+++ b/docs/2.5.3/conditionConstraints.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.3/conditionConstraints.html
+++ b/docs/2.5.3/conditionConstraints.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.3/conditionConstraints.html
+++ b/docs/2.5.3/conditionConstraints.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.3/configEditor.html
+++ b/docs/2.5.3/configEditor.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.3/configEditor.html
+++ b/docs/2.5.3/configEditor.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.3/configEditor.html
+++ b/docs/2.5.3/configEditor.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.3/configEditor.html
+++ b/docs/2.5.3/configEditor.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.3/configFiles.html
+++ b/docs/2.5.3/configFiles.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.3/configFiles.html
+++ b/docs/2.5.3/configFiles.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.3/configFiles.html
+++ b/docs/2.5.3/configFiles.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.3/configFiles.html
+++ b/docs/2.5.3/configFiles.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.3/consoleCommandLine.html
+++ b/docs/2.5.3/consoleCommandLine.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.3/consoleCommandLine.html
+++ b/docs/2.5.3/consoleCommandLine.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.3/consoleCommandLine.html
+++ b/docs/2.5.3/consoleCommandLine.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.3/consoleCommandLine.html
+++ b/docs/2.5.3/consoleCommandLine.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.3/constraintModel.html
+++ b/docs/2.5.3/constraintModel.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.3/constraintModel.html
+++ b/docs/2.5.3/constraintModel.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.3/constraintModel.html
+++ b/docs/2.5.3/constraintModel.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.3/constraintModel.html
+++ b/docs/2.5.3/constraintModel.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.3/contextMenu.html
+++ b/docs/2.5.3/contextMenu.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.3/contextMenu.html
+++ b/docs/2.5.3/contextMenu.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.3/contextMenu.html
+++ b/docs/2.5.3/contextMenu.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.3/contextMenu.html
+++ b/docs/2.5.3/contextMenu.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.3/culture.html
+++ b/docs/2.5.3/culture.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.3/culture.html
+++ b/docs/2.5.3/culture.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.3/culture.html
+++ b/docs/2.5.3/culture.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.3/culture.html
+++ b/docs/2.5.3/culture.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.3/customConstraints.html
+++ b/docs/2.5.3/customConstraints.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.3/customConstraints.html
+++ b/docs/2.5.3/customConstraints.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.3/customConstraints.html
+++ b/docs/2.5.3/customConstraints.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.3/customConstraints.html
+++ b/docs/2.5.3/customConstraints.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.3/datapoint.html
+++ b/docs/2.5.3/datapoint.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.3/datapoint.html
+++ b/docs/2.5.3/datapoint.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.3/datapoint.html
+++ b/docs/2.5.3/datapoint.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.3/datapoint.html
+++ b/docs/2.5.3/datapoint.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.3/datapointProviders.html
+++ b/docs/2.5.3/datapointProviders.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.3/datapointProviders.html
+++ b/docs/2.5.3/datapointProviders.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.3/datapointProviders.html
+++ b/docs/2.5.3/datapointProviders.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.3/datapointProviders.html
+++ b/docs/2.5.3/datapointProviders.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.3/delayedConstraint.html
+++ b/docs/2.5.3/delayedConstraint.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.3/delayedConstraint.html
+++ b/docs/2.5.3/delayedConstraint.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.3/delayedConstraint.html
+++ b/docs/2.5.3/delayedConstraint.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.3/delayedConstraint.html
+++ b/docs/2.5.3/delayedConstraint.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.3/description.html
+++ b/docs/2.5.3/description.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.3/description.html
+++ b/docs/2.5.3/description.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.3/description.html
+++ b/docs/2.5.3/description.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.3/description.html
+++ b/docs/2.5.3/description.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.3/directoryAssert.html
+++ b/docs/2.5.3/directoryAssert.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.3/directoryAssert.html
+++ b/docs/2.5.3/directoryAssert.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.3/directoryAssert.html
+++ b/docs/2.5.3/directoryAssert.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.3/directoryAssert.html
+++ b/docs/2.5.3/directoryAssert.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.3/docHome.html
+++ b/docs/2.5.3/docHome.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.3/docHome.html
+++ b/docs/2.5.3/docHome.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.3/docHome.html
+++ b/docs/2.5.3/docHome.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.3/docHome.html
+++ b/docs/2.5.3/docHome.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.3/equalConstraint.html
+++ b/docs/2.5.3/equalConstraint.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.3/equalConstraint.html
+++ b/docs/2.5.3/equalConstraint.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.3/equalConstraint.html
+++ b/docs/2.5.3/equalConstraint.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.3/equalConstraint.html
+++ b/docs/2.5.3/equalConstraint.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.3/equalityAsserts.html
+++ b/docs/2.5.3/equalityAsserts.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.3/equalityAsserts.html
+++ b/docs/2.5.3/equalityAsserts.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.3/equalityAsserts.html
+++ b/docs/2.5.3/equalityAsserts.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.3/equalityAsserts.html
+++ b/docs/2.5.3/equalityAsserts.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.3/eventListeners.html
+++ b/docs/2.5.3/eventListeners.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.3/eventListeners.html
+++ b/docs/2.5.3/eventListeners.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.3/eventListeners.html
+++ b/docs/2.5.3/eventListeners.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.3/eventListeners.html
+++ b/docs/2.5.3/eventListeners.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.3/exception.html
+++ b/docs/2.5.3/exception.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.3/exception.html
+++ b/docs/2.5.3/exception.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.3/exception.html
+++ b/docs/2.5.3/exception.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.3/exception.html
+++ b/docs/2.5.3/exception.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.3/exceptionAsserts.html
+++ b/docs/2.5.3/exceptionAsserts.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.3/exceptionAsserts.html
+++ b/docs/2.5.3/exceptionAsserts.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.3/exceptionAsserts.html
+++ b/docs/2.5.3/exceptionAsserts.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.3/exceptionAsserts.html
+++ b/docs/2.5.3/exceptionAsserts.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.3/explicit.html
+++ b/docs/2.5.3/explicit.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.3/explicit.html
+++ b/docs/2.5.3/explicit.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.3/explicit.html
+++ b/docs/2.5.3/explicit.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.3/explicit.html
+++ b/docs/2.5.3/explicit.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.3/extensibility.html
+++ b/docs/2.5.3/extensibility.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.3/extensibility.html
+++ b/docs/2.5.3/extensibility.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.3/extensibility.html
+++ b/docs/2.5.3/extensibility.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.3/extensibility.html
+++ b/docs/2.5.3/extensibility.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.3/extensionTips.html
+++ b/docs/2.5.3/extensionTips.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.3/extensionTips.html
+++ b/docs/2.5.3/extensionTips.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.3/extensionTips.html
+++ b/docs/2.5.3/extensionTips.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.3/extensionTips.html
+++ b/docs/2.5.3/extensionTips.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.3/fileAssert.html
+++ b/docs/2.5.3/fileAssert.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.3/fileAssert.html
+++ b/docs/2.5.3/fileAssert.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.3/fileAssert.html
+++ b/docs/2.5.3/fileAssert.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.3/fileAssert.html
+++ b/docs/2.5.3/fileAssert.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.3/fixtureSetup.html
+++ b/docs/2.5.3/fixtureSetup.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.3/fixtureSetup.html
+++ b/docs/2.5.3/fixtureSetup.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.3/fixtureSetup.html
+++ b/docs/2.5.3/fixtureSetup.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.3/fixtureSetup.html
+++ b/docs/2.5.3/fixtureSetup.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.3/fixtureTeardown.html
+++ b/docs/2.5.3/fixtureTeardown.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.3/fixtureTeardown.html
+++ b/docs/2.5.3/fixtureTeardown.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.3/fixtureTeardown.html
+++ b/docs/2.5.3/fixtureTeardown.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.3/fixtureTeardown.html
+++ b/docs/2.5.3/fixtureTeardown.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.3/getStarted.html
+++ b/docs/2.5.3/getStarted.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.3/getStarted.html
+++ b/docs/2.5.3/getStarted.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.3/getStarted.html
+++ b/docs/2.5.3/getStarted.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.3/getStarted.html
+++ b/docs/2.5.3/getStarted.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.3/guiCommandLine.html
+++ b/docs/2.5.3/guiCommandLine.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.3/guiCommandLine.html
+++ b/docs/2.5.3/guiCommandLine.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.3/guiCommandLine.html
+++ b/docs/2.5.3/guiCommandLine.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.3/guiCommandLine.html
+++ b/docs/2.5.3/guiCommandLine.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.3/identityAsserts.html
+++ b/docs/2.5.3/identityAsserts.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.3/identityAsserts.html
+++ b/docs/2.5.3/identityAsserts.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.3/identityAsserts.html
+++ b/docs/2.5.3/identityAsserts.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.3/identityAsserts.html
+++ b/docs/2.5.3/identityAsserts.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.3/ignore.html
+++ b/docs/2.5.3/ignore.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.3/ignore.html
+++ b/docs/2.5.3/ignore.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.3/ignore.html
+++ b/docs/2.5.3/ignore.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.3/ignore.html
+++ b/docs/2.5.3/ignore.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.3/installation.html
+++ b/docs/2.5.3/installation.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.3/installation.html
+++ b/docs/2.5.3/installation.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.3/installation.html
+++ b/docs/2.5.3/installation.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.3/installation.html
+++ b/docs/2.5.3/installation.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.3/license.html
+++ b/docs/2.5.3/license.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.3/license.html
+++ b/docs/2.5.3/license.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.3/license.html
+++ b/docs/2.5.3/license.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.3/license.html
+++ b/docs/2.5.3/license.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.3/listMapper.html
+++ b/docs/2.5.3/listMapper.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.3/listMapper.html
+++ b/docs/2.5.3/listMapper.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.3/listMapper.html
+++ b/docs/2.5.3/listMapper.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.3/listMapper.html
+++ b/docs/2.5.3/listMapper.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.3/mainMenu.html
+++ b/docs/2.5.3/mainMenu.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.3/mainMenu.html
+++ b/docs/2.5.3/mainMenu.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.3/mainMenu.html
+++ b/docs/2.5.3/mainMenu.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.3/mainMenu.html
+++ b/docs/2.5.3/mainMenu.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.3/maxtime.html
+++ b/docs/2.5.3/maxtime.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.3/maxtime.html
+++ b/docs/2.5.3/maxtime.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.3/maxtime.html
+++ b/docs/2.5.3/maxtime.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.3/maxtime.html
+++ b/docs/2.5.3/maxtime.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.3/multiAssembly.html
+++ b/docs/2.5.3/multiAssembly.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.3/multiAssembly.html
+++ b/docs/2.5.3/multiAssembly.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.3/multiAssembly.html
+++ b/docs/2.5.3/multiAssembly.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.3/multiAssembly.html
+++ b/docs/2.5.3/multiAssembly.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.3/nunit-console.html
+++ b/docs/2.5.3/nunit-console.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.3/nunit-console.html
+++ b/docs/2.5.3/nunit-console.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.3/nunit-console.html
+++ b/docs/2.5.3/nunit-console.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.3/nunit-console.html
+++ b/docs/2.5.3/nunit-console.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.3/nunit-gui.html
+++ b/docs/2.5.3/nunit-gui.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.3/nunit-gui.html
+++ b/docs/2.5.3/nunit-gui.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.3/nunit-gui.html
+++ b/docs/2.5.3/nunit-gui.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.3/nunit-gui.html
+++ b/docs/2.5.3/nunit-gui.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.3/nunitAddins.html
+++ b/docs/2.5.3/nunitAddins.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.3/nunitAddins.html
+++ b/docs/2.5.3/nunitAddins.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.3/nunitAddins.html
+++ b/docs/2.5.3/nunitAddins.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.3/nunitAddins.html
+++ b/docs/2.5.3/nunitAddins.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.3/pairwise.html
+++ b/docs/2.5.3/pairwise.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.3/pairwise.html
+++ b/docs/2.5.3/pairwise.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.3/pairwise.html
+++ b/docs/2.5.3/pairwise.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.3/pairwise.html
+++ b/docs/2.5.3/pairwise.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.3/parameterizedTests.html
+++ b/docs/2.5.3/parameterizedTests.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.3/parameterizedTests.html
+++ b/docs/2.5.3/parameterizedTests.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.3/parameterizedTests.html
+++ b/docs/2.5.3/parameterizedTests.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.3/parameterizedTests.html
+++ b/docs/2.5.3/parameterizedTests.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.3/pathConstraints.html
+++ b/docs/2.5.3/pathConstraints.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.3/pathConstraints.html
+++ b/docs/2.5.3/pathConstraints.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.3/pathConstraints.html
+++ b/docs/2.5.3/pathConstraints.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.3/pathConstraints.html
+++ b/docs/2.5.3/pathConstraints.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.3/platform.html
+++ b/docs/2.5.3/platform.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.3/platform.html
+++ b/docs/2.5.3/platform.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.3/platform.html
+++ b/docs/2.5.3/platform.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.3/platform.html
+++ b/docs/2.5.3/platform.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.3/pnunit.html
+++ b/docs/2.5.3/pnunit.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.3/pnunit.html
+++ b/docs/2.5.3/pnunit.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.3/pnunit.html
+++ b/docs/2.5.3/pnunit.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.3/pnunit.html
+++ b/docs/2.5.3/pnunit.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.3/projectEditor.html
+++ b/docs/2.5.3/projectEditor.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.3/projectEditor.html
+++ b/docs/2.5.3/projectEditor.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.3/projectEditor.html
+++ b/docs/2.5.3/projectEditor.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.3/projectEditor.html
+++ b/docs/2.5.3/projectEditor.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.3/property.html
+++ b/docs/2.5.3/property.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.3/property.html
+++ b/docs/2.5.3/property.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.3/property.html
+++ b/docs/2.5.3/property.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.3/property.html
+++ b/docs/2.5.3/property.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.3/propertyConstraint.html
+++ b/docs/2.5.3/propertyConstraint.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.3/propertyConstraint.html
+++ b/docs/2.5.3/propertyConstraint.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.3/propertyConstraint.html
+++ b/docs/2.5.3/propertyConstraint.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.3/propertyConstraint.html
+++ b/docs/2.5.3/propertyConstraint.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.3/quickStart.html
+++ b/docs/2.5.3/quickStart.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.3/quickStart.html
+++ b/docs/2.5.3/quickStart.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.3/quickStart.html
+++ b/docs/2.5.3/quickStart.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.3/quickStart.html
+++ b/docs/2.5.3/quickStart.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.3/quickStartSource.html
+++ b/docs/2.5.3/quickStartSource.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.3/quickStartSource.html
+++ b/docs/2.5.3/quickStartSource.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.3/quickStartSource.html
+++ b/docs/2.5.3/quickStartSource.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.3/quickStartSource.html
+++ b/docs/2.5.3/quickStartSource.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.3/random.html
+++ b/docs/2.5.3/random.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.3/random.html
+++ b/docs/2.5.3/random.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.3/random.html
+++ b/docs/2.5.3/random.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.3/random.html
+++ b/docs/2.5.3/random.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.3/range.html
+++ b/docs/2.5.3/range.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.3/range.html
+++ b/docs/2.5.3/range.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.3/range.html
+++ b/docs/2.5.3/range.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.3/range.html
+++ b/docs/2.5.3/range.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.3/releaseNotes.html
+++ b/docs/2.5.3/releaseNotes.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.3/releaseNotes.html
+++ b/docs/2.5.3/releaseNotes.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.3/releaseNotes.html
+++ b/docs/2.5.3/releaseNotes.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.3/releaseNotes.html
+++ b/docs/2.5.3/releaseNotes.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.3/repeat.html
+++ b/docs/2.5.3/repeat.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.3/repeat.html
+++ b/docs/2.5.3/repeat.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.3/repeat.html
+++ b/docs/2.5.3/repeat.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.3/repeat.html
+++ b/docs/2.5.3/repeat.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.3/requiredAddin.html
+++ b/docs/2.5.3/requiredAddin.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.3/requiredAddin.html
+++ b/docs/2.5.3/requiredAddin.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.3/requiredAddin.html
+++ b/docs/2.5.3/requiredAddin.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.3/requiredAddin.html
+++ b/docs/2.5.3/requiredAddin.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.3/requiresMTA.html
+++ b/docs/2.5.3/requiresMTA.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.3/requiresMTA.html
+++ b/docs/2.5.3/requiresMTA.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.3/requiresMTA.html
+++ b/docs/2.5.3/requiresMTA.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.3/requiresMTA.html
+++ b/docs/2.5.3/requiresMTA.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.3/requiresSTA.html
+++ b/docs/2.5.3/requiresSTA.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.3/requiresSTA.html
+++ b/docs/2.5.3/requiresSTA.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.3/requiresSTA.html
+++ b/docs/2.5.3/requiresSTA.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.3/requiresSTA.html
+++ b/docs/2.5.3/requiresSTA.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.3/requiresThread.html
+++ b/docs/2.5.3/requiresThread.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.3/requiresThread.html
+++ b/docs/2.5.3/requiresThread.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.3/requiresThread.html
+++ b/docs/2.5.3/requiresThread.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.3/requiresThread.html
+++ b/docs/2.5.3/requiresThread.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.3/sameasConstraint.html
+++ b/docs/2.5.3/sameasConstraint.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.3/sameasConstraint.html
+++ b/docs/2.5.3/sameasConstraint.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.3/sameasConstraint.html
+++ b/docs/2.5.3/sameasConstraint.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.3/sameasConstraint.html
+++ b/docs/2.5.3/sameasConstraint.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.3/samples.html
+++ b/docs/2.5.3/samples.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.3/samples.html
+++ b/docs/2.5.3/samples.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.3/samples.html
+++ b/docs/2.5.3/samples.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.3/samples.html
+++ b/docs/2.5.3/samples.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.3/sequential.html
+++ b/docs/2.5.3/sequential.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.3/sequential.html
+++ b/docs/2.5.3/sequential.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.3/sequential.html
+++ b/docs/2.5.3/sequential.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.3/sequential.html
+++ b/docs/2.5.3/sequential.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.3/setCulture.html
+++ b/docs/2.5.3/setCulture.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.3/setCulture.html
+++ b/docs/2.5.3/setCulture.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.3/setCulture.html
+++ b/docs/2.5.3/setCulture.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.3/setCulture.html
+++ b/docs/2.5.3/setCulture.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.3/setUICulture.html
+++ b/docs/2.5.3/setUICulture.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.3/setUICulture.html
+++ b/docs/2.5.3/setUICulture.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.3/setUICulture.html
+++ b/docs/2.5.3/setUICulture.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.3/setUICulture.html
+++ b/docs/2.5.3/setUICulture.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.3/settingsDialog.html
+++ b/docs/2.5.3/settingsDialog.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.3/settingsDialog.html
+++ b/docs/2.5.3/settingsDialog.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.3/settingsDialog.html
+++ b/docs/2.5.3/settingsDialog.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.3/settingsDialog.html
+++ b/docs/2.5.3/settingsDialog.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.3/setup.html
+++ b/docs/2.5.3/setup.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.3/setup.html
+++ b/docs/2.5.3/setup.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.3/setup.html
+++ b/docs/2.5.3/setup.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.3/setup.html
+++ b/docs/2.5.3/setup.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.3/setupFixture.html
+++ b/docs/2.5.3/setupFixture.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.3/setupFixture.html
+++ b/docs/2.5.3/setupFixture.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.3/setupFixture.html
+++ b/docs/2.5.3/setupFixture.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.3/setupFixture.html
+++ b/docs/2.5.3/setupFixture.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.3/stringAssert.html
+++ b/docs/2.5.3/stringAssert.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.3/stringAssert.html
+++ b/docs/2.5.3/stringAssert.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.3/stringAssert.html
+++ b/docs/2.5.3/stringAssert.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.3/stringAssert.html
+++ b/docs/2.5.3/stringAssert.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.3/stringConstraints.html
+++ b/docs/2.5.3/stringConstraints.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.3/stringConstraints.html
+++ b/docs/2.5.3/stringConstraints.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.3/stringConstraints.html
+++ b/docs/2.5.3/stringConstraints.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.3/stringConstraints.html
+++ b/docs/2.5.3/stringConstraints.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.3/suite.html
+++ b/docs/2.5.3/suite.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.3/suite.html
+++ b/docs/2.5.3/suite.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.3/suite.html
+++ b/docs/2.5.3/suite.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.3/suite.html
+++ b/docs/2.5.3/suite.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.3/suiteBuilders.html
+++ b/docs/2.5.3/suiteBuilders.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.3/suiteBuilders.html
+++ b/docs/2.5.3/suiteBuilders.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.3/suiteBuilders.html
+++ b/docs/2.5.3/suiteBuilders.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.3/suiteBuilders.html
+++ b/docs/2.5.3/suiteBuilders.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.3/teardown.html
+++ b/docs/2.5.3/teardown.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.3/teardown.html
+++ b/docs/2.5.3/teardown.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.3/teardown.html
+++ b/docs/2.5.3/teardown.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.3/teardown.html
+++ b/docs/2.5.3/teardown.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.3/test.html
+++ b/docs/2.5.3/test.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.3/test.html
+++ b/docs/2.5.3/test.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.3/test.html
+++ b/docs/2.5.3/test.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.3/test.html
+++ b/docs/2.5.3/test.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.3/testCase.html
+++ b/docs/2.5.3/testCase.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.3/testCase.html
+++ b/docs/2.5.3/testCase.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.3/testCase.html
+++ b/docs/2.5.3/testCase.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.3/testCase.html
+++ b/docs/2.5.3/testCase.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.3/testCaseSource.html
+++ b/docs/2.5.3/testCaseSource.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.3/testCaseSource.html
+++ b/docs/2.5.3/testCaseSource.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.3/testCaseSource.html
+++ b/docs/2.5.3/testCaseSource.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.3/testCaseSource.html
+++ b/docs/2.5.3/testCaseSource.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.3/testDecorators.html
+++ b/docs/2.5.3/testDecorators.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.3/testDecorators.html
+++ b/docs/2.5.3/testDecorators.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.3/testDecorators.html
+++ b/docs/2.5.3/testDecorators.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.3/testDecorators.html
+++ b/docs/2.5.3/testDecorators.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.3/testFixture.html
+++ b/docs/2.5.3/testFixture.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.3/testFixture.html
+++ b/docs/2.5.3/testFixture.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.3/testFixture.html
+++ b/docs/2.5.3/testFixture.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.3/testFixture.html
+++ b/docs/2.5.3/testFixture.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.3/testProperties.html
+++ b/docs/2.5.3/testProperties.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.3/testProperties.html
+++ b/docs/2.5.3/testProperties.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.3/testProperties.html
+++ b/docs/2.5.3/testProperties.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.3/testProperties.html
+++ b/docs/2.5.3/testProperties.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.3/testcaseBuilders.html
+++ b/docs/2.5.3/testcaseBuilders.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.3/testcaseBuilders.html
+++ b/docs/2.5.3/testcaseBuilders.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.3/testcaseBuilders.html
+++ b/docs/2.5.3/testcaseBuilders.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.3/testcaseBuilders.html
+++ b/docs/2.5.3/testcaseBuilders.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.3/testcaseProviders.html
+++ b/docs/2.5.3/testcaseProviders.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.3/testcaseProviders.html
+++ b/docs/2.5.3/testcaseProviders.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.3/testcaseProviders.html
+++ b/docs/2.5.3/testcaseProviders.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.3/testcaseProviders.html
+++ b/docs/2.5.3/testcaseProviders.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.3/theory.html
+++ b/docs/2.5.3/theory.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.3/theory.html
+++ b/docs/2.5.3/theory.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.3/theory.html
+++ b/docs/2.5.3/theory.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.3/theory.html
+++ b/docs/2.5.3/theory.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.3/throwsConstraint.html
+++ b/docs/2.5.3/throwsConstraint.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.3/throwsConstraint.html
+++ b/docs/2.5.3/throwsConstraint.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.3/throwsConstraint.html
+++ b/docs/2.5.3/throwsConstraint.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.3/throwsConstraint.html
+++ b/docs/2.5.3/throwsConstraint.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.3/timeout.html
+++ b/docs/2.5.3/timeout.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.3/timeout.html
+++ b/docs/2.5.3/timeout.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.3/timeout.html
+++ b/docs/2.5.3/timeout.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.3/timeout.html
+++ b/docs/2.5.3/timeout.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.3/typeAsserts.html
+++ b/docs/2.5.3/typeAsserts.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.3/typeAsserts.html
+++ b/docs/2.5.3/typeAsserts.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.3/typeAsserts.html
+++ b/docs/2.5.3/typeAsserts.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.3/typeAsserts.html
+++ b/docs/2.5.3/typeAsserts.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.3/typeConstraints.html
+++ b/docs/2.5.3/typeConstraints.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.3/typeConstraints.html
+++ b/docs/2.5.3/typeConstraints.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.3/typeConstraints.html
+++ b/docs/2.5.3/typeConstraints.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.3/typeConstraints.html
+++ b/docs/2.5.3/typeConstraints.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.3/upgrade.html
+++ b/docs/2.5.3/upgrade.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.3/upgrade.html
+++ b/docs/2.5.3/upgrade.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.3/upgrade.html
+++ b/docs/2.5.3/upgrade.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.3/upgrade.html
+++ b/docs/2.5.3/upgrade.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.3/utilityAsserts.html
+++ b/docs/2.5.3/utilityAsserts.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.3/utilityAsserts.html
+++ b/docs/2.5.3/utilityAsserts.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.3/utilityAsserts.html
+++ b/docs/2.5.3/utilityAsserts.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.3/utilityAsserts.html
+++ b/docs/2.5.3/utilityAsserts.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.3/valueSource.html
+++ b/docs/2.5.3/valueSource.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.3/valueSource.html
+++ b/docs/2.5.3/valueSource.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.3/valueSource.html
+++ b/docs/2.5.3/valueSource.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.3/valueSource.html
+++ b/docs/2.5.3/valueSource.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.3/values.html
+++ b/docs/2.5.3/values.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.3/values.html
+++ b/docs/2.5.3/values.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.3/values.html
+++ b/docs/2.5.3/values.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.3/values.html
+++ b/docs/2.5.3/values.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.3/vsSupport.html
+++ b/docs/2.5.3/vsSupport.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.3/vsSupport.html
+++ b/docs/2.5.3/vsSupport.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.3/vsSupport.html
+++ b/docs/2.5.3/vsSupport.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.3/vsSupport.html
+++ b/docs/2.5.3/vsSupport.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.4/addinsDialog.html
+++ b/docs/2.5.4/addinsDialog.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.4/addinsDialog.html
+++ b/docs/2.5.4/addinsDialog.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.4/addinsDialog.html
+++ b/docs/2.5.4/addinsDialog.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.4/addinsDialog.html
+++ b/docs/2.5.4/addinsDialog.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.4/assemblyIsolation.html
+++ b/docs/2.5.4/assemblyIsolation.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.4/assemblyIsolation.html
+++ b/docs/2.5.4/assemblyIsolation.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.4/assemblyIsolation.html
+++ b/docs/2.5.4/assemblyIsolation.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.4/assemblyIsolation.html
+++ b/docs/2.5.4/assemblyIsolation.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.4/assertions.html
+++ b/docs/2.5.4/assertions.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.4/assertions.html
+++ b/docs/2.5.4/assertions.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.4/assertions.html
+++ b/docs/2.5.4/assertions.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.4/assertions.html
+++ b/docs/2.5.4/assertions.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.4/attributes.html
+++ b/docs/2.5.4/attributes.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.4/attributes.html
+++ b/docs/2.5.4/attributes.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.4/attributes.html
+++ b/docs/2.5.4/attributes.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.4/attributes.html
+++ b/docs/2.5.4/attributes.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.4/category.html
+++ b/docs/2.5.4/category.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.4/category.html
+++ b/docs/2.5.4/category.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.4/category.html
+++ b/docs/2.5.4/category.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.4/category.html
+++ b/docs/2.5.4/category.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.4/collectionAssert.html
+++ b/docs/2.5.4/collectionAssert.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.4/collectionAssert.html
+++ b/docs/2.5.4/collectionAssert.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.4/collectionAssert.html
+++ b/docs/2.5.4/collectionAssert.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.4/collectionAssert.html
+++ b/docs/2.5.4/collectionAssert.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.4/collectionConstraints.html
+++ b/docs/2.5.4/collectionConstraints.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.4/collectionConstraints.html
+++ b/docs/2.5.4/collectionConstraints.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.4/collectionConstraints.html
+++ b/docs/2.5.4/collectionConstraints.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.4/collectionConstraints.html
+++ b/docs/2.5.4/collectionConstraints.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.4/combinatorial.html
+++ b/docs/2.5.4/combinatorial.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.4/combinatorial.html
+++ b/docs/2.5.4/combinatorial.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.4/combinatorial.html
+++ b/docs/2.5.4/combinatorial.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.4/combinatorial.html
+++ b/docs/2.5.4/combinatorial.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.4/comparisonAsserts.html
+++ b/docs/2.5.4/comparisonAsserts.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.4/comparisonAsserts.html
+++ b/docs/2.5.4/comparisonAsserts.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.4/comparisonAsserts.html
+++ b/docs/2.5.4/comparisonAsserts.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.4/comparisonAsserts.html
+++ b/docs/2.5.4/comparisonAsserts.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.4/comparisonConstraints.html
+++ b/docs/2.5.4/comparisonConstraints.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.4/comparisonConstraints.html
+++ b/docs/2.5.4/comparisonConstraints.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.4/comparisonConstraints.html
+++ b/docs/2.5.4/comparisonConstraints.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.4/comparisonConstraints.html
+++ b/docs/2.5.4/comparisonConstraints.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.4/compoundConstraints.html
+++ b/docs/2.5.4/compoundConstraints.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.4/compoundConstraints.html
+++ b/docs/2.5.4/compoundConstraints.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.4/compoundConstraints.html
+++ b/docs/2.5.4/compoundConstraints.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.4/compoundConstraints.html
+++ b/docs/2.5.4/compoundConstraints.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.4/conditionAsserts.html
+++ b/docs/2.5.4/conditionAsserts.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.4/conditionAsserts.html
+++ b/docs/2.5.4/conditionAsserts.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.4/conditionAsserts.html
+++ b/docs/2.5.4/conditionAsserts.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.4/conditionAsserts.html
+++ b/docs/2.5.4/conditionAsserts.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.4/conditionConstraints.html
+++ b/docs/2.5.4/conditionConstraints.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.4/conditionConstraints.html
+++ b/docs/2.5.4/conditionConstraints.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.4/conditionConstraints.html
+++ b/docs/2.5.4/conditionConstraints.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.4/conditionConstraints.html
+++ b/docs/2.5.4/conditionConstraints.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.4/configEditor.html
+++ b/docs/2.5.4/configEditor.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.4/configEditor.html
+++ b/docs/2.5.4/configEditor.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.4/configEditor.html
+++ b/docs/2.5.4/configEditor.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.4/configEditor.html
+++ b/docs/2.5.4/configEditor.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.4/configFiles.html
+++ b/docs/2.5.4/configFiles.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.4/configFiles.html
+++ b/docs/2.5.4/configFiles.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.4/configFiles.html
+++ b/docs/2.5.4/configFiles.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.4/configFiles.html
+++ b/docs/2.5.4/configFiles.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.4/consoleCommandLine.html
+++ b/docs/2.5.4/consoleCommandLine.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.4/consoleCommandLine.html
+++ b/docs/2.5.4/consoleCommandLine.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.4/consoleCommandLine.html
+++ b/docs/2.5.4/consoleCommandLine.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.4/consoleCommandLine.html
+++ b/docs/2.5.4/consoleCommandLine.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.4/constraintModel.html
+++ b/docs/2.5.4/constraintModel.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.4/constraintModel.html
+++ b/docs/2.5.4/constraintModel.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.4/constraintModel.html
+++ b/docs/2.5.4/constraintModel.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.4/constraintModel.html
+++ b/docs/2.5.4/constraintModel.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.4/contextMenu.html
+++ b/docs/2.5.4/contextMenu.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.4/contextMenu.html
+++ b/docs/2.5.4/contextMenu.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.4/contextMenu.html
+++ b/docs/2.5.4/contextMenu.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.4/contextMenu.html
+++ b/docs/2.5.4/contextMenu.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.4/culture.html
+++ b/docs/2.5.4/culture.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.4/culture.html
+++ b/docs/2.5.4/culture.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.4/culture.html
+++ b/docs/2.5.4/culture.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.4/culture.html
+++ b/docs/2.5.4/culture.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.4/customConstraints.html
+++ b/docs/2.5.4/customConstraints.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.4/customConstraints.html
+++ b/docs/2.5.4/customConstraints.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.4/customConstraints.html
+++ b/docs/2.5.4/customConstraints.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.4/customConstraints.html
+++ b/docs/2.5.4/customConstraints.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.4/datapoint.html
+++ b/docs/2.5.4/datapoint.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.4/datapoint.html
+++ b/docs/2.5.4/datapoint.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.4/datapoint.html
+++ b/docs/2.5.4/datapoint.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.4/datapoint.html
+++ b/docs/2.5.4/datapoint.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.4/datapointProviders.html
+++ b/docs/2.5.4/datapointProviders.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.4/datapointProviders.html
+++ b/docs/2.5.4/datapointProviders.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.4/datapointProviders.html
+++ b/docs/2.5.4/datapointProviders.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.4/datapointProviders.html
+++ b/docs/2.5.4/datapointProviders.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.4/delayedConstraint.html
+++ b/docs/2.5.4/delayedConstraint.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.4/delayedConstraint.html
+++ b/docs/2.5.4/delayedConstraint.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.4/delayedConstraint.html
+++ b/docs/2.5.4/delayedConstraint.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.4/delayedConstraint.html
+++ b/docs/2.5.4/delayedConstraint.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.4/description.html
+++ b/docs/2.5.4/description.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.4/description.html
+++ b/docs/2.5.4/description.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.4/description.html
+++ b/docs/2.5.4/description.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.4/description.html
+++ b/docs/2.5.4/description.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.4/directoryAssert.html
+++ b/docs/2.5.4/directoryAssert.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.4/directoryAssert.html
+++ b/docs/2.5.4/directoryAssert.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.4/directoryAssert.html
+++ b/docs/2.5.4/directoryAssert.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.4/directoryAssert.html
+++ b/docs/2.5.4/directoryAssert.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.4/docHome.html
+++ b/docs/2.5.4/docHome.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.4/docHome.html
+++ b/docs/2.5.4/docHome.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.4/docHome.html
+++ b/docs/2.5.4/docHome.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.4/docHome.html
+++ b/docs/2.5.4/docHome.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.4/equalConstraint.html
+++ b/docs/2.5.4/equalConstraint.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.4/equalConstraint.html
+++ b/docs/2.5.4/equalConstraint.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.4/equalConstraint.html
+++ b/docs/2.5.4/equalConstraint.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.4/equalConstraint.html
+++ b/docs/2.5.4/equalConstraint.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.4/equalityAsserts.html
+++ b/docs/2.5.4/equalityAsserts.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.4/equalityAsserts.html
+++ b/docs/2.5.4/equalityAsserts.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.4/equalityAsserts.html
+++ b/docs/2.5.4/equalityAsserts.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.4/equalityAsserts.html
+++ b/docs/2.5.4/equalityAsserts.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.4/eventListeners.html
+++ b/docs/2.5.4/eventListeners.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.4/eventListeners.html
+++ b/docs/2.5.4/eventListeners.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.4/eventListeners.html
+++ b/docs/2.5.4/eventListeners.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.4/eventListeners.html
+++ b/docs/2.5.4/eventListeners.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.4/exception.html
+++ b/docs/2.5.4/exception.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.4/exception.html
+++ b/docs/2.5.4/exception.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.4/exception.html
+++ b/docs/2.5.4/exception.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.4/exception.html
+++ b/docs/2.5.4/exception.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.4/exceptionAsserts.html
+++ b/docs/2.5.4/exceptionAsserts.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.4/exceptionAsserts.html
+++ b/docs/2.5.4/exceptionAsserts.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.4/exceptionAsserts.html
+++ b/docs/2.5.4/exceptionAsserts.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.4/exceptionAsserts.html
+++ b/docs/2.5.4/exceptionAsserts.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.4/explicit.html
+++ b/docs/2.5.4/explicit.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.4/explicit.html
+++ b/docs/2.5.4/explicit.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.4/explicit.html
+++ b/docs/2.5.4/explicit.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.4/explicit.html
+++ b/docs/2.5.4/explicit.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.4/extensibility.html
+++ b/docs/2.5.4/extensibility.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.4/extensibility.html
+++ b/docs/2.5.4/extensibility.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.4/extensibility.html
+++ b/docs/2.5.4/extensibility.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.4/extensibility.html
+++ b/docs/2.5.4/extensibility.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.4/extensionTips.html
+++ b/docs/2.5.4/extensionTips.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.4/extensionTips.html
+++ b/docs/2.5.4/extensionTips.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.4/extensionTips.html
+++ b/docs/2.5.4/extensionTips.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.4/extensionTips.html
+++ b/docs/2.5.4/extensionTips.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.4/fileAssert.html
+++ b/docs/2.5.4/fileAssert.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.4/fileAssert.html
+++ b/docs/2.5.4/fileAssert.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.4/fileAssert.html
+++ b/docs/2.5.4/fileAssert.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.4/fileAssert.html
+++ b/docs/2.5.4/fileAssert.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.4/fixtureSetup.html
+++ b/docs/2.5.4/fixtureSetup.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.4/fixtureSetup.html
+++ b/docs/2.5.4/fixtureSetup.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.4/fixtureSetup.html
+++ b/docs/2.5.4/fixtureSetup.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.4/fixtureSetup.html
+++ b/docs/2.5.4/fixtureSetup.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.4/fixtureTeardown.html
+++ b/docs/2.5.4/fixtureTeardown.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.4/fixtureTeardown.html
+++ b/docs/2.5.4/fixtureTeardown.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.4/fixtureTeardown.html
+++ b/docs/2.5.4/fixtureTeardown.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.4/fixtureTeardown.html
+++ b/docs/2.5.4/fixtureTeardown.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.4/getStarted.html
+++ b/docs/2.5.4/getStarted.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.4/getStarted.html
+++ b/docs/2.5.4/getStarted.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.4/getStarted.html
+++ b/docs/2.5.4/getStarted.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.4/getStarted.html
+++ b/docs/2.5.4/getStarted.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.4/guiCommandLine.html
+++ b/docs/2.5.4/guiCommandLine.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.4/guiCommandLine.html
+++ b/docs/2.5.4/guiCommandLine.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.4/guiCommandLine.html
+++ b/docs/2.5.4/guiCommandLine.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.4/guiCommandLine.html
+++ b/docs/2.5.4/guiCommandLine.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.4/identityAsserts.html
+++ b/docs/2.5.4/identityAsserts.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.4/identityAsserts.html
+++ b/docs/2.5.4/identityAsserts.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.4/identityAsserts.html
+++ b/docs/2.5.4/identityAsserts.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.4/identityAsserts.html
+++ b/docs/2.5.4/identityAsserts.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.4/ignore.html
+++ b/docs/2.5.4/ignore.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.4/ignore.html
+++ b/docs/2.5.4/ignore.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.4/ignore.html
+++ b/docs/2.5.4/ignore.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.4/ignore.html
+++ b/docs/2.5.4/ignore.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.4/installation.html
+++ b/docs/2.5.4/installation.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.4/installation.html
+++ b/docs/2.5.4/installation.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.4/installation.html
+++ b/docs/2.5.4/installation.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.4/installation.html
+++ b/docs/2.5.4/installation.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.4/license.html
+++ b/docs/2.5.4/license.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.4/license.html
+++ b/docs/2.5.4/license.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.4/license.html
+++ b/docs/2.5.4/license.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.4/license.html
+++ b/docs/2.5.4/license.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.4/listMapper.html
+++ b/docs/2.5.4/listMapper.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.4/listMapper.html
+++ b/docs/2.5.4/listMapper.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.4/listMapper.html
+++ b/docs/2.5.4/listMapper.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.4/listMapper.html
+++ b/docs/2.5.4/listMapper.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.4/mainMenu.html
+++ b/docs/2.5.4/mainMenu.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.4/mainMenu.html
+++ b/docs/2.5.4/mainMenu.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.4/mainMenu.html
+++ b/docs/2.5.4/mainMenu.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.4/mainMenu.html
+++ b/docs/2.5.4/mainMenu.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.4/maxtime.html
+++ b/docs/2.5.4/maxtime.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.4/maxtime.html
+++ b/docs/2.5.4/maxtime.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.4/maxtime.html
+++ b/docs/2.5.4/maxtime.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.4/maxtime.html
+++ b/docs/2.5.4/maxtime.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.4/multiAssembly.html
+++ b/docs/2.5.4/multiAssembly.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.4/multiAssembly.html
+++ b/docs/2.5.4/multiAssembly.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.4/multiAssembly.html
+++ b/docs/2.5.4/multiAssembly.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.4/multiAssembly.html
+++ b/docs/2.5.4/multiAssembly.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.4/nunit-console.html
+++ b/docs/2.5.4/nunit-console.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.4/nunit-console.html
+++ b/docs/2.5.4/nunit-console.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.4/nunit-console.html
+++ b/docs/2.5.4/nunit-console.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.4/nunit-console.html
+++ b/docs/2.5.4/nunit-console.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.4/nunit-gui.html
+++ b/docs/2.5.4/nunit-gui.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.4/nunit-gui.html
+++ b/docs/2.5.4/nunit-gui.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.4/nunit-gui.html
+++ b/docs/2.5.4/nunit-gui.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.4/nunit-gui.html
+++ b/docs/2.5.4/nunit-gui.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.4/nunitAddins.html
+++ b/docs/2.5.4/nunitAddins.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.4/nunitAddins.html
+++ b/docs/2.5.4/nunitAddins.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.4/nunitAddins.html
+++ b/docs/2.5.4/nunitAddins.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.4/nunitAddins.html
+++ b/docs/2.5.4/nunitAddins.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.4/pairwise.html
+++ b/docs/2.5.4/pairwise.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.4/pairwise.html
+++ b/docs/2.5.4/pairwise.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.4/pairwise.html
+++ b/docs/2.5.4/pairwise.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.4/pairwise.html
+++ b/docs/2.5.4/pairwise.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.4/parameterizedTests.html
+++ b/docs/2.5.4/parameterizedTests.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.4/parameterizedTests.html
+++ b/docs/2.5.4/parameterizedTests.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.4/parameterizedTests.html
+++ b/docs/2.5.4/parameterizedTests.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.4/parameterizedTests.html
+++ b/docs/2.5.4/parameterizedTests.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.4/pathConstraints.html
+++ b/docs/2.5.4/pathConstraints.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.4/pathConstraints.html
+++ b/docs/2.5.4/pathConstraints.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.4/pathConstraints.html
+++ b/docs/2.5.4/pathConstraints.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.4/pathConstraints.html
+++ b/docs/2.5.4/pathConstraints.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.4/platform.html
+++ b/docs/2.5.4/platform.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.4/platform.html
+++ b/docs/2.5.4/platform.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.4/platform.html
+++ b/docs/2.5.4/platform.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.4/platform.html
+++ b/docs/2.5.4/platform.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.4/pnunit.html
+++ b/docs/2.5.4/pnunit.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.4/pnunit.html
+++ b/docs/2.5.4/pnunit.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.4/pnunit.html
+++ b/docs/2.5.4/pnunit.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.4/pnunit.html
+++ b/docs/2.5.4/pnunit.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.4/projectEditor.html
+++ b/docs/2.5.4/projectEditor.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.4/projectEditor.html
+++ b/docs/2.5.4/projectEditor.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.4/projectEditor.html
+++ b/docs/2.5.4/projectEditor.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.4/projectEditor.html
+++ b/docs/2.5.4/projectEditor.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.4/property.html
+++ b/docs/2.5.4/property.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.4/property.html
+++ b/docs/2.5.4/property.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.4/property.html
+++ b/docs/2.5.4/property.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.4/property.html
+++ b/docs/2.5.4/property.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.4/propertyConstraint.html
+++ b/docs/2.5.4/propertyConstraint.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.4/propertyConstraint.html
+++ b/docs/2.5.4/propertyConstraint.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.4/propertyConstraint.html
+++ b/docs/2.5.4/propertyConstraint.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.4/propertyConstraint.html
+++ b/docs/2.5.4/propertyConstraint.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.4/quickStart.html
+++ b/docs/2.5.4/quickStart.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.4/quickStart.html
+++ b/docs/2.5.4/quickStart.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.4/quickStart.html
+++ b/docs/2.5.4/quickStart.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.4/quickStart.html
+++ b/docs/2.5.4/quickStart.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.4/quickStartSource.html
+++ b/docs/2.5.4/quickStartSource.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.4/quickStartSource.html
+++ b/docs/2.5.4/quickStartSource.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.4/quickStartSource.html
+++ b/docs/2.5.4/quickStartSource.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.4/quickStartSource.html
+++ b/docs/2.5.4/quickStartSource.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.4/random.html
+++ b/docs/2.5.4/random.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.4/random.html
+++ b/docs/2.5.4/random.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.4/random.html
+++ b/docs/2.5.4/random.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.4/random.html
+++ b/docs/2.5.4/random.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.4/range.html
+++ b/docs/2.5.4/range.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.4/range.html
+++ b/docs/2.5.4/range.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.4/range.html
+++ b/docs/2.5.4/range.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.4/range.html
+++ b/docs/2.5.4/range.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.4/releaseNotes.html
+++ b/docs/2.5.4/releaseNotes.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.4/releaseNotes.html
+++ b/docs/2.5.4/releaseNotes.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.4/releaseNotes.html
+++ b/docs/2.5.4/releaseNotes.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.4/releaseNotes.html
+++ b/docs/2.5.4/releaseNotes.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.4/repeat.html
+++ b/docs/2.5.4/repeat.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.4/repeat.html
+++ b/docs/2.5.4/repeat.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.4/repeat.html
+++ b/docs/2.5.4/repeat.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.4/repeat.html
+++ b/docs/2.5.4/repeat.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.4/requiredAddin.html
+++ b/docs/2.5.4/requiredAddin.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.4/requiredAddin.html
+++ b/docs/2.5.4/requiredAddin.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.4/requiredAddin.html
+++ b/docs/2.5.4/requiredAddin.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.4/requiredAddin.html
+++ b/docs/2.5.4/requiredAddin.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.4/requiresMTA.html
+++ b/docs/2.5.4/requiresMTA.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.4/requiresMTA.html
+++ b/docs/2.5.4/requiresMTA.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.4/requiresMTA.html
+++ b/docs/2.5.4/requiresMTA.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.4/requiresMTA.html
+++ b/docs/2.5.4/requiresMTA.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.4/requiresSTA.html
+++ b/docs/2.5.4/requiresSTA.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.4/requiresSTA.html
+++ b/docs/2.5.4/requiresSTA.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.4/requiresSTA.html
+++ b/docs/2.5.4/requiresSTA.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.4/requiresSTA.html
+++ b/docs/2.5.4/requiresSTA.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.4/requiresThread.html
+++ b/docs/2.5.4/requiresThread.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.4/requiresThread.html
+++ b/docs/2.5.4/requiresThread.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.4/requiresThread.html
+++ b/docs/2.5.4/requiresThread.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.4/requiresThread.html
+++ b/docs/2.5.4/requiresThread.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.4/runningTests.html
+++ b/docs/2.5.4/runningTests.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.4/runningTests.html
+++ b/docs/2.5.4/runningTests.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.4/runningTests.html
+++ b/docs/2.5.4/runningTests.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.4/runningTests.html
+++ b/docs/2.5.4/runningTests.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.4/runtimeSelection.html
+++ b/docs/2.5.4/runtimeSelection.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.4/runtimeSelection.html
+++ b/docs/2.5.4/runtimeSelection.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.4/runtimeSelection.html
+++ b/docs/2.5.4/runtimeSelection.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.4/runtimeSelection.html
+++ b/docs/2.5.4/runtimeSelection.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.4/sameasConstraint.html
+++ b/docs/2.5.4/sameasConstraint.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.4/sameasConstraint.html
+++ b/docs/2.5.4/sameasConstraint.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.4/sameasConstraint.html
+++ b/docs/2.5.4/sameasConstraint.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.4/sameasConstraint.html
+++ b/docs/2.5.4/sameasConstraint.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.4/samples.html
+++ b/docs/2.5.4/samples.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.4/samples.html
+++ b/docs/2.5.4/samples.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.4/samples.html
+++ b/docs/2.5.4/samples.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.4/samples.html
+++ b/docs/2.5.4/samples.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.4/sequential.html
+++ b/docs/2.5.4/sequential.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.4/sequential.html
+++ b/docs/2.5.4/sequential.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.4/sequential.html
+++ b/docs/2.5.4/sequential.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.4/sequential.html
+++ b/docs/2.5.4/sequential.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.4/setCulture.html
+++ b/docs/2.5.4/setCulture.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.4/setCulture.html
+++ b/docs/2.5.4/setCulture.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.4/setCulture.html
+++ b/docs/2.5.4/setCulture.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.4/setCulture.html
+++ b/docs/2.5.4/setCulture.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.4/setUICulture.html
+++ b/docs/2.5.4/setUICulture.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.4/setUICulture.html
+++ b/docs/2.5.4/setUICulture.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.4/setUICulture.html
+++ b/docs/2.5.4/setUICulture.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.4/setUICulture.html
+++ b/docs/2.5.4/setUICulture.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.4/settingsDialog.html
+++ b/docs/2.5.4/settingsDialog.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.4/settingsDialog.html
+++ b/docs/2.5.4/settingsDialog.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.4/settingsDialog.html
+++ b/docs/2.5.4/settingsDialog.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.4/settingsDialog.html
+++ b/docs/2.5.4/settingsDialog.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.4/setup.html
+++ b/docs/2.5.4/setup.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.4/setup.html
+++ b/docs/2.5.4/setup.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.4/setup.html
+++ b/docs/2.5.4/setup.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.4/setup.html
+++ b/docs/2.5.4/setup.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.4/setupFixture.html
+++ b/docs/2.5.4/setupFixture.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.4/setupFixture.html
+++ b/docs/2.5.4/setupFixture.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.4/setupFixture.html
+++ b/docs/2.5.4/setupFixture.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.4/setupFixture.html
+++ b/docs/2.5.4/setupFixture.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.4/stringAssert.html
+++ b/docs/2.5.4/stringAssert.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.4/stringAssert.html
+++ b/docs/2.5.4/stringAssert.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.4/stringAssert.html
+++ b/docs/2.5.4/stringAssert.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.4/stringAssert.html
+++ b/docs/2.5.4/stringAssert.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.4/stringConstraints.html
+++ b/docs/2.5.4/stringConstraints.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.4/stringConstraints.html
+++ b/docs/2.5.4/stringConstraints.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.4/stringConstraints.html
+++ b/docs/2.5.4/stringConstraints.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.4/stringConstraints.html
+++ b/docs/2.5.4/stringConstraints.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.4/suite.html
+++ b/docs/2.5.4/suite.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.4/suite.html
+++ b/docs/2.5.4/suite.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.4/suite.html
+++ b/docs/2.5.4/suite.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.4/suite.html
+++ b/docs/2.5.4/suite.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.4/suiteBuilders.html
+++ b/docs/2.5.4/suiteBuilders.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.4/suiteBuilders.html
+++ b/docs/2.5.4/suiteBuilders.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.4/suiteBuilders.html
+++ b/docs/2.5.4/suiteBuilders.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.4/suiteBuilders.html
+++ b/docs/2.5.4/suiteBuilders.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.4/teardown.html
+++ b/docs/2.5.4/teardown.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.4/teardown.html
+++ b/docs/2.5.4/teardown.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.4/teardown.html
+++ b/docs/2.5.4/teardown.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.4/teardown.html
+++ b/docs/2.5.4/teardown.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.4/test.html
+++ b/docs/2.5.4/test.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.4/test.html
+++ b/docs/2.5.4/test.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.4/test.html
+++ b/docs/2.5.4/test.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.4/test.html
+++ b/docs/2.5.4/test.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.4/testCase.html
+++ b/docs/2.5.4/testCase.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.4/testCase.html
+++ b/docs/2.5.4/testCase.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.4/testCase.html
+++ b/docs/2.5.4/testCase.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.4/testCase.html
+++ b/docs/2.5.4/testCase.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.4/testCaseSource.html
+++ b/docs/2.5.4/testCaseSource.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.4/testCaseSource.html
+++ b/docs/2.5.4/testCaseSource.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.4/testCaseSource.html
+++ b/docs/2.5.4/testCaseSource.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.4/testCaseSource.html
+++ b/docs/2.5.4/testCaseSource.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.4/testDecorators.html
+++ b/docs/2.5.4/testDecorators.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.4/testDecorators.html
+++ b/docs/2.5.4/testDecorators.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.4/testDecorators.html
+++ b/docs/2.5.4/testDecorators.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.4/testDecorators.html
+++ b/docs/2.5.4/testDecorators.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.4/testFixture.html
+++ b/docs/2.5.4/testFixture.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.4/testFixture.html
+++ b/docs/2.5.4/testFixture.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.4/testFixture.html
+++ b/docs/2.5.4/testFixture.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.4/testFixture.html
+++ b/docs/2.5.4/testFixture.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.4/testProperties.html
+++ b/docs/2.5.4/testProperties.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.4/testProperties.html
+++ b/docs/2.5.4/testProperties.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.4/testProperties.html
+++ b/docs/2.5.4/testProperties.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.4/testProperties.html
+++ b/docs/2.5.4/testProperties.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.4/testcaseBuilders.html
+++ b/docs/2.5.4/testcaseBuilders.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.4/testcaseBuilders.html
+++ b/docs/2.5.4/testcaseBuilders.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.4/testcaseBuilders.html
+++ b/docs/2.5.4/testcaseBuilders.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.4/testcaseBuilders.html
+++ b/docs/2.5.4/testcaseBuilders.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.4/testcaseProviders.html
+++ b/docs/2.5.4/testcaseProviders.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.4/testcaseProviders.html
+++ b/docs/2.5.4/testcaseProviders.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.4/testcaseProviders.html
+++ b/docs/2.5.4/testcaseProviders.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.4/testcaseProviders.html
+++ b/docs/2.5.4/testcaseProviders.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.4/theory.html
+++ b/docs/2.5.4/theory.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.4/theory.html
+++ b/docs/2.5.4/theory.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.4/theory.html
+++ b/docs/2.5.4/theory.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.4/theory.html
+++ b/docs/2.5.4/theory.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.4/throwsConstraint.html
+++ b/docs/2.5.4/throwsConstraint.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.4/throwsConstraint.html
+++ b/docs/2.5.4/throwsConstraint.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.4/throwsConstraint.html
+++ b/docs/2.5.4/throwsConstraint.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.4/throwsConstraint.html
+++ b/docs/2.5.4/throwsConstraint.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.4/timeout.html
+++ b/docs/2.5.4/timeout.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.4/timeout.html
+++ b/docs/2.5.4/timeout.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.4/timeout.html
+++ b/docs/2.5.4/timeout.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.4/timeout.html
+++ b/docs/2.5.4/timeout.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.4/typeAsserts.html
+++ b/docs/2.5.4/typeAsserts.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.4/typeAsserts.html
+++ b/docs/2.5.4/typeAsserts.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.4/typeAsserts.html
+++ b/docs/2.5.4/typeAsserts.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.4/typeAsserts.html
+++ b/docs/2.5.4/typeAsserts.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.4/typeConstraints.html
+++ b/docs/2.5.4/typeConstraints.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.4/typeConstraints.html
+++ b/docs/2.5.4/typeConstraints.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.4/typeConstraints.html
+++ b/docs/2.5.4/typeConstraints.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.4/typeConstraints.html
+++ b/docs/2.5.4/typeConstraints.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.4/upgrade.html
+++ b/docs/2.5.4/upgrade.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.4/upgrade.html
+++ b/docs/2.5.4/upgrade.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.4/upgrade.html
+++ b/docs/2.5.4/upgrade.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.4/upgrade.html
+++ b/docs/2.5.4/upgrade.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.4/utilityAsserts.html
+++ b/docs/2.5.4/utilityAsserts.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.4/utilityAsserts.html
+++ b/docs/2.5.4/utilityAsserts.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.4/utilityAsserts.html
+++ b/docs/2.5.4/utilityAsserts.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.4/utilityAsserts.html
+++ b/docs/2.5.4/utilityAsserts.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.4/valueSource.html
+++ b/docs/2.5.4/valueSource.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.4/valueSource.html
+++ b/docs/2.5.4/valueSource.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.4/valueSource.html
+++ b/docs/2.5.4/valueSource.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.4/valueSource.html
+++ b/docs/2.5.4/valueSource.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.4/values.html
+++ b/docs/2.5.4/values.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.4/values.html
+++ b/docs/2.5.4/values.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.4/values.html
+++ b/docs/2.5.4/values.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.4/values.html
+++ b/docs/2.5.4/values.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.4/vsSupport.html
+++ b/docs/2.5.4/vsSupport.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.4/vsSupport.html
+++ b/docs/2.5.4/vsSupport.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.4/vsSupport.html
+++ b/docs/2.5.4/vsSupport.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.4/vsSupport.html
+++ b/docs/2.5.4/vsSupport.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.5/addinsDialog.html
+++ b/docs/2.5.5/addinsDialog.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.5/addinsDialog.html
+++ b/docs/2.5.5/addinsDialog.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.5/addinsDialog.html
+++ b/docs/2.5.5/addinsDialog.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.5/addinsDialog.html
+++ b/docs/2.5.5/addinsDialog.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.5/assemblyIsolation.html
+++ b/docs/2.5.5/assemblyIsolation.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.5/assemblyIsolation.html
+++ b/docs/2.5.5/assemblyIsolation.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.5/assemblyIsolation.html
+++ b/docs/2.5.5/assemblyIsolation.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.5/assemblyIsolation.html
+++ b/docs/2.5.5/assemblyIsolation.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.5/assertions.html
+++ b/docs/2.5.5/assertions.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.5/assertions.html
+++ b/docs/2.5.5/assertions.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.5/assertions.html
+++ b/docs/2.5.5/assertions.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.5/assertions.html
+++ b/docs/2.5.5/assertions.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.5/attributes.html
+++ b/docs/2.5.5/attributes.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.5/attributes.html
+++ b/docs/2.5.5/attributes.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.5/attributes.html
+++ b/docs/2.5.5/attributes.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.5/attributes.html
+++ b/docs/2.5.5/attributes.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.5/category.html
+++ b/docs/2.5.5/category.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.5/category.html
+++ b/docs/2.5.5/category.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.5/category.html
+++ b/docs/2.5.5/category.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.5/category.html
+++ b/docs/2.5.5/category.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.5/collectionAssert.html
+++ b/docs/2.5.5/collectionAssert.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.5/collectionAssert.html
+++ b/docs/2.5.5/collectionAssert.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.5/collectionAssert.html
+++ b/docs/2.5.5/collectionAssert.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.5/collectionAssert.html
+++ b/docs/2.5.5/collectionAssert.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.5/collectionConstraints.html
+++ b/docs/2.5.5/collectionConstraints.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.5/collectionConstraints.html
+++ b/docs/2.5.5/collectionConstraints.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.5/collectionConstraints.html
+++ b/docs/2.5.5/collectionConstraints.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.5/collectionConstraints.html
+++ b/docs/2.5.5/collectionConstraints.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.5/combinatorial.html
+++ b/docs/2.5.5/combinatorial.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.5/combinatorial.html
+++ b/docs/2.5.5/combinatorial.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.5/combinatorial.html
+++ b/docs/2.5.5/combinatorial.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.5/combinatorial.html
+++ b/docs/2.5.5/combinatorial.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.5/comparisonAsserts.html
+++ b/docs/2.5.5/comparisonAsserts.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.5/comparisonAsserts.html
+++ b/docs/2.5.5/comparisonAsserts.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.5/comparisonAsserts.html
+++ b/docs/2.5.5/comparisonAsserts.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.5/comparisonAsserts.html
+++ b/docs/2.5.5/comparisonAsserts.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.5/comparisonConstraints.html
+++ b/docs/2.5.5/comparisonConstraints.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.5/comparisonConstraints.html
+++ b/docs/2.5.5/comparisonConstraints.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.5/comparisonConstraints.html
+++ b/docs/2.5.5/comparisonConstraints.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.5/comparisonConstraints.html
+++ b/docs/2.5.5/comparisonConstraints.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.5/compoundConstraints.html
+++ b/docs/2.5.5/compoundConstraints.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.5/compoundConstraints.html
+++ b/docs/2.5.5/compoundConstraints.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.5/compoundConstraints.html
+++ b/docs/2.5.5/compoundConstraints.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.5/compoundConstraints.html
+++ b/docs/2.5.5/compoundConstraints.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.5/conditionAsserts.html
+++ b/docs/2.5.5/conditionAsserts.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.5/conditionAsserts.html
+++ b/docs/2.5.5/conditionAsserts.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.5/conditionAsserts.html
+++ b/docs/2.5.5/conditionAsserts.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.5/conditionAsserts.html
+++ b/docs/2.5.5/conditionAsserts.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.5/conditionConstraints.html
+++ b/docs/2.5.5/conditionConstraints.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.5/conditionConstraints.html
+++ b/docs/2.5.5/conditionConstraints.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.5/conditionConstraints.html
+++ b/docs/2.5.5/conditionConstraints.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.5/conditionConstraints.html
+++ b/docs/2.5.5/conditionConstraints.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.5/configEditor.html
+++ b/docs/2.5.5/configEditor.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.5/configEditor.html
+++ b/docs/2.5.5/configEditor.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.5/configEditor.html
+++ b/docs/2.5.5/configEditor.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.5/configEditor.html
+++ b/docs/2.5.5/configEditor.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.5/configFiles.html
+++ b/docs/2.5.5/configFiles.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.5/configFiles.html
+++ b/docs/2.5.5/configFiles.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.5/configFiles.html
+++ b/docs/2.5.5/configFiles.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.5/configFiles.html
+++ b/docs/2.5.5/configFiles.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.5/consoleCommandLine.html
+++ b/docs/2.5.5/consoleCommandLine.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.5/consoleCommandLine.html
+++ b/docs/2.5.5/consoleCommandLine.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.5/consoleCommandLine.html
+++ b/docs/2.5.5/consoleCommandLine.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.5/consoleCommandLine.html
+++ b/docs/2.5.5/consoleCommandLine.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.5/constraintModel.html
+++ b/docs/2.5.5/constraintModel.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.5/constraintModel.html
+++ b/docs/2.5.5/constraintModel.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.5/constraintModel.html
+++ b/docs/2.5.5/constraintModel.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.5/constraintModel.html
+++ b/docs/2.5.5/constraintModel.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.5/contextMenu.html
+++ b/docs/2.5.5/contextMenu.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.5/contextMenu.html
+++ b/docs/2.5.5/contextMenu.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.5/contextMenu.html
+++ b/docs/2.5.5/contextMenu.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.5/contextMenu.html
+++ b/docs/2.5.5/contextMenu.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.5/culture.html
+++ b/docs/2.5.5/culture.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.5/culture.html
+++ b/docs/2.5.5/culture.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.5/culture.html
+++ b/docs/2.5.5/culture.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.5/culture.html
+++ b/docs/2.5.5/culture.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.5/customConstraints.html
+++ b/docs/2.5.5/customConstraints.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.5/customConstraints.html
+++ b/docs/2.5.5/customConstraints.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.5/customConstraints.html
+++ b/docs/2.5.5/customConstraints.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.5/customConstraints.html
+++ b/docs/2.5.5/customConstraints.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.5/datapoint.html
+++ b/docs/2.5.5/datapoint.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.5/datapoint.html
+++ b/docs/2.5.5/datapoint.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.5/datapoint.html
+++ b/docs/2.5.5/datapoint.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.5/datapoint.html
+++ b/docs/2.5.5/datapoint.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.5/datapointProviders.html
+++ b/docs/2.5.5/datapointProviders.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.5/datapointProviders.html
+++ b/docs/2.5.5/datapointProviders.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.5/datapointProviders.html
+++ b/docs/2.5.5/datapointProviders.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.5/datapointProviders.html
+++ b/docs/2.5.5/datapointProviders.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.5/delayedConstraint.html
+++ b/docs/2.5.5/delayedConstraint.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.5/delayedConstraint.html
+++ b/docs/2.5.5/delayedConstraint.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.5/delayedConstraint.html
+++ b/docs/2.5.5/delayedConstraint.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.5/delayedConstraint.html
+++ b/docs/2.5.5/delayedConstraint.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.5/description.html
+++ b/docs/2.5.5/description.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.5/description.html
+++ b/docs/2.5.5/description.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.5/description.html
+++ b/docs/2.5.5/description.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.5/description.html
+++ b/docs/2.5.5/description.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.5/directoryAssert.html
+++ b/docs/2.5.5/directoryAssert.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.5/directoryAssert.html
+++ b/docs/2.5.5/directoryAssert.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.5/directoryAssert.html
+++ b/docs/2.5.5/directoryAssert.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.5/directoryAssert.html
+++ b/docs/2.5.5/directoryAssert.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.5/docHome.html
+++ b/docs/2.5.5/docHome.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.5/docHome.html
+++ b/docs/2.5.5/docHome.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.5/docHome.html
+++ b/docs/2.5.5/docHome.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.5/docHome.html
+++ b/docs/2.5.5/docHome.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.5/equalConstraint.html
+++ b/docs/2.5.5/equalConstraint.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.5/equalConstraint.html
+++ b/docs/2.5.5/equalConstraint.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.5/equalConstraint.html
+++ b/docs/2.5.5/equalConstraint.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.5/equalConstraint.html
+++ b/docs/2.5.5/equalConstraint.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.5/equalityAsserts.html
+++ b/docs/2.5.5/equalityAsserts.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.5/equalityAsserts.html
+++ b/docs/2.5.5/equalityAsserts.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.5/equalityAsserts.html
+++ b/docs/2.5.5/equalityAsserts.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.5/equalityAsserts.html
+++ b/docs/2.5.5/equalityAsserts.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.5/eventListeners.html
+++ b/docs/2.5.5/eventListeners.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.5/eventListeners.html
+++ b/docs/2.5.5/eventListeners.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.5/eventListeners.html
+++ b/docs/2.5.5/eventListeners.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.5/eventListeners.html
+++ b/docs/2.5.5/eventListeners.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.5/exception.html
+++ b/docs/2.5.5/exception.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.5/exception.html
+++ b/docs/2.5.5/exception.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.5/exception.html
+++ b/docs/2.5.5/exception.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.5/exception.html
+++ b/docs/2.5.5/exception.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.5/exceptionAsserts.html
+++ b/docs/2.5.5/exceptionAsserts.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.5/exceptionAsserts.html
+++ b/docs/2.5.5/exceptionAsserts.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.5/exceptionAsserts.html
+++ b/docs/2.5.5/exceptionAsserts.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.5/exceptionAsserts.html
+++ b/docs/2.5.5/exceptionAsserts.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.5/explicit.html
+++ b/docs/2.5.5/explicit.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.5/explicit.html
+++ b/docs/2.5.5/explicit.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.5/explicit.html
+++ b/docs/2.5.5/explicit.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.5/explicit.html
+++ b/docs/2.5.5/explicit.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.5/extensibility.html
+++ b/docs/2.5.5/extensibility.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.5/extensibility.html
+++ b/docs/2.5.5/extensibility.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.5/extensibility.html
+++ b/docs/2.5.5/extensibility.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.5/extensibility.html
+++ b/docs/2.5.5/extensibility.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.5/extensionTips.html
+++ b/docs/2.5.5/extensionTips.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.5/extensionTips.html
+++ b/docs/2.5.5/extensionTips.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.5/extensionTips.html
+++ b/docs/2.5.5/extensionTips.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.5/extensionTips.html
+++ b/docs/2.5.5/extensionTips.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.5/fileAssert.html
+++ b/docs/2.5.5/fileAssert.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.5/fileAssert.html
+++ b/docs/2.5.5/fileAssert.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.5/fileAssert.html
+++ b/docs/2.5.5/fileAssert.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.5/fileAssert.html
+++ b/docs/2.5.5/fileAssert.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.5/fixtureSetup.html
+++ b/docs/2.5.5/fixtureSetup.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.5/fixtureSetup.html
+++ b/docs/2.5.5/fixtureSetup.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.5/fixtureSetup.html
+++ b/docs/2.5.5/fixtureSetup.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.5/fixtureSetup.html
+++ b/docs/2.5.5/fixtureSetup.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.5/fixtureTeardown.html
+++ b/docs/2.5.5/fixtureTeardown.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.5/fixtureTeardown.html
+++ b/docs/2.5.5/fixtureTeardown.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.5/fixtureTeardown.html
+++ b/docs/2.5.5/fixtureTeardown.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.5/fixtureTeardown.html
+++ b/docs/2.5.5/fixtureTeardown.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.5/getStarted.html
+++ b/docs/2.5.5/getStarted.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.5/getStarted.html
+++ b/docs/2.5.5/getStarted.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.5/getStarted.html
+++ b/docs/2.5.5/getStarted.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.5/getStarted.html
+++ b/docs/2.5.5/getStarted.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.5/guiCommandLine.html
+++ b/docs/2.5.5/guiCommandLine.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.5/guiCommandLine.html
+++ b/docs/2.5.5/guiCommandLine.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.5/guiCommandLine.html
+++ b/docs/2.5.5/guiCommandLine.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.5/guiCommandLine.html
+++ b/docs/2.5.5/guiCommandLine.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.5/identityAsserts.html
+++ b/docs/2.5.5/identityAsserts.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.5/identityAsserts.html
+++ b/docs/2.5.5/identityAsserts.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.5/identityAsserts.html
+++ b/docs/2.5.5/identityAsserts.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.5/identityAsserts.html
+++ b/docs/2.5.5/identityAsserts.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.5/ignore.html
+++ b/docs/2.5.5/ignore.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.5/ignore.html
+++ b/docs/2.5.5/ignore.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.5/ignore.html
+++ b/docs/2.5.5/ignore.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.5/ignore.html
+++ b/docs/2.5.5/ignore.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.5/installation.html
+++ b/docs/2.5.5/installation.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.5/installation.html
+++ b/docs/2.5.5/installation.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.5/installation.html
+++ b/docs/2.5.5/installation.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.5/installation.html
+++ b/docs/2.5.5/installation.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.5/license.html
+++ b/docs/2.5.5/license.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.5/license.html
+++ b/docs/2.5.5/license.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.5/license.html
+++ b/docs/2.5.5/license.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.5/license.html
+++ b/docs/2.5.5/license.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.5/listMapper.html
+++ b/docs/2.5.5/listMapper.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.5/listMapper.html
+++ b/docs/2.5.5/listMapper.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.5/listMapper.html
+++ b/docs/2.5.5/listMapper.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.5/listMapper.html
+++ b/docs/2.5.5/listMapper.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.5/mainMenu.html
+++ b/docs/2.5.5/mainMenu.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.5/mainMenu.html
+++ b/docs/2.5.5/mainMenu.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.5/mainMenu.html
+++ b/docs/2.5.5/mainMenu.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.5/mainMenu.html
+++ b/docs/2.5.5/mainMenu.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.5/maxtime.html
+++ b/docs/2.5.5/maxtime.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.5/maxtime.html
+++ b/docs/2.5.5/maxtime.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.5/maxtime.html
+++ b/docs/2.5.5/maxtime.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.5/maxtime.html
+++ b/docs/2.5.5/maxtime.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.5/multiAssembly.html
+++ b/docs/2.5.5/multiAssembly.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.5/multiAssembly.html
+++ b/docs/2.5.5/multiAssembly.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.5/multiAssembly.html
+++ b/docs/2.5.5/multiAssembly.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.5/multiAssembly.html
+++ b/docs/2.5.5/multiAssembly.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.5/nunit-console.html
+++ b/docs/2.5.5/nunit-console.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.5/nunit-console.html
+++ b/docs/2.5.5/nunit-console.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.5/nunit-console.html
+++ b/docs/2.5.5/nunit-console.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.5/nunit-console.html
+++ b/docs/2.5.5/nunit-console.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.5/nunit-gui.html
+++ b/docs/2.5.5/nunit-gui.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.5/nunit-gui.html
+++ b/docs/2.5.5/nunit-gui.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.5/nunit-gui.html
+++ b/docs/2.5.5/nunit-gui.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.5/nunit-gui.html
+++ b/docs/2.5.5/nunit-gui.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.5/nunitAddins.html
+++ b/docs/2.5.5/nunitAddins.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.5/nunitAddins.html
+++ b/docs/2.5.5/nunitAddins.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.5/nunitAddins.html
+++ b/docs/2.5.5/nunitAddins.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.5/nunitAddins.html
+++ b/docs/2.5.5/nunitAddins.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.5/pairwise.html
+++ b/docs/2.5.5/pairwise.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.5/pairwise.html
+++ b/docs/2.5.5/pairwise.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.5/pairwise.html
+++ b/docs/2.5.5/pairwise.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.5/pairwise.html
+++ b/docs/2.5.5/pairwise.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.5/parameterizedTests.html
+++ b/docs/2.5.5/parameterizedTests.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.5/parameterizedTests.html
+++ b/docs/2.5.5/parameterizedTests.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.5/parameterizedTests.html
+++ b/docs/2.5.5/parameterizedTests.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.5/parameterizedTests.html
+++ b/docs/2.5.5/parameterizedTests.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.5/pathConstraints.html
+++ b/docs/2.5.5/pathConstraints.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.5/pathConstraints.html
+++ b/docs/2.5.5/pathConstraints.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.5/pathConstraints.html
+++ b/docs/2.5.5/pathConstraints.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.5/pathConstraints.html
+++ b/docs/2.5.5/pathConstraints.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.5/platform.html
+++ b/docs/2.5.5/platform.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.5/platform.html
+++ b/docs/2.5.5/platform.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.5/platform.html
+++ b/docs/2.5.5/platform.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.5/platform.html
+++ b/docs/2.5.5/platform.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.5/pnunit.html
+++ b/docs/2.5.5/pnunit.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.5/pnunit.html
+++ b/docs/2.5.5/pnunit.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.5/pnunit.html
+++ b/docs/2.5.5/pnunit.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.5/pnunit.html
+++ b/docs/2.5.5/pnunit.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.5/projectEditor.html
+++ b/docs/2.5.5/projectEditor.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.5/projectEditor.html
+++ b/docs/2.5.5/projectEditor.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.5/projectEditor.html
+++ b/docs/2.5.5/projectEditor.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.5/projectEditor.html
+++ b/docs/2.5.5/projectEditor.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.5/property.html
+++ b/docs/2.5.5/property.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.5/property.html
+++ b/docs/2.5.5/property.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.5/property.html
+++ b/docs/2.5.5/property.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.5/property.html
+++ b/docs/2.5.5/property.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.5/propertyConstraint.html
+++ b/docs/2.5.5/propertyConstraint.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.5/propertyConstraint.html
+++ b/docs/2.5.5/propertyConstraint.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.5/propertyConstraint.html
+++ b/docs/2.5.5/propertyConstraint.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.5/propertyConstraint.html
+++ b/docs/2.5.5/propertyConstraint.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.5/quickStart.html
+++ b/docs/2.5.5/quickStart.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.5/quickStart.html
+++ b/docs/2.5.5/quickStart.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.5/quickStart.html
+++ b/docs/2.5.5/quickStart.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.5/quickStart.html
+++ b/docs/2.5.5/quickStart.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.5/quickStartSource.html
+++ b/docs/2.5.5/quickStartSource.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.5/quickStartSource.html
+++ b/docs/2.5.5/quickStartSource.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.5/quickStartSource.html
+++ b/docs/2.5.5/quickStartSource.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.5/quickStartSource.html
+++ b/docs/2.5.5/quickStartSource.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.5/random.html
+++ b/docs/2.5.5/random.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.5/random.html
+++ b/docs/2.5.5/random.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.5/random.html
+++ b/docs/2.5.5/random.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.5/random.html
+++ b/docs/2.5.5/random.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.5/range.html
+++ b/docs/2.5.5/range.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.5/range.html
+++ b/docs/2.5.5/range.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.5/range.html
+++ b/docs/2.5.5/range.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.5/range.html
+++ b/docs/2.5.5/range.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.5/releaseNotes.html
+++ b/docs/2.5.5/releaseNotes.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.5/releaseNotes.html
+++ b/docs/2.5.5/releaseNotes.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.5/releaseNotes.html
+++ b/docs/2.5.5/releaseNotes.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.5/releaseNotes.html
+++ b/docs/2.5.5/releaseNotes.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.5/repeat.html
+++ b/docs/2.5.5/repeat.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.5/repeat.html
+++ b/docs/2.5.5/repeat.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.5/repeat.html
+++ b/docs/2.5.5/repeat.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.5/repeat.html
+++ b/docs/2.5.5/repeat.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.5/requiredAddin.html
+++ b/docs/2.5.5/requiredAddin.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.5/requiredAddin.html
+++ b/docs/2.5.5/requiredAddin.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.5/requiredAddin.html
+++ b/docs/2.5.5/requiredAddin.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.5/requiredAddin.html
+++ b/docs/2.5.5/requiredAddin.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.5/requiresMTA.html
+++ b/docs/2.5.5/requiresMTA.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.5/requiresMTA.html
+++ b/docs/2.5.5/requiresMTA.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.5/requiresMTA.html
+++ b/docs/2.5.5/requiresMTA.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.5/requiresMTA.html
+++ b/docs/2.5.5/requiresMTA.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.5/requiresSTA.html
+++ b/docs/2.5.5/requiresSTA.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.5/requiresSTA.html
+++ b/docs/2.5.5/requiresSTA.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.5/requiresSTA.html
+++ b/docs/2.5.5/requiresSTA.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.5/requiresSTA.html
+++ b/docs/2.5.5/requiresSTA.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.5/requiresThread.html
+++ b/docs/2.5.5/requiresThread.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.5/requiresThread.html
+++ b/docs/2.5.5/requiresThread.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.5/requiresThread.html
+++ b/docs/2.5.5/requiresThread.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.5/requiresThread.html
+++ b/docs/2.5.5/requiresThread.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.5/runningTests.html
+++ b/docs/2.5.5/runningTests.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.5/runningTests.html
+++ b/docs/2.5.5/runningTests.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.5/runningTests.html
+++ b/docs/2.5.5/runningTests.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.5/runningTests.html
+++ b/docs/2.5.5/runningTests.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.5/runtimeSelection.html
+++ b/docs/2.5.5/runtimeSelection.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.5/runtimeSelection.html
+++ b/docs/2.5.5/runtimeSelection.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.5/runtimeSelection.html
+++ b/docs/2.5.5/runtimeSelection.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.5/runtimeSelection.html
+++ b/docs/2.5.5/runtimeSelection.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.5/sameasConstraint.html
+++ b/docs/2.5.5/sameasConstraint.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.5/sameasConstraint.html
+++ b/docs/2.5.5/sameasConstraint.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.5/sameasConstraint.html
+++ b/docs/2.5.5/sameasConstraint.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.5/sameasConstraint.html
+++ b/docs/2.5.5/sameasConstraint.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.5/samples.html
+++ b/docs/2.5.5/samples.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.5/samples.html
+++ b/docs/2.5.5/samples.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.5/samples.html
+++ b/docs/2.5.5/samples.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.5/samples.html
+++ b/docs/2.5.5/samples.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.5/sequential.html
+++ b/docs/2.5.5/sequential.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.5/sequential.html
+++ b/docs/2.5.5/sequential.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.5/sequential.html
+++ b/docs/2.5.5/sequential.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.5/sequential.html
+++ b/docs/2.5.5/sequential.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.5/setCulture.html
+++ b/docs/2.5.5/setCulture.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.5/setCulture.html
+++ b/docs/2.5.5/setCulture.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.5/setCulture.html
+++ b/docs/2.5.5/setCulture.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.5/setCulture.html
+++ b/docs/2.5.5/setCulture.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.5/setUICulture.html
+++ b/docs/2.5.5/setUICulture.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.5/setUICulture.html
+++ b/docs/2.5.5/setUICulture.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.5/setUICulture.html
+++ b/docs/2.5.5/setUICulture.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.5/setUICulture.html
+++ b/docs/2.5.5/setUICulture.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.5/settingsDialog.html
+++ b/docs/2.5.5/settingsDialog.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.5/settingsDialog.html
+++ b/docs/2.5.5/settingsDialog.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.5/settingsDialog.html
+++ b/docs/2.5.5/settingsDialog.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.5/settingsDialog.html
+++ b/docs/2.5.5/settingsDialog.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.5/setup.html
+++ b/docs/2.5.5/setup.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.5/setup.html
+++ b/docs/2.5.5/setup.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.5/setup.html
+++ b/docs/2.5.5/setup.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.5/setup.html
+++ b/docs/2.5.5/setup.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.5/setupFixture.html
+++ b/docs/2.5.5/setupFixture.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.5/setupFixture.html
+++ b/docs/2.5.5/setupFixture.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.5/setupFixture.html
+++ b/docs/2.5.5/setupFixture.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.5/setupFixture.html
+++ b/docs/2.5.5/setupFixture.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.5/stringAssert.html
+++ b/docs/2.5.5/stringAssert.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.5/stringAssert.html
+++ b/docs/2.5.5/stringAssert.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.5/stringAssert.html
+++ b/docs/2.5.5/stringAssert.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.5/stringAssert.html
+++ b/docs/2.5.5/stringAssert.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.5/stringConstraints.html
+++ b/docs/2.5.5/stringConstraints.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.5/stringConstraints.html
+++ b/docs/2.5.5/stringConstraints.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.5/stringConstraints.html
+++ b/docs/2.5.5/stringConstraints.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.5/stringConstraints.html
+++ b/docs/2.5.5/stringConstraints.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.5/suite.html
+++ b/docs/2.5.5/suite.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.5/suite.html
+++ b/docs/2.5.5/suite.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.5/suite.html
+++ b/docs/2.5.5/suite.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.5/suite.html
+++ b/docs/2.5.5/suite.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.5/suiteBuilders.html
+++ b/docs/2.5.5/suiteBuilders.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.5/suiteBuilders.html
+++ b/docs/2.5.5/suiteBuilders.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.5/suiteBuilders.html
+++ b/docs/2.5.5/suiteBuilders.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.5/suiteBuilders.html
+++ b/docs/2.5.5/suiteBuilders.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.5/teardown.html
+++ b/docs/2.5.5/teardown.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.5/teardown.html
+++ b/docs/2.5.5/teardown.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.5/teardown.html
+++ b/docs/2.5.5/teardown.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.5/teardown.html
+++ b/docs/2.5.5/teardown.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.5/test.html
+++ b/docs/2.5.5/test.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.5/test.html
+++ b/docs/2.5.5/test.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.5/test.html
+++ b/docs/2.5.5/test.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.5/test.html
+++ b/docs/2.5.5/test.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.5/testCase.html
+++ b/docs/2.5.5/testCase.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.5/testCase.html
+++ b/docs/2.5.5/testCase.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.5/testCase.html
+++ b/docs/2.5.5/testCase.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.5/testCase.html
+++ b/docs/2.5.5/testCase.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.5/testCaseSource.html
+++ b/docs/2.5.5/testCaseSource.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.5/testCaseSource.html
+++ b/docs/2.5.5/testCaseSource.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.5/testCaseSource.html
+++ b/docs/2.5.5/testCaseSource.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.5/testCaseSource.html
+++ b/docs/2.5.5/testCaseSource.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.5/testDecorators.html
+++ b/docs/2.5.5/testDecorators.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.5/testDecorators.html
+++ b/docs/2.5.5/testDecorators.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.5/testDecorators.html
+++ b/docs/2.5.5/testDecorators.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.5/testDecorators.html
+++ b/docs/2.5.5/testDecorators.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.5/testFixture.html
+++ b/docs/2.5.5/testFixture.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.5/testFixture.html
+++ b/docs/2.5.5/testFixture.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.5/testFixture.html
+++ b/docs/2.5.5/testFixture.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.5/testFixture.html
+++ b/docs/2.5.5/testFixture.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.5/testProperties.html
+++ b/docs/2.5.5/testProperties.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.5/testProperties.html
+++ b/docs/2.5.5/testProperties.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.5/testProperties.html
+++ b/docs/2.5.5/testProperties.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.5/testProperties.html
+++ b/docs/2.5.5/testProperties.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.5/testcaseBuilders.html
+++ b/docs/2.5.5/testcaseBuilders.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.5/testcaseBuilders.html
+++ b/docs/2.5.5/testcaseBuilders.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.5/testcaseBuilders.html
+++ b/docs/2.5.5/testcaseBuilders.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.5/testcaseBuilders.html
+++ b/docs/2.5.5/testcaseBuilders.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.5/testcaseProviders.html
+++ b/docs/2.5.5/testcaseProviders.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.5/testcaseProviders.html
+++ b/docs/2.5.5/testcaseProviders.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.5/testcaseProviders.html
+++ b/docs/2.5.5/testcaseProviders.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.5/testcaseProviders.html
+++ b/docs/2.5.5/testcaseProviders.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.5/theory.html
+++ b/docs/2.5.5/theory.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.5/theory.html
+++ b/docs/2.5.5/theory.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.5/theory.html
+++ b/docs/2.5.5/theory.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.5/theory.html
+++ b/docs/2.5.5/theory.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.5/throwsConstraint.html
+++ b/docs/2.5.5/throwsConstraint.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.5/throwsConstraint.html
+++ b/docs/2.5.5/throwsConstraint.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.5/throwsConstraint.html
+++ b/docs/2.5.5/throwsConstraint.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.5/throwsConstraint.html
+++ b/docs/2.5.5/throwsConstraint.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.5/timeout.html
+++ b/docs/2.5.5/timeout.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.5/timeout.html
+++ b/docs/2.5.5/timeout.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.5/timeout.html
+++ b/docs/2.5.5/timeout.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.5/timeout.html
+++ b/docs/2.5.5/timeout.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.5/typeAsserts.html
+++ b/docs/2.5.5/typeAsserts.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.5/typeAsserts.html
+++ b/docs/2.5.5/typeAsserts.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.5/typeAsserts.html
+++ b/docs/2.5.5/typeAsserts.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.5/typeAsserts.html
+++ b/docs/2.5.5/typeAsserts.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.5/typeConstraints.html
+++ b/docs/2.5.5/typeConstraints.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.5/typeConstraints.html
+++ b/docs/2.5.5/typeConstraints.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.5/typeConstraints.html
+++ b/docs/2.5.5/typeConstraints.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.5/typeConstraints.html
+++ b/docs/2.5.5/typeConstraints.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.5/upgrade.html
+++ b/docs/2.5.5/upgrade.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.5/upgrade.html
+++ b/docs/2.5.5/upgrade.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.5/upgrade.html
+++ b/docs/2.5.5/upgrade.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.5/upgrade.html
+++ b/docs/2.5.5/upgrade.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.5/utilityAsserts.html
+++ b/docs/2.5.5/utilityAsserts.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.5/utilityAsserts.html
+++ b/docs/2.5.5/utilityAsserts.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.5/utilityAsserts.html
+++ b/docs/2.5.5/utilityAsserts.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.5/utilityAsserts.html
+++ b/docs/2.5.5/utilityAsserts.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.5/valueSource.html
+++ b/docs/2.5.5/valueSource.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.5/valueSource.html
+++ b/docs/2.5.5/valueSource.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.5/valueSource.html
+++ b/docs/2.5.5/valueSource.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.5/valueSource.html
+++ b/docs/2.5.5/valueSource.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.5/values.html
+++ b/docs/2.5.5/values.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.5/values.html
+++ b/docs/2.5.5/values.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.5/values.html
+++ b/docs/2.5.5/values.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.5/values.html
+++ b/docs/2.5.5/values.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.5/vsSupport.html
+++ b/docs/2.5.5/vsSupport.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.5/vsSupport.html
+++ b/docs/2.5.5/vsSupport.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.5/vsSupport.html
+++ b/docs/2.5.5/vsSupport.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.5/vsSupport.html
+++ b/docs/2.5.5/vsSupport.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.6/addinsDialog.html
+++ b/docs/2.5.6/addinsDialog.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.6/addinsDialog.html
+++ b/docs/2.5.6/addinsDialog.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.6/addinsDialog.html
+++ b/docs/2.5.6/addinsDialog.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.6/addinsDialog.html
+++ b/docs/2.5.6/addinsDialog.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.6/assemblyIsolation.html
+++ b/docs/2.5.6/assemblyIsolation.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.6/assemblyIsolation.html
+++ b/docs/2.5.6/assemblyIsolation.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.6/assemblyIsolation.html
+++ b/docs/2.5.6/assemblyIsolation.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.6/assemblyIsolation.html
+++ b/docs/2.5.6/assemblyIsolation.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.6/assertions.html
+++ b/docs/2.5.6/assertions.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.6/assertions.html
+++ b/docs/2.5.6/assertions.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.6/assertions.html
+++ b/docs/2.5.6/assertions.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.6/assertions.html
+++ b/docs/2.5.6/assertions.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.6/attributes.html
+++ b/docs/2.5.6/attributes.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.6/attributes.html
+++ b/docs/2.5.6/attributes.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.6/attributes.html
+++ b/docs/2.5.6/attributes.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.6/attributes.html
+++ b/docs/2.5.6/attributes.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.6/category.html
+++ b/docs/2.5.6/category.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.6/category.html
+++ b/docs/2.5.6/category.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.6/category.html
+++ b/docs/2.5.6/category.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.6/category.html
+++ b/docs/2.5.6/category.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.6/collectionAssert.html
+++ b/docs/2.5.6/collectionAssert.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.6/collectionAssert.html
+++ b/docs/2.5.6/collectionAssert.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.6/collectionAssert.html
+++ b/docs/2.5.6/collectionAssert.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.6/collectionAssert.html
+++ b/docs/2.5.6/collectionAssert.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.6/collectionConstraints.html
+++ b/docs/2.5.6/collectionConstraints.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.6/collectionConstraints.html
+++ b/docs/2.5.6/collectionConstraints.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.6/collectionConstraints.html
+++ b/docs/2.5.6/collectionConstraints.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.6/collectionConstraints.html
+++ b/docs/2.5.6/collectionConstraints.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.6/combinatorial.html
+++ b/docs/2.5.6/combinatorial.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.6/combinatorial.html
+++ b/docs/2.5.6/combinatorial.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.6/combinatorial.html
+++ b/docs/2.5.6/combinatorial.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.6/combinatorial.html
+++ b/docs/2.5.6/combinatorial.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.6/comparisonAsserts.html
+++ b/docs/2.5.6/comparisonAsserts.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.6/comparisonAsserts.html
+++ b/docs/2.5.6/comparisonAsserts.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.6/comparisonAsserts.html
+++ b/docs/2.5.6/comparisonAsserts.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.6/comparisonAsserts.html
+++ b/docs/2.5.6/comparisonAsserts.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.6/comparisonConstraints.html
+++ b/docs/2.5.6/comparisonConstraints.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.6/comparisonConstraints.html
+++ b/docs/2.5.6/comparisonConstraints.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.6/comparisonConstraints.html
+++ b/docs/2.5.6/comparisonConstraints.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.6/comparisonConstraints.html
+++ b/docs/2.5.6/comparisonConstraints.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.6/compoundConstraints.html
+++ b/docs/2.5.6/compoundConstraints.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.6/compoundConstraints.html
+++ b/docs/2.5.6/compoundConstraints.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.6/compoundConstraints.html
+++ b/docs/2.5.6/compoundConstraints.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.6/compoundConstraints.html
+++ b/docs/2.5.6/compoundConstraints.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.6/conditionAsserts.html
+++ b/docs/2.5.6/conditionAsserts.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.6/conditionAsserts.html
+++ b/docs/2.5.6/conditionAsserts.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.6/conditionAsserts.html
+++ b/docs/2.5.6/conditionAsserts.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.6/conditionAsserts.html
+++ b/docs/2.5.6/conditionAsserts.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.6/conditionConstraints.html
+++ b/docs/2.5.6/conditionConstraints.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.6/conditionConstraints.html
+++ b/docs/2.5.6/conditionConstraints.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.6/conditionConstraints.html
+++ b/docs/2.5.6/conditionConstraints.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.6/conditionConstraints.html
+++ b/docs/2.5.6/conditionConstraints.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.6/configEditor.html
+++ b/docs/2.5.6/configEditor.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.6/configEditor.html
+++ b/docs/2.5.6/configEditor.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.6/configEditor.html
+++ b/docs/2.5.6/configEditor.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.6/configEditor.html
+++ b/docs/2.5.6/configEditor.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.6/configFiles.html
+++ b/docs/2.5.6/configFiles.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.6/configFiles.html
+++ b/docs/2.5.6/configFiles.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.6/configFiles.html
+++ b/docs/2.5.6/configFiles.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.6/configFiles.html
+++ b/docs/2.5.6/configFiles.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.6/consoleCommandLine.html
+++ b/docs/2.5.6/consoleCommandLine.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.6/consoleCommandLine.html
+++ b/docs/2.5.6/consoleCommandLine.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.6/consoleCommandLine.html
+++ b/docs/2.5.6/consoleCommandLine.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.6/consoleCommandLine.html
+++ b/docs/2.5.6/consoleCommandLine.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.6/constraintModel.html
+++ b/docs/2.5.6/constraintModel.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.6/constraintModel.html
+++ b/docs/2.5.6/constraintModel.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.6/constraintModel.html
+++ b/docs/2.5.6/constraintModel.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.6/constraintModel.html
+++ b/docs/2.5.6/constraintModel.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.6/contextMenu.html
+++ b/docs/2.5.6/contextMenu.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.6/contextMenu.html
+++ b/docs/2.5.6/contextMenu.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.6/contextMenu.html
+++ b/docs/2.5.6/contextMenu.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.6/contextMenu.html
+++ b/docs/2.5.6/contextMenu.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.6/culture.html
+++ b/docs/2.5.6/culture.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.6/culture.html
+++ b/docs/2.5.6/culture.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.6/culture.html
+++ b/docs/2.5.6/culture.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.6/culture.html
+++ b/docs/2.5.6/culture.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.6/customConstraints.html
+++ b/docs/2.5.6/customConstraints.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.6/customConstraints.html
+++ b/docs/2.5.6/customConstraints.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.6/customConstraints.html
+++ b/docs/2.5.6/customConstraints.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.6/customConstraints.html
+++ b/docs/2.5.6/customConstraints.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.6/datapoint.html
+++ b/docs/2.5.6/datapoint.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.6/datapoint.html
+++ b/docs/2.5.6/datapoint.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.6/datapoint.html
+++ b/docs/2.5.6/datapoint.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.6/datapoint.html
+++ b/docs/2.5.6/datapoint.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.6/datapointProviders.html
+++ b/docs/2.5.6/datapointProviders.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.6/datapointProviders.html
+++ b/docs/2.5.6/datapointProviders.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.6/datapointProviders.html
+++ b/docs/2.5.6/datapointProviders.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.6/datapointProviders.html
+++ b/docs/2.5.6/datapointProviders.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.6/delayedConstraint.html
+++ b/docs/2.5.6/delayedConstraint.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.6/delayedConstraint.html
+++ b/docs/2.5.6/delayedConstraint.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.6/delayedConstraint.html
+++ b/docs/2.5.6/delayedConstraint.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.6/delayedConstraint.html
+++ b/docs/2.5.6/delayedConstraint.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.6/description.html
+++ b/docs/2.5.6/description.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.6/description.html
+++ b/docs/2.5.6/description.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.6/description.html
+++ b/docs/2.5.6/description.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.6/description.html
+++ b/docs/2.5.6/description.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.6/directoryAssert.html
+++ b/docs/2.5.6/directoryAssert.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.6/directoryAssert.html
+++ b/docs/2.5.6/directoryAssert.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.6/directoryAssert.html
+++ b/docs/2.5.6/directoryAssert.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.6/directoryAssert.html
+++ b/docs/2.5.6/directoryAssert.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.6/docHome.html
+++ b/docs/2.5.6/docHome.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.6/docHome.html
+++ b/docs/2.5.6/docHome.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.6/docHome.html
+++ b/docs/2.5.6/docHome.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.6/docHome.html
+++ b/docs/2.5.6/docHome.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.6/equalConstraint.html
+++ b/docs/2.5.6/equalConstraint.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.6/equalConstraint.html
+++ b/docs/2.5.6/equalConstraint.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.6/equalConstraint.html
+++ b/docs/2.5.6/equalConstraint.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.6/equalConstraint.html
+++ b/docs/2.5.6/equalConstraint.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.6/equalityAsserts.html
+++ b/docs/2.5.6/equalityAsserts.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.6/equalityAsserts.html
+++ b/docs/2.5.6/equalityAsserts.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.6/equalityAsserts.html
+++ b/docs/2.5.6/equalityAsserts.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.6/equalityAsserts.html
+++ b/docs/2.5.6/equalityAsserts.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.6/eventListeners.html
+++ b/docs/2.5.6/eventListeners.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.6/eventListeners.html
+++ b/docs/2.5.6/eventListeners.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.6/eventListeners.html
+++ b/docs/2.5.6/eventListeners.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.6/eventListeners.html
+++ b/docs/2.5.6/eventListeners.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.6/exception.html
+++ b/docs/2.5.6/exception.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.6/exception.html
+++ b/docs/2.5.6/exception.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.6/exception.html
+++ b/docs/2.5.6/exception.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.6/exception.html
+++ b/docs/2.5.6/exception.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.6/exceptionAsserts.html
+++ b/docs/2.5.6/exceptionAsserts.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.6/exceptionAsserts.html
+++ b/docs/2.5.6/exceptionAsserts.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.6/exceptionAsserts.html
+++ b/docs/2.5.6/exceptionAsserts.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.6/exceptionAsserts.html
+++ b/docs/2.5.6/exceptionAsserts.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.6/explicit.html
+++ b/docs/2.5.6/explicit.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.6/explicit.html
+++ b/docs/2.5.6/explicit.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.6/explicit.html
+++ b/docs/2.5.6/explicit.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.6/explicit.html
+++ b/docs/2.5.6/explicit.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.6/extensibility.html
+++ b/docs/2.5.6/extensibility.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.6/extensibility.html
+++ b/docs/2.5.6/extensibility.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.6/extensibility.html
+++ b/docs/2.5.6/extensibility.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.6/extensibility.html
+++ b/docs/2.5.6/extensibility.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.6/extensionTips.html
+++ b/docs/2.5.6/extensionTips.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.6/extensionTips.html
+++ b/docs/2.5.6/extensionTips.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.6/extensionTips.html
+++ b/docs/2.5.6/extensionTips.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.6/extensionTips.html
+++ b/docs/2.5.6/extensionTips.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.6/fileAssert.html
+++ b/docs/2.5.6/fileAssert.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.6/fileAssert.html
+++ b/docs/2.5.6/fileAssert.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.6/fileAssert.html
+++ b/docs/2.5.6/fileAssert.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.6/fileAssert.html
+++ b/docs/2.5.6/fileAssert.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.6/fixtureSetup.html
+++ b/docs/2.5.6/fixtureSetup.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.6/fixtureSetup.html
+++ b/docs/2.5.6/fixtureSetup.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.6/fixtureSetup.html
+++ b/docs/2.5.6/fixtureSetup.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.6/fixtureSetup.html
+++ b/docs/2.5.6/fixtureSetup.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.6/fixtureTeardown.html
+++ b/docs/2.5.6/fixtureTeardown.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.6/fixtureTeardown.html
+++ b/docs/2.5.6/fixtureTeardown.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.6/fixtureTeardown.html
+++ b/docs/2.5.6/fixtureTeardown.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.6/fixtureTeardown.html
+++ b/docs/2.5.6/fixtureTeardown.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.6/getStarted.html
+++ b/docs/2.5.6/getStarted.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.6/getStarted.html
+++ b/docs/2.5.6/getStarted.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.6/getStarted.html
+++ b/docs/2.5.6/getStarted.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.6/getStarted.html
+++ b/docs/2.5.6/getStarted.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.6/guiCommandLine.html
+++ b/docs/2.5.6/guiCommandLine.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.6/guiCommandLine.html
+++ b/docs/2.5.6/guiCommandLine.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.6/guiCommandLine.html
+++ b/docs/2.5.6/guiCommandLine.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.6/guiCommandLine.html
+++ b/docs/2.5.6/guiCommandLine.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.6/identityAsserts.html
+++ b/docs/2.5.6/identityAsserts.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.6/identityAsserts.html
+++ b/docs/2.5.6/identityAsserts.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.6/identityAsserts.html
+++ b/docs/2.5.6/identityAsserts.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.6/identityAsserts.html
+++ b/docs/2.5.6/identityAsserts.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.6/ignore.html
+++ b/docs/2.5.6/ignore.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.6/ignore.html
+++ b/docs/2.5.6/ignore.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.6/ignore.html
+++ b/docs/2.5.6/ignore.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.6/ignore.html
+++ b/docs/2.5.6/ignore.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.6/installation.html
+++ b/docs/2.5.6/installation.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.6/installation.html
+++ b/docs/2.5.6/installation.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.6/installation.html
+++ b/docs/2.5.6/installation.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.6/installation.html
+++ b/docs/2.5.6/installation.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.6/license.html
+++ b/docs/2.5.6/license.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.6/license.html
+++ b/docs/2.5.6/license.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.6/license.html
+++ b/docs/2.5.6/license.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.6/license.html
+++ b/docs/2.5.6/license.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.6/listMapper.html
+++ b/docs/2.5.6/listMapper.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.6/listMapper.html
+++ b/docs/2.5.6/listMapper.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.6/listMapper.html
+++ b/docs/2.5.6/listMapper.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.6/listMapper.html
+++ b/docs/2.5.6/listMapper.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.6/mainMenu.html
+++ b/docs/2.5.6/mainMenu.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.6/mainMenu.html
+++ b/docs/2.5.6/mainMenu.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.6/mainMenu.html
+++ b/docs/2.5.6/mainMenu.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.6/mainMenu.html
+++ b/docs/2.5.6/mainMenu.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.6/maxtime.html
+++ b/docs/2.5.6/maxtime.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.6/maxtime.html
+++ b/docs/2.5.6/maxtime.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.6/maxtime.html
+++ b/docs/2.5.6/maxtime.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.6/maxtime.html
+++ b/docs/2.5.6/maxtime.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.6/multiAssembly.html
+++ b/docs/2.5.6/multiAssembly.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.6/multiAssembly.html
+++ b/docs/2.5.6/multiAssembly.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.6/multiAssembly.html
+++ b/docs/2.5.6/multiAssembly.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.6/multiAssembly.html
+++ b/docs/2.5.6/multiAssembly.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.6/nunit-console.html
+++ b/docs/2.5.6/nunit-console.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.6/nunit-console.html
+++ b/docs/2.5.6/nunit-console.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.6/nunit-console.html
+++ b/docs/2.5.6/nunit-console.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.6/nunit-console.html
+++ b/docs/2.5.6/nunit-console.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.6/nunit-gui.html
+++ b/docs/2.5.6/nunit-gui.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.6/nunit-gui.html
+++ b/docs/2.5.6/nunit-gui.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.6/nunit-gui.html
+++ b/docs/2.5.6/nunit-gui.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.6/nunit-gui.html
+++ b/docs/2.5.6/nunit-gui.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.6/nunitAddins.html
+++ b/docs/2.5.6/nunitAddins.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.6/nunitAddins.html
+++ b/docs/2.5.6/nunitAddins.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.6/nunitAddins.html
+++ b/docs/2.5.6/nunitAddins.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.6/nunitAddins.html
+++ b/docs/2.5.6/nunitAddins.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.6/pairwise.html
+++ b/docs/2.5.6/pairwise.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.6/pairwise.html
+++ b/docs/2.5.6/pairwise.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.6/pairwise.html
+++ b/docs/2.5.6/pairwise.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.6/pairwise.html
+++ b/docs/2.5.6/pairwise.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.6/parameterizedTests.html
+++ b/docs/2.5.6/parameterizedTests.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.6/parameterizedTests.html
+++ b/docs/2.5.6/parameterizedTests.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.6/parameterizedTests.html
+++ b/docs/2.5.6/parameterizedTests.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.6/parameterizedTests.html
+++ b/docs/2.5.6/parameterizedTests.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.6/pathConstraints.html
+++ b/docs/2.5.6/pathConstraints.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.6/pathConstraints.html
+++ b/docs/2.5.6/pathConstraints.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.6/pathConstraints.html
+++ b/docs/2.5.6/pathConstraints.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.6/pathConstraints.html
+++ b/docs/2.5.6/pathConstraints.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.6/platform.html
+++ b/docs/2.5.6/platform.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.6/platform.html
+++ b/docs/2.5.6/platform.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.6/platform.html
+++ b/docs/2.5.6/platform.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.6/platform.html
+++ b/docs/2.5.6/platform.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.6/pnunit.html
+++ b/docs/2.5.6/pnunit.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.6/pnunit.html
+++ b/docs/2.5.6/pnunit.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.6/pnunit.html
+++ b/docs/2.5.6/pnunit.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.6/pnunit.html
+++ b/docs/2.5.6/pnunit.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.6/projectEditor.html
+++ b/docs/2.5.6/projectEditor.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.6/projectEditor.html
+++ b/docs/2.5.6/projectEditor.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.6/projectEditor.html
+++ b/docs/2.5.6/projectEditor.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.6/projectEditor.html
+++ b/docs/2.5.6/projectEditor.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.6/property.html
+++ b/docs/2.5.6/property.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.6/property.html
+++ b/docs/2.5.6/property.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.6/property.html
+++ b/docs/2.5.6/property.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.6/property.html
+++ b/docs/2.5.6/property.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.6/propertyConstraint.html
+++ b/docs/2.5.6/propertyConstraint.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.6/propertyConstraint.html
+++ b/docs/2.5.6/propertyConstraint.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.6/propertyConstraint.html
+++ b/docs/2.5.6/propertyConstraint.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.6/propertyConstraint.html
+++ b/docs/2.5.6/propertyConstraint.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.6/quickStart.html
+++ b/docs/2.5.6/quickStart.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.6/quickStart.html
+++ b/docs/2.5.6/quickStart.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.6/quickStart.html
+++ b/docs/2.5.6/quickStart.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.6/quickStart.html
+++ b/docs/2.5.6/quickStart.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.6/quickStartSource.html
+++ b/docs/2.5.6/quickStartSource.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.6/quickStartSource.html
+++ b/docs/2.5.6/quickStartSource.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.6/quickStartSource.html
+++ b/docs/2.5.6/quickStartSource.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.6/quickStartSource.html
+++ b/docs/2.5.6/quickStartSource.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.6/random.html
+++ b/docs/2.5.6/random.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.6/random.html
+++ b/docs/2.5.6/random.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.6/random.html
+++ b/docs/2.5.6/random.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.6/random.html
+++ b/docs/2.5.6/random.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.6/range.html
+++ b/docs/2.5.6/range.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.6/range.html
+++ b/docs/2.5.6/range.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.6/range.html
+++ b/docs/2.5.6/range.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.6/range.html
+++ b/docs/2.5.6/range.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.6/releaseNotes.html
+++ b/docs/2.5.6/releaseNotes.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.6/releaseNotes.html
+++ b/docs/2.5.6/releaseNotes.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.6/releaseNotes.html
+++ b/docs/2.5.6/releaseNotes.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.6/releaseNotes.html
+++ b/docs/2.5.6/releaseNotes.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.6/repeat.html
+++ b/docs/2.5.6/repeat.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.6/repeat.html
+++ b/docs/2.5.6/repeat.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.6/repeat.html
+++ b/docs/2.5.6/repeat.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.6/repeat.html
+++ b/docs/2.5.6/repeat.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.6/requiredAddin.html
+++ b/docs/2.5.6/requiredAddin.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.6/requiredAddin.html
+++ b/docs/2.5.6/requiredAddin.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.6/requiredAddin.html
+++ b/docs/2.5.6/requiredAddin.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.6/requiredAddin.html
+++ b/docs/2.5.6/requiredAddin.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.6/requiresMTA.html
+++ b/docs/2.5.6/requiresMTA.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.6/requiresMTA.html
+++ b/docs/2.5.6/requiresMTA.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.6/requiresMTA.html
+++ b/docs/2.5.6/requiresMTA.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.6/requiresMTA.html
+++ b/docs/2.5.6/requiresMTA.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.6/requiresSTA.html
+++ b/docs/2.5.6/requiresSTA.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.6/requiresSTA.html
+++ b/docs/2.5.6/requiresSTA.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.6/requiresSTA.html
+++ b/docs/2.5.6/requiresSTA.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.6/requiresSTA.html
+++ b/docs/2.5.6/requiresSTA.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.6/requiresThread.html
+++ b/docs/2.5.6/requiresThread.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.6/requiresThread.html
+++ b/docs/2.5.6/requiresThread.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.6/requiresThread.html
+++ b/docs/2.5.6/requiresThread.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.6/requiresThread.html
+++ b/docs/2.5.6/requiresThread.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.6/reusableConstraint.html
+++ b/docs/2.5.6/reusableConstraint.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.6/reusableConstraint.html
+++ b/docs/2.5.6/reusableConstraint.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.6/reusableConstraint.html
+++ b/docs/2.5.6/reusableConstraint.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.6/reusableConstraint.html
+++ b/docs/2.5.6/reusableConstraint.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.6/runningTests.html
+++ b/docs/2.5.6/runningTests.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.6/runningTests.html
+++ b/docs/2.5.6/runningTests.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.6/runningTests.html
+++ b/docs/2.5.6/runningTests.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.6/runningTests.html
+++ b/docs/2.5.6/runningTests.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.6/runtimeSelection.html
+++ b/docs/2.5.6/runtimeSelection.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.6/runtimeSelection.html
+++ b/docs/2.5.6/runtimeSelection.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.6/runtimeSelection.html
+++ b/docs/2.5.6/runtimeSelection.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.6/runtimeSelection.html
+++ b/docs/2.5.6/runtimeSelection.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.6/sameasConstraint.html
+++ b/docs/2.5.6/sameasConstraint.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.6/sameasConstraint.html
+++ b/docs/2.5.6/sameasConstraint.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.6/sameasConstraint.html
+++ b/docs/2.5.6/sameasConstraint.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.6/sameasConstraint.html
+++ b/docs/2.5.6/sameasConstraint.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.6/samples.html
+++ b/docs/2.5.6/samples.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.6/samples.html
+++ b/docs/2.5.6/samples.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.6/samples.html
+++ b/docs/2.5.6/samples.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.6/samples.html
+++ b/docs/2.5.6/samples.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.6/sequential.html
+++ b/docs/2.5.6/sequential.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.6/sequential.html
+++ b/docs/2.5.6/sequential.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.6/sequential.html
+++ b/docs/2.5.6/sequential.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.6/sequential.html
+++ b/docs/2.5.6/sequential.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.6/setCulture.html
+++ b/docs/2.5.6/setCulture.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.6/setCulture.html
+++ b/docs/2.5.6/setCulture.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.6/setCulture.html
+++ b/docs/2.5.6/setCulture.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.6/setCulture.html
+++ b/docs/2.5.6/setCulture.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.6/setUICulture.html
+++ b/docs/2.5.6/setUICulture.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.6/setUICulture.html
+++ b/docs/2.5.6/setUICulture.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.6/setUICulture.html
+++ b/docs/2.5.6/setUICulture.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.6/setUICulture.html
+++ b/docs/2.5.6/setUICulture.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.6/settingsDialog.html
+++ b/docs/2.5.6/settingsDialog.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.6/settingsDialog.html
+++ b/docs/2.5.6/settingsDialog.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.6/settingsDialog.html
+++ b/docs/2.5.6/settingsDialog.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.6/settingsDialog.html
+++ b/docs/2.5.6/settingsDialog.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.6/setup.html
+++ b/docs/2.5.6/setup.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.6/setup.html
+++ b/docs/2.5.6/setup.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.6/setup.html
+++ b/docs/2.5.6/setup.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.6/setup.html
+++ b/docs/2.5.6/setup.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.6/setupFixture.html
+++ b/docs/2.5.6/setupFixture.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.6/setupFixture.html
+++ b/docs/2.5.6/setupFixture.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.6/setupFixture.html
+++ b/docs/2.5.6/setupFixture.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.6/setupFixture.html
+++ b/docs/2.5.6/setupFixture.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.6/stringAssert.html
+++ b/docs/2.5.6/stringAssert.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.6/stringAssert.html
+++ b/docs/2.5.6/stringAssert.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.6/stringAssert.html
+++ b/docs/2.5.6/stringAssert.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.6/stringAssert.html
+++ b/docs/2.5.6/stringAssert.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.6/stringConstraints.html
+++ b/docs/2.5.6/stringConstraints.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.6/stringConstraints.html
+++ b/docs/2.5.6/stringConstraints.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.6/stringConstraints.html
+++ b/docs/2.5.6/stringConstraints.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.6/stringConstraints.html
+++ b/docs/2.5.6/stringConstraints.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.6/suite.html
+++ b/docs/2.5.6/suite.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.6/suite.html
+++ b/docs/2.5.6/suite.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.6/suite.html
+++ b/docs/2.5.6/suite.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.6/suite.html
+++ b/docs/2.5.6/suite.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.6/suiteBuilders.html
+++ b/docs/2.5.6/suiteBuilders.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.6/suiteBuilders.html
+++ b/docs/2.5.6/suiteBuilders.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.6/suiteBuilders.html
+++ b/docs/2.5.6/suiteBuilders.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.6/suiteBuilders.html
+++ b/docs/2.5.6/suiteBuilders.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.6/teardown.html
+++ b/docs/2.5.6/teardown.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.6/teardown.html
+++ b/docs/2.5.6/teardown.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.6/teardown.html
+++ b/docs/2.5.6/teardown.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.6/teardown.html
+++ b/docs/2.5.6/teardown.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.6/test.html
+++ b/docs/2.5.6/test.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.6/test.html
+++ b/docs/2.5.6/test.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.6/test.html
+++ b/docs/2.5.6/test.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.6/test.html
+++ b/docs/2.5.6/test.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.6/testCase.html
+++ b/docs/2.5.6/testCase.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.6/testCase.html
+++ b/docs/2.5.6/testCase.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.6/testCase.html
+++ b/docs/2.5.6/testCase.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.6/testCase.html
+++ b/docs/2.5.6/testCase.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.6/testCaseSource.html
+++ b/docs/2.5.6/testCaseSource.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.6/testCaseSource.html
+++ b/docs/2.5.6/testCaseSource.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.6/testCaseSource.html
+++ b/docs/2.5.6/testCaseSource.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.6/testCaseSource.html
+++ b/docs/2.5.6/testCaseSource.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.6/testDecorators.html
+++ b/docs/2.5.6/testDecorators.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.6/testDecorators.html
+++ b/docs/2.5.6/testDecorators.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.6/testDecorators.html
+++ b/docs/2.5.6/testDecorators.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.6/testDecorators.html
+++ b/docs/2.5.6/testDecorators.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.6/testFixture.html
+++ b/docs/2.5.6/testFixture.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.6/testFixture.html
+++ b/docs/2.5.6/testFixture.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.6/testFixture.html
+++ b/docs/2.5.6/testFixture.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.6/testFixture.html
+++ b/docs/2.5.6/testFixture.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.6/testProperties.html
+++ b/docs/2.5.6/testProperties.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.6/testProperties.html
+++ b/docs/2.5.6/testProperties.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.6/testProperties.html
+++ b/docs/2.5.6/testProperties.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.6/testProperties.html
+++ b/docs/2.5.6/testProperties.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.6/testcaseBuilders.html
+++ b/docs/2.5.6/testcaseBuilders.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.6/testcaseBuilders.html
+++ b/docs/2.5.6/testcaseBuilders.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.6/testcaseBuilders.html
+++ b/docs/2.5.6/testcaseBuilders.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.6/testcaseBuilders.html
+++ b/docs/2.5.6/testcaseBuilders.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.6/testcaseProviders.html
+++ b/docs/2.5.6/testcaseProviders.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.6/testcaseProviders.html
+++ b/docs/2.5.6/testcaseProviders.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.6/testcaseProviders.html
+++ b/docs/2.5.6/testcaseProviders.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.6/testcaseProviders.html
+++ b/docs/2.5.6/testcaseProviders.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.6/theory.html
+++ b/docs/2.5.6/theory.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.6/theory.html
+++ b/docs/2.5.6/theory.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.6/theory.html
+++ b/docs/2.5.6/theory.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.6/theory.html
+++ b/docs/2.5.6/theory.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.6/throwsConstraint.html
+++ b/docs/2.5.6/throwsConstraint.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.6/throwsConstraint.html
+++ b/docs/2.5.6/throwsConstraint.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.6/throwsConstraint.html
+++ b/docs/2.5.6/throwsConstraint.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.6/throwsConstraint.html
+++ b/docs/2.5.6/throwsConstraint.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.6/timeout.html
+++ b/docs/2.5.6/timeout.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.6/timeout.html
+++ b/docs/2.5.6/timeout.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.6/timeout.html
+++ b/docs/2.5.6/timeout.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.6/timeout.html
+++ b/docs/2.5.6/timeout.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.6/typeAsserts.html
+++ b/docs/2.5.6/typeAsserts.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.6/typeAsserts.html
+++ b/docs/2.5.6/typeAsserts.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.6/typeAsserts.html
+++ b/docs/2.5.6/typeAsserts.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.6/typeAsserts.html
+++ b/docs/2.5.6/typeAsserts.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.6/typeConstraints.html
+++ b/docs/2.5.6/typeConstraints.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.6/typeConstraints.html
+++ b/docs/2.5.6/typeConstraints.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.6/typeConstraints.html
+++ b/docs/2.5.6/typeConstraints.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.6/typeConstraints.html
+++ b/docs/2.5.6/typeConstraints.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.6/upgrade.html
+++ b/docs/2.5.6/upgrade.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.6/upgrade.html
+++ b/docs/2.5.6/upgrade.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.6/upgrade.html
+++ b/docs/2.5.6/upgrade.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.6/upgrade.html
+++ b/docs/2.5.6/upgrade.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.6/utilityAsserts.html
+++ b/docs/2.5.6/utilityAsserts.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.6/utilityAsserts.html
+++ b/docs/2.5.6/utilityAsserts.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.6/utilityAsserts.html
+++ b/docs/2.5.6/utilityAsserts.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.6/utilityAsserts.html
+++ b/docs/2.5.6/utilityAsserts.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.6/valueSource.html
+++ b/docs/2.5.6/valueSource.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.6/valueSource.html
+++ b/docs/2.5.6/valueSource.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.6/valueSource.html
+++ b/docs/2.5.6/valueSource.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.6/valueSource.html
+++ b/docs/2.5.6/valueSource.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.6/values.html
+++ b/docs/2.5.6/values.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.6/values.html
+++ b/docs/2.5.6/values.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.6/values.html
+++ b/docs/2.5.6/values.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.6/values.html
+++ b/docs/2.5.6/values.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.6/vsSupport.html
+++ b/docs/2.5.6/vsSupport.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.6/vsSupport.html
+++ b/docs/2.5.6/vsSupport.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.6/vsSupport.html
+++ b/docs/2.5.6/vsSupport.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.6/vsSupport.html
+++ b/docs/2.5.6/vsSupport.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.7/addinsDialog.html
+++ b/docs/2.5.7/addinsDialog.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.7/addinsDialog.html
+++ b/docs/2.5.7/addinsDialog.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.7/addinsDialog.html
+++ b/docs/2.5.7/addinsDialog.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.7/addinsDialog.html
+++ b/docs/2.5.7/addinsDialog.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.7/assemblyIsolation.html
+++ b/docs/2.5.7/assemblyIsolation.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.7/assemblyIsolation.html
+++ b/docs/2.5.7/assemblyIsolation.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.7/assemblyIsolation.html
+++ b/docs/2.5.7/assemblyIsolation.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.7/assemblyIsolation.html
+++ b/docs/2.5.7/assemblyIsolation.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.7/assertions.html
+++ b/docs/2.5.7/assertions.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.7/assertions.html
+++ b/docs/2.5.7/assertions.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.7/assertions.html
+++ b/docs/2.5.7/assertions.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.7/assertions.html
+++ b/docs/2.5.7/assertions.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.7/attributes.html
+++ b/docs/2.5.7/attributes.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.7/attributes.html
+++ b/docs/2.5.7/attributes.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.7/attributes.html
+++ b/docs/2.5.7/attributes.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.7/attributes.html
+++ b/docs/2.5.7/attributes.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.7/category.html
+++ b/docs/2.5.7/category.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.7/category.html
+++ b/docs/2.5.7/category.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.7/category.html
+++ b/docs/2.5.7/category.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.7/category.html
+++ b/docs/2.5.7/category.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.7/collectionAssert.html
+++ b/docs/2.5.7/collectionAssert.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.7/collectionAssert.html
+++ b/docs/2.5.7/collectionAssert.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.7/collectionAssert.html
+++ b/docs/2.5.7/collectionAssert.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.7/collectionAssert.html
+++ b/docs/2.5.7/collectionAssert.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.7/collectionConstraints.html
+++ b/docs/2.5.7/collectionConstraints.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.7/collectionConstraints.html
+++ b/docs/2.5.7/collectionConstraints.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.7/collectionConstraints.html
+++ b/docs/2.5.7/collectionConstraints.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.7/collectionConstraints.html
+++ b/docs/2.5.7/collectionConstraints.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.7/combinatorial.html
+++ b/docs/2.5.7/combinatorial.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.7/combinatorial.html
+++ b/docs/2.5.7/combinatorial.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.7/combinatorial.html
+++ b/docs/2.5.7/combinatorial.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.7/combinatorial.html
+++ b/docs/2.5.7/combinatorial.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.7/comparisonAsserts.html
+++ b/docs/2.5.7/comparisonAsserts.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.7/comparisonAsserts.html
+++ b/docs/2.5.7/comparisonAsserts.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.7/comparisonAsserts.html
+++ b/docs/2.5.7/comparisonAsserts.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.7/comparisonAsserts.html
+++ b/docs/2.5.7/comparisonAsserts.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.7/comparisonConstraints.html
+++ b/docs/2.5.7/comparisonConstraints.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.7/comparisonConstraints.html
+++ b/docs/2.5.7/comparisonConstraints.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.7/comparisonConstraints.html
+++ b/docs/2.5.7/comparisonConstraints.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.7/comparisonConstraints.html
+++ b/docs/2.5.7/comparisonConstraints.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.7/compoundConstraints.html
+++ b/docs/2.5.7/compoundConstraints.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.7/compoundConstraints.html
+++ b/docs/2.5.7/compoundConstraints.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.7/compoundConstraints.html
+++ b/docs/2.5.7/compoundConstraints.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.7/compoundConstraints.html
+++ b/docs/2.5.7/compoundConstraints.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.7/conditionAsserts.html
+++ b/docs/2.5.7/conditionAsserts.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.7/conditionAsserts.html
+++ b/docs/2.5.7/conditionAsserts.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.7/conditionAsserts.html
+++ b/docs/2.5.7/conditionAsserts.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.7/conditionAsserts.html
+++ b/docs/2.5.7/conditionAsserts.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.7/conditionConstraints.html
+++ b/docs/2.5.7/conditionConstraints.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.7/conditionConstraints.html
+++ b/docs/2.5.7/conditionConstraints.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.7/conditionConstraints.html
+++ b/docs/2.5.7/conditionConstraints.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.7/conditionConstraints.html
+++ b/docs/2.5.7/conditionConstraints.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.7/configEditor.html
+++ b/docs/2.5.7/configEditor.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.7/configEditor.html
+++ b/docs/2.5.7/configEditor.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.7/configEditor.html
+++ b/docs/2.5.7/configEditor.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.7/configEditor.html
+++ b/docs/2.5.7/configEditor.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.7/configFiles.html
+++ b/docs/2.5.7/configFiles.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.7/configFiles.html
+++ b/docs/2.5.7/configFiles.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.7/configFiles.html
+++ b/docs/2.5.7/configFiles.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.7/configFiles.html
+++ b/docs/2.5.7/configFiles.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.7/consoleCommandLine.html
+++ b/docs/2.5.7/consoleCommandLine.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.7/consoleCommandLine.html
+++ b/docs/2.5.7/consoleCommandLine.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.7/consoleCommandLine.html
+++ b/docs/2.5.7/consoleCommandLine.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.7/consoleCommandLine.html
+++ b/docs/2.5.7/consoleCommandLine.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.7/constraintModel.html
+++ b/docs/2.5.7/constraintModel.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.7/constraintModel.html
+++ b/docs/2.5.7/constraintModel.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.7/constraintModel.html
+++ b/docs/2.5.7/constraintModel.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.7/constraintModel.html
+++ b/docs/2.5.7/constraintModel.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.7/contextMenu.html
+++ b/docs/2.5.7/contextMenu.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.7/contextMenu.html
+++ b/docs/2.5.7/contextMenu.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.7/contextMenu.html
+++ b/docs/2.5.7/contextMenu.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.7/contextMenu.html
+++ b/docs/2.5.7/contextMenu.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.7/culture.html
+++ b/docs/2.5.7/culture.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.7/culture.html
+++ b/docs/2.5.7/culture.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.7/culture.html
+++ b/docs/2.5.7/culture.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.7/culture.html
+++ b/docs/2.5.7/culture.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.7/customConstraints.html
+++ b/docs/2.5.7/customConstraints.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.7/customConstraints.html
+++ b/docs/2.5.7/customConstraints.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.7/customConstraints.html
+++ b/docs/2.5.7/customConstraints.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.7/customConstraints.html
+++ b/docs/2.5.7/customConstraints.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.7/datapoint.html
+++ b/docs/2.5.7/datapoint.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.7/datapoint.html
+++ b/docs/2.5.7/datapoint.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.7/datapoint.html
+++ b/docs/2.5.7/datapoint.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.7/datapoint.html
+++ b/docs/2.5.7/datapoint.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.7/datapointProviders.html
+++ b/docs/2.5.7/datapointProviders.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.7/datapointProviders.html
+++ b/docs/2.5.7/datapointProviders.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.7/datapointProviders.html
+++ b/docs/2.5.7/datapointProviders.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.7/datapointProviders.html
+++ b/docs/2.5.7/datapointProviders.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.7/delayedConstraint.html
+++ b/docs/2.5.7/delayedConstraint.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.7/delayedConstraint.html
+++ b/docs/2.5.7/delayedConstraint.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.7/delayedConstraint.html
+++ b/docs/2.5.7/delayedConstraint.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.7/delayedConstraint.html
+++ b/docs/2.5.7/delayedConstraint.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.7/description.html
+++ b/docs/2.5.7/description.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.7/description.html
+++ b/docs/2.5.7/description.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.7/description.html
+++ b/docs/2.5.7/description.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.7/description.html
+++ b/docs/2.5.7/description.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.7/directoryAssert.html
+++ b/docs/2.5.7/directoryAssert.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.7/directoryAssert.html
+++ b/docs/2.5.7/directoryAssert.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.7/directoryAssert.html
+++ b/docs/2.5.7/directoryAssert.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.7/directoryAssert.html
+++ b/docs/2.5.7/directoryAssert.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.7/docHome.html
+++ b/docs/2.5.7/docHome.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.7/docHome.html
+++ b/docs/2.5.7/docHome.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.7/docHome.html
+++ b/docs/2.5.7/docHome.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.7/docHome.html
+++ b/docs/2.5.7/docHome.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.7/equalConstraint.html
+++ b/docs/2.5.7/equalConstraint.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.7/equalConstraint.html
+++ b/docs/2.5.7/equalConstraint.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.7/equalConstraint.html
+++ b/docs/2.5.7/equalConstraint.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.7/equalConstraint.html
+++ b/docs/2.5.7/equalConstraint.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.7/equalityAsserts.html
+++ b/docs/2.5.7/equalityAsserts.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.7/equalityAsserts.html
+++ b/docs/2.5.7/equalityAsserts.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.7/equalityAsserts.html
+++ b/docs/2.5.7/equalityAsserts.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.7/equalityAsserts.html
+++ b/docs/2.5.7/equalityAsserts.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.7/eventListeners.html
+++ b/docs/2.5.7/eventListeners.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.7/eventListeners.html
+++ b/docs/2.5.7/eventListeners.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.7/eventListeners.html
+++ b/docs/2.5.7/eventListeners.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.7/eventListeners.html
+++ b/docs/2.5.7/eventListeners.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.7/exception.html
+++ b/docs/2.5.7/exception.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.7/exception.html
+++ b/docs/2.5.7/exception.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.7/exception.html
+++ b/docs/2.5.7/exception.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.7/exception.html
+++ b/docs/2.5.7/exception.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.7/exceptionAsserts.html
+++ b/docs/2.5.7/exceptionAsserts.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.7/exceptionAsserts.html
+++ b/docs/2.5.7/exceptionAsserts.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.7/exceptionAsserts.html
+++ b/docs/2.5.7/exceptionAsserts.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.7/exceptionAsserts.html
+++ b/docs/2.5.7/exceptionAsserts.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.7/explicit.html
+++ b/docs/2.5.7/explicit.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.7/explicit.html
+++ b/docs/2.5.7/explicit.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.7/explicit.html
+++ b/docs/2.5.7/explicit.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.7/explicit.html
+++ b/docs/2.5.7/explicit.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.7/extensibility.html
+++ b/docs/2.5.7/extensibility.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.7/extensibility.html
+++ b/docs/2.5.7/extensibility.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.7/extensibility.html
+++ b/docs/2.5.7/extensibility.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.7/extensibility.html
+++ b/docs/2.5.7/extensibility.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.7/extensionTips.html
+++ b/docs/2.5.7/extensionTips.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.7/extensionTips.html
+++ b/docs/2.5.7/extensionTips.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.7/extensionTips.html
+++ b/docs/2.5.7/extensionTips.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.7/extensionTips.html
+++ b/docs/2.5.7/extensionTips.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.7/fileAssert.html
+++ b/docs/2.5.7/fileAssert.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.7/fileAssert.html
+++ b/docs/2.5.7/fileAssert.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.7/fileAssert.html
+++ b/docs/2.5.7/fileAssert.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.7/fileAssert.html
+++ b/docs/2.5.7/fileAssert.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.7/fixtureSetup.html
+++ b/docs/2.5.7/fixtureSetup.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.7/fixtureSetup.html
+++ b/docs/2.5.7/fixtureSetup.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.7/fixtureSetup.html
+++ b/docs/2.5.7/fixtureSetup.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.7/fixtureSetup.html
+++ b/docs/2.5.7/fixtureSetup.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.7/fixtureTeardown.html
+++ b/docs/2.5.7/fixtureTeardown.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.7/fixtureTeardown.html
+++ b/docs/2.5.7/fixtureTeardown.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.7/fixtureTeardown.html
+++ b/docs/2.5.7/fixtureTeardown.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.7/fixtureTeardown.html
+++ b/docs/2.5.7/fixtureTeardown.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.7/getStarted.html
+++ b/docs/2.5.7/getStarted.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.7/getStarted.html
+++ b/docs/2.5.7/getStarted.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.7/getStarted.html
+++ b/docs/2.5.7/getStarted.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.7/getStarted.html
+++ b/docs/2.5.7/getStarted.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.7/guiCommandLine.html
+++ b/docs/2.5.7/guiCommandLine.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.7/guiCommandLine.html
+++ b/docs/2.5.7/guiCommandLine.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.7/guiCommandLine.html
+++ b/docs/2.5.7/guiCommandLine.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.7/guiCommandLine.html
+++ b/docs/2.5.7/guiCommandLine.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.7/identityAsserts.html
+++ b/docs/2.5.7/identityAsserts.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.7/identityAsserts.html
+++ b/docs/2.5.7/identityAsserts.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.7/identityAsserts.html
+++ b/docs/2.5.7/identityAsserts.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.7/identityAsserts.html
+++ b/docs/2.5.7/identityAsserts.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.7/ignore.html
+++ b/docs/2.5.7/ignore.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.7/ignore.html
+++ b/docs/2.5.7/ignore.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.7/ignore.html
+++ b/docs/2.5.7/ignore.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.7/ignore.html
+++ b/docs/2.5.7/ignore.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.7/installation.html
+++ b/docs/2.5.7/installation.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.7/installation.html
+++ b/docs/2.5.7/installation.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.7/installation.html
+++ b/docs/2.5.7/installation.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.7/installation.html
+++ b/docs/2.5.7/installation.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.7/license.html
+++ b/docs/2.5.7/license.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.7/license.html
+++ b/docs/2.5.7/license.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.7/license.html
+++ b/docs/2.5.7/license.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.7/license.html
+++ b/docs/2.5.7/license.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.7/listMapper.html
+++ b/docs/2.5.7/listMapper.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.7/listMapper.html
+++ b/docs/2.5.7/listMapper.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.7/listMapper.html
+++ b/docs/2.5.7/listMapper.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.7/listMapper.html
+++ b/docs/2.5.7/listMapper.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.7/mainMenu.html
+++ b/docs/2.5.7/mainMenu.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.7/mainMenu.html
+++ b/docs/2.5.7/mainMenu.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.7/mainMenu.html
+++ b/docs/2.5.7/mainMenu.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.7/mainMenu.html
+++ b/docs/2.5.7/mainMenu.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.7/maxtime.html
+++ b/docs/2.5.7/maxtime.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.7/maxtime.html
+++ b/docs/2.5.7/maxtime.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.7/maxtime.html
+++ b/docs/2.5.7/maxtime.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.7/maxtime.html
+++ b/docs/2.5.7/maxtime.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.7/multiAssembly.html
+++ b/docs/2.5.7/multiAssembly.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.7/multiAssembly.html
+++ b/docs/2.5.7/multiAssembly.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.7/multiAssembly.html
+++ b/docs/2.5.7/multiAssembly.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.7/multiAssembly.html
+++ b/docs/2.5.7/multiAssembly.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.7/nunit-console.html
+++ b/docs/2.5.7/nunit-console.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.7/nunit-console.html
+++ b/docs/2.5.7/nunit-console.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.7/nunit-console.html
+++ b/docs/2.5.7/nunit-console.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.7/nunit-console.html
+++ b/docs/2.5.7/nunit-console.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.7/nunit-gui.html
+++ b/docs/2.5.7/nunit-gui.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.7/nunit-gui.html
+++ b/docs/2.5.7/nunit-gui.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.7/nunit-gui.html
+++ b/docs/2.5.7/nunit-gui.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.7/nunit-gui.html
+++ b/docs/2.5.7/nunit-gui.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.7/nunitAddins.html
+++ b/docs/2.5.7/nunitAddins.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.7/nunitAddins.html
+++ b/docs/2.5.7/nunitAddins.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.7/nunitAddins.html
+++ b/docs/2.5.7/nunitAddins.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.7/nunitAddins.html
+++ b/docs/2.5.7/nunitAddins.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.7/pairwise.html
+++ b/docs/2.5.7/pairwise.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.7/pairwise.html
+++ b/docs/2.5.7/pairwise.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.7/pairwise.html
+++ b/docs/2.5.7/pairwise.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.7/pairwise.html
+++ b/docs/2.5.7/pairwise.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.7/parameterizedTests.html
+++ b/docs/2.5.7/parameterizedTests.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.7/parameterizedTests.html
+++ b/docs/2.5.7/parameterizedTests.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.7/parameterizedTests.html
+++ b/docs/2.5.7/parameterizedTests.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.7/parameterizedTests.html
+++ b/docs/2.5.7/parameterizedTests.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.7/pathConstraints.html
+++ b/docs/2.5.7/pathConstraints.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.7/pathConstraints.html
+++ b/docs/2.5.7/pathConstraints.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.7/pathConstraints.html
+++ b/docs/2.5.7/pathConstraints.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.7/pathConstraints.html
+++ b/docs/2.5.7/pathConstraints.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.7/platform.html
+++ b/docs/2.5.7/platform.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.7/platform.html
+++ b/docs/2.5.7/platform.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.7/platform.html
+++ b/docs/2.5.7/platform.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.7/platform.html
+++ b/docs/2.5.7/platform.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.7/pnunit.html
+++ b/docs/2.5.7/pnunit.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.7/pnunit.html
+++ b/docs/2.5.7/pnunit.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.7/pnunit.html
+++ b/docs/2.5.7/pnunit.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.7/pnunit.html
+++ b/docs/2.5.7/pnunit.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.7/projectEditor.html
+++ b/docs/2.5.7/projectEditor.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.7/projectEditor.html
+++ b/docs/2.5.7/projectEditor.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.7/projectEditor.html
+++ b/docs/2.5.7/projectEditor.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.7/projectEditor.html
+++ b/docs/2.5.7/projectEditor.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.7/property.html
+++ b/docs/2.5.7/property.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.7/property.html
+++ b/docs/2.5.7/property.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.7/property.html
+++ b/docs/2.5.7/property.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.7/property.html
+++ b/docs/2.5.7/property.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.7/propertyConstraint.html
+++ b/docs/2.5.7/propertyConstraint.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.7/propertyConstraint.html
+++ b/docs/2.5.7/propertyConstraint.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.7/propertyConstraint.html
+++ b/docs/2.5.7/propertyConstraint.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.7/propertyConstraint.html
+++ b/docs/2.5.7/propertyConstraint.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.7/quickStart.html
+++ b/docs/2.5.7/quickStart.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.7/quickStart.html
+++ b/docs/2.5.7/quickStart.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.7/quickStart.html
+++ b/docs/2.5.7/quickStart.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.7/quickStart.html
+++ b/docs/2.5.7/quickStart.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.7/quickStartSource.html
+++ b/docs/2.5.7/quickStartSource.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.7/quickStartSource.html
+++ b/docs/2.5.7/quickStartSource.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.7/quickStartSource.html
+++ b/docs/2.5.7/quickStartSource.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.7/quickStartSource.html
+++ b/docs/2.5.7/quickStartSource.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.7/random.html
+++ b/docs/2.5.7/random.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.7/random.html
+++ b/docs/2.5.7/random.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.7/random.html
+++ b/docs/2.5.7/random.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.7/random.html
+++ b/docs/2.5.7/random.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.7/range.html
+++ b/docs/2.5.7/range.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.7/range.html
+++ b/docs/2.5.7/range.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.7/range.html
+++ b/docs/2.5.7/range.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.7/range.html
+++ b/docs/2.5.7/range.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.7/releaseNotes.html
+++ b/docs/2.5.7/releaseNotes.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.7/releaseNotes.html
+++ b/docs/2.5.7/releaseNotes.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.7/releaseNotes.html
+++ b/docs/2.5.7/releaseNotes.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.7/releaseNotes.html
+++ b/docs/2.5.7/releaseNotes.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.7/repeat.html
+++ b/docs/2.5.7/repeat.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.7/repeat.html
+++ b/docs/2.5.7/repeat.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.7/repeat.html
+++ b/docs/2.5.7/repeat.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.7/repeat.html
+++ b/docs/2.5.7/repeat.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.7/requiredAddin.html
+++ b/docs/2.5.7/requiredAddin.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.7/requiredAddin.html
+++ b/docs/2.5.7/requiredAddin.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.7/requiredAddin.html
+++ b/docs/2.5.7/requiredAddin.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.7/requiredAddin.html
+++ b/docs/2.5.7/requiredAddin.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.7/requiresMTA.html
+++ b/docs/2.5.7/requiresMTA.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.7/requiresMTA.html
+++ b/docs/2.5.7/requiresMTA.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.7/requiresMTA.html
+++ b/docs/2.5.7/requiresMTA.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.7/requiresMTA.html
+++ b/docs/2.5.7/requiresMTA.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.7/requiresSTA.html
+++ b/docs/2.5.7/requiresSTA.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.7/requiresSTA.html
+++ b/docs/2.5.7/requiresSTA.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.7/requiresSTA.html
+++ b/docs/2.5.7/requiresSTA.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.7/requiresSTA.html
+++ b/docs/2.5.7/requiresSTA.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.7/requiresThread.html
+++ b/docs/2.5.7/requiresThread.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.7/requiresThread.html
+++ b/docs/2.5.7/requiresThread.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.7/requiresThread.html
+++ b/docs/2.5.7/requiresThread.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.7/requiresThread.html
+++ b/docs/2.5.7/requiresThread.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.7/reusableConstraint.html
+++ b/docs/2.5.7/reusableConstraint.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.7/reusableConstraint.html
+++ b/docs/2.5.7/reusableConstraint.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.7/reusableConstraint.html
+++ b/docs/2.5.7/reusableConstraint.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.7/reusableConstraint.html
+++ b/docs/2.5.7/reusableConstraint.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.7/runningTests.html
+++ b/docs/2.5.7/runningTests.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.7/runningTests.html
+++ b/docs/2.5.7/runningTests.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.7/runningTests.html
+++ b/docs/2.5.7/runningTests.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.7/runningTests.html
+++ b/docs/2.5.7/runningTests.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.7/runtimeSelection.html
+++ b/docs/2.5.7/runtimeSelection.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.7/runtimeSelection.html
+++ b/docs/2.5.7/runtimeSelection.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.7/runtimeSelection.html
+++ b/docs/2.5.7/runtimeSelection.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.7/runtimeSelection.html
+++ b/docs/2.5.7/runtimeSelection.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.7/sameasConstraint.html
+++ b/docs/2.5.7/sameasConstraint.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.7/sameasConstraint.html
+++ b/docs/2.5.7/sameasConstraint.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.7/sameasConstraint.html
+++ b/docs/2.5.7/sameasConstraint.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.7/sameasConstraint.html
+++ b/docs/2.5.7/sameasConstraint.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.7/samples.html
+++ b/docs/2.5.7/samples.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.7/samples.html
+++ b/docs/2.5.7/samples.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.7/samples.html
+++ b/docs/2.5.7/samples.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.7/samples.html
+++ b/docs/2.5.7/samples.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.7/sequential.html
+++ b/docs/2.5.7/sequential.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.7/sequential.html
+++ b/docs/2.5.7/sequential.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.7/sequential.html
+++ b/docs/2.5.7/sequential.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.7/sequential.html
+++ b/docs/2.5.7/sequential.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.7/setCulture.html
+++ b/docs/2.5.7/setCulture.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.7/setCulture.html
+++ b/docs/2.5.7/setCulture.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.7/setCulture.html
+++ b/docs/2.5.7/setCulture.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.7/setCulture.html
+++ b/docs/2.5.7/setCulture.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.7/setUICulture.html
+++ b/docs/2.5.7/setUICulture.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.7/setUICulture.html
+++ b/docs/2.5.7/setUICulture.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.7/setUICulture.html
+++ b/docs/2.5.7/setUICulture.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.7/setUICulture.html
+++ b/docs/2.5.7/setUICulture.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.7/settingsDialog.html
+++ b/docs/2.5.7/settingsDialog.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.7/settingsDialog.html
+++ b/docs/2.5.7/settingsDialog.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.7/settingsDialog.html
+++ b/docs/2.5.7/settingsDialog.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.7/settingsDialog.html
+++ b/docs/2.5.7/settingsDialog.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.7/setup.html
+++ b/docs/2.5.7/setup.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.7/setup.html
+++ b/docs/2.5.7/setup.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.7/setup.html
+++ b/docs/2.5.7/setup.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.7/setup.html
+++ b/docs/2.5.7/setup.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.7/setupFixture.html
+++ b/docs/2.5.7/setupFixture.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.7/setupFixture.html
+++ b/docs/2.5.7/setupFixture.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.7/setupFixture.html
+++ b/docs/2.5.7/setupFixture.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.7/setupFixture.html
+++ b/docs/2.5.7/setupFixture.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.7/stringAssert.html
+++ b/docs/2.5.7/stringAssert.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.7/stringAssert.html
+++ b/docs/2.5.7/stringAssert.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.7/stringAssert.html
+++ b/docs/2.5.7/stringAssert.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.7/stringAssert.html
+++ b/docs/2.5.7/stringAssert.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.7/stringConstraints.html
+++ b/docs/2.5.7/stringConstraints.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.7/stringConstraints.html
+++ b/docs/2.5.7/stringConstraints.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.7/stringConstraints.html
+++ b/docs/2.5.7/stringConstraints.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.7/stringConstraints.html
+++ b/docs/2.5.7/stringConstraints.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.7/suite.html
+++ b/docs/2.5.7/suite.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.7/suite.html
+++ b/docs/2.5.7/suite.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.7/suite.html
+++ b/docs/2.5.7/suite.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.7/suite.html
+++ b/docs/2.5.7/suite.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.7/suiteBuilders.html
+++ b/docs/2.5.7/suiteBuilders.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.7/suiteBuilders.html
+++ b/docs/2.5.7/suiteBuilders.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.7/suiteBuilders.html
+++ b/docs/2.5.7/suiteBuilders.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.7/suiteBuilders.html
+++ b/docs/2.5.7/suiteBuilders.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.7/teardown.html
+++ b/docs/2.5.7/teardown.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.7/teardown.html
+++ b/docs/2.5.7/teardown.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.7/teardown.html
+++ b/docs/2.5.7/teardown.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.7/teardown.html
+++ b/docs/2.5.7/teardown.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.7/test.html
+++ b/docs/2.5.7/test.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.7/test.html
+++ b/docs/2.5.7/test.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.7/test.html
+++ b/docs/2.5.7/test.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.7/test.html
+++ b/docs/2.5.7/test.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.7/testCase.html
+++ b/docs/2.5.7/testCase.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.7/testCase.html
+++ b/docs/2.5.7/testCase.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.7/testCase.html
+++ b/docs/2.5.7/testCase.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.7/testCase.html
+++ b/docs/2.5.7/testCase.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.7/testCaseSource.html
+++ b/docs/2.5.7/testCaseSource.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.7/testCaseSource.html
+++ b/docs/2.5.7/testCaseSource.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.7/testCaseSource.html
+++ b/docs/2.5.7/testCaseSource.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.7/testCaseSource.html
+++ b/docs/2.5.7/testCaseSource.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.7/testDecorators.html
+++ b/docs/2.5.7/testDecorators.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.7/testDecorators.html
+++ b/docs/2.5.7/testDecorators.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.7/testDecorators.html
+++ b/docs/2.5.7/testDecorators.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.7/testDecorators.html
+++ b/docs/2.5.7/testDecorators.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.7/testFixture.html
+++ b/docs/2.5.7/testFixture.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.7/testFixture.html
+++ b/docs/2.5.7/testFixture.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.7/testFixture.html
+++ b/docs/2.5.7/testFixture.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.7/testFixture.html
+++ b/docs/2.5.7/testFixture.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.7/testProperties.html
+++ b/docs/2.5.7/testProperties.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.7/testProperties.html
+++ b/docs/2.5.7/testProperties.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.7/testProperties.html
+++ b/docs/2.5.7/testProperties.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.7/testProperties.html
+++ b/docs/2.5.7/testProperties.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.7/testcaseBuilders.html
+++ b/docs/2.5.7/testcaseBuilders.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.7/testcaseBuilders.html
+++ b/docs/2.5.7/testcaseBuilders.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.7/testcaseBuilders.html
+++ b/docs/2.5.7/testcaseBuilders.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.7/testcaseBuilders.html
+++ b/docs/2.5.7/testcaseBuilders.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.7/testcaseProviders.html
+++ b/docs/2.5.7/testcaseProviders.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.7/testcaseProviders.html
+++ b/docs/2.5.7/testcaseProviders.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.7/testcaseProviders.html
+++ b/docs/2.5.7/testcaseProviders.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.7/testcaseProviders.html
+++ b/docs/2.5.7/testcaseProviders.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.7/theory.html
+++ b/docs/2.5.7/theory.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.7/theory.html
+++ b/docs/2.5.7/theory.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.7/theory.html
+++ b/docs/2.5.7/theory.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.7/theory.html
+++ b/docs/2.5.7/theory.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.7/throwsConstraint.html
+++ b/docs/2.5.7/throwsConstraint.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.7/throwsConstraint.html
+++ b/docs/2.5.7/throwsConstraint.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.7/throwsConstraint.html
+++ b/docs/2.5.7/throwsConstraint.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.7/throwsConstraint.html
+++ b/docs/2.5.7/throwsConstraint.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.7/timeout.html
+++ b/docs/2.5.7/timeout.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.7/timeout.html
+++ b/docs/2.5.7/timeout.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.7/timeout.html
+++ b/docs/2.5.7/timeout.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.7/timeout.html
+++ b/docs/2.5.7/timeout.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.7/typeAsserts.html
+++ b/docs/2.5.7/typeAsserts.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.7/typeAsserts.html
+++ b/docs/2.5.7/typeAsserts.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.7/typeAsserts.html
+++ b/docs/2.5.7/typeAsserts.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.7/typeAsserts.html
+++ b/docs/2.5.7/typeAsserts.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.7/typeConstraints.html
+++ b/docs/2.5.7/typeConstraints.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.7/typeConstraints.html
+++ b/docs/2.5.7/typeConstraints.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.7/typeConstraints.html
+++ b/docs/2.5.7/typeConstraints.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.7/typeConstraints.html
+++ b/docs/2.5.7/typeConstraints.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.7/upgrade.html
+++ b/docs/2.5.7/upgrade.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.7/upgrade.html
+++ b/docs/2.5.7/upgrade.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.7/upgrade.html
+++ b/docs/2.5.7/upgrade.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.7/upgrade.html
+++ b/docs/2.5.7/upgrade.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.7/utilityAsserts.html
+++ b/docs/2.5.7/utilityAsserts.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.7/utilityAsserts.html
+++ b/docs/2.5.7/utilityAsserts.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.7/utilityAsserts.html
+++ b/docs/2.5.7/utilityAsserts.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.7/utilityAsserts.html
+++ b/docs/2.5.7/utilityAsserts.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.7/valueSource.html
+++ b/docs/2.5.7/valueSource.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.7/valueSource.html
+++ b/docs/2.5.7/valueSource.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.7/valueSource.html
+++ b/docs/2.5.7/valueSource.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.7/valueSource.html
+++ b/docs/2.5.7/valueSource.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.7/values.html
+++ b/docs/2.5.7/values.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.7/values.html
+++ b/docs/2.5.7/values.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.7/values.html
+++ b/docs/2.5.7/values.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.7/values.html
+++ b/docs/2.5.7/values.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.7/vsSupport.html
+++ b/docs/2.5.7/vsSupport.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.7/vsSupport.html
+++ b/docs/2.5.7/vsSupport.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.7/vsSupport.html
+++ b/docs/2.5.7/vsSupport.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.7/vsSupport.html
+++ b/docs/2.5.7/vsSupport.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.8/addinsDialog.html
+++ b/docs/2.5.8/addinsDialog.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.8/addinsDialog.html
+++ b/docs/2.5.8/addinsDialog.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.8/addinsDialog.html
+++ b/docs/2.5.8/addinsDialog.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.8/addinsDialog.html
+++ b/docs/2.5.8/addinsDialog.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.8/assemblyIsolation.html
+++ b/docs/2.5.8/assemblyIsolation.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.8/assemblyIsolation.html
+++ b/docs/2.5.8/assemblyIsolation.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.8/assemblyIsolation.html
+++ b/docs/2.5.8/assemblyIsolation.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.8/assemblyIsolation.html
+++ b/docs/2.5.8/assemblyIsolation.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.8/assertions.html
+++ b/docs/2.5.8/assertions.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.8/assertions.html
+++ b/docs/2.5.8/assertions.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.8/assertions.html
+++ b/docs/2.5.8/assertions.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.8/assertions.html
+++ b/docs/2.5.8/assertions.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.8/attributes.html
+++ b/docs/2.5.8/attributes.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.8/attributes.html
+++ b/docs/2.5.8/attributes.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.8/attributes.html
+++ b/docs/2.5.8/attributes.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.8/attributes.html
+++ b/docs/2.5.8/attributes.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.8/category.html
+++ b/docs/2.5.8/category.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.8/category.html
+++ b/docs/2.5.8/category.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.8/category.html
+++ b/docs/2.5.8/category.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.8/category.html
+++ b/docs/2.5.8/category.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.8/collectionAssert.html
+++ b/docs/2.5.8/collectionAssert.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.8/collectionAssert.html
+++ b/docs/2.5.8/collectionAssert.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.8/collectionAssert.html
+++ b/docs/2.5.8/collectionAssert.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.8/collectionAssert.html
+++ b/docs/2.5.8/collectionAssert.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.8/collectionConstraints.html
+++ b/docs/2.5.8/collectionConstraints.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.8/collectionConstraints.html
+++ b/docs/2.5.8/collectionConstraints.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.8/collectionConstraints.html
+++ b/docs/2.5.8/collectionConstraints.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.8/collectionConstraints.html
+++ b/docs/2.5.8/collectionConstraints.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.8/combinatorial.html
+++ b/docs/2.5.8/combinatorial.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.8/combinatorial.html
+++ b/docs/2.5.8/combinatorial.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.8/combinatorial.html
+++ b/docs/2.5.8/combinatorial.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.8/combinatorial.html
+++ b/docs/2.5.8/combinatorial.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.8/comparisonAsserts.html
+++ b/docs/2.5.8/comparisonAsserts.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.8/comparisonAsserts.html
+++ b/docs/2.5.8/comparisonAsserts.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.8/comparisonAsserts.html
+++ b/docs/2.5.8/comparisonAsserts.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.8/comparisonAsserts.html
+++ b/docs/2.5.8/comparisonAsserts.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.8/comparisonConstraints.html
+++ b/docs/2.5.8/comparisonConstraints.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.8/comparisonConstraints.html
+++ b/docs/2.5.8/comparisonConstraints.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.8/comparisonConstraints.html
+++ b/docs/2.5.8/comparisonConstraints.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.8/comparisonConstraints.html
+++ b/docs/2.5.8/comparisonConstraints.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.8/compoundConstraints.html
+++ b/docs/2.5.8/compoundConstraints.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.8/compoundConstraints.html
+++ b/docs/2.5.8/compoundConstraints.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.8/compoundConstraints.html
+++ b/docs/2.5.8/compoundConstraints.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.8/compoundConstraints.html
+++ b/docs/2.5.8/compoundConstraints.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.8/conditionAsserts.html
+++ b/docs/2.5.8/conditionAsserts.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.8/conditionAsserts.html
+++ b/docs/2.5.8/conditionAsserts.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.8/conditionAsserts.html
+++ b/docs/2.5.8/conditionAsserts.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.8/conditionAsserts.html
+++ b/docs/2.5.8/conditionAsserts.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.8/conditionConstraints.html
+++ b/docs/2.5.8/conditionConstraints.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.8/conditionConstraints.html
+++ b/docs/2.5.8/conditionConstraints.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.8/conditionConstraints.html
+++ b/docs/2.5.8/conditionConstraints.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.8/conditionConstraints.html
+++ b/docs/2.5.8/conditionConstraints.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.8/configEditor.html
+++ b/docs/2.5.8/configEditor.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.8/configEditor.html
+++ b/docs/2.5.8/configEditor.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.8/configEditor.html
+++ b/docs/2.5.8/configEditor.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.8/configEditor.html
+++ b/docs/2.5.8/configEditor.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.8/configFiles.html
+++ b/docs/2.5.8/configFiles.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.8/configFiles.html
+++ b/docs/2.5.8/configFiles.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.8/configFiles.html
+++ b/docs/2.5.8/configFiles.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.8/configFiles.html
+++ b/docs/2.5.8/configFiles.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.8/consoleCommandLine.html
+++ b/docs/2.5.8/consoleCommandLine.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.8/consoleCommandLine.html
+++ b/docs/2.5.8/consoleCommandLine.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.8/consoleCommandLine.html
+++ b/docs/2.5.8/consoleCommandLine.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.8/consoleCommandLine.html
+++ b/docs/2.5.8/consoleCommandLine.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.8/constraintModel.html
+++ b/docs/2.5.8/constraintModel.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.8/constraintModel.html
+++ b/docs/2.5.8/constraintModel.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.8/constraintModel.html
+++ b/docs/2.5.8/constraintModel.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.8/constraintModel.html
+++ b/docs/2.5.8/constraintModel.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.8/contextMenu.html
+++ b/docs/2.5.8/contextMenu.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.8/contextMenu.html
+++ b/docs/2.5.8/contextMenu.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.8/contextMenu.html
+++ b/docs/2.5.8/contextMenu.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.8/contextMenu.html
+++ b/docs/2.5.8/contextMenu.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.8/culture.html
+++ b/docs/2.5.8/culture.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.8/culture.html
+++ b/docs/2.5.8/culture.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.8/culture.html
+++ b/docs/2.5.8/culture.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.8/culture.html
+++ b/docs/2.5.8/culture.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.8/customConstraints.html
+++ b/docs/2.5.8/customConstraints.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.8/customConstraints.html
+++ b/docs/2.5.8/customConstraints.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.8/customConstraints.html
+++ b/docs/2.5.8/customConstraints.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.8/customConstraints.html
+++ b/docs/2.5.8/customConstraints.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.8/datapoint.html
+++ b/docs/2.5.8/datapoint.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.8/datapoint.html
+++ b/docs/2.5.8/datapoint.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.8/datapoint.html
+++ b/docs/2.5.8/datapoint.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.8/datapoint.html
+++ b/docs/2.5.8/datapoint.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.8/datapointProviders.html
+++ b/docs/2.5.8/datapointProviders.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.8/datapointProviders.html
+++ b/docs/2.5.8/datapointProviders.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.8/datapointProviders.html
+++ b/docs/2.5.8/datapointProviders.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.8/datapointProviders.html
+++ b/docs/2.5.8/datapointProviders.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.8/delayedConstraint.html
+++ b/docs/2.5.8/delayedConstraint.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.8/delayedConstraint.html
+++ b/docs/2.5.8/delayedConstraint.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.8/delayedConstraint.html
+++ b/docs/2.5.8/delayedConstraint.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.8/delayedConstraint.html
+++ b/docs/2.5.8/delayedConstraint.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.8/description.html
+++ b/docs/2.5.8/description.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.8/description.html
+++ b/docs/2.5.8/description.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.8/description.html
+++ b/docs/2.5.8/description.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.8/description.html
+++ b/docs/2.5.8/description.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.8/directoryAssert.html
+++ b/docs/2.5.8/directoryAssert.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.8/directoryAssert.html
+++ b/docs/2.5.8/directoryAssert.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.8/directoryAssert.html
+++ b/docs/2.5.8/directoryAssert.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.8/directoryAssert.html
+++ b/docs/2.5.8/directoryAssert.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.8/docHome.html
+++ b/docs/2.5.8/docHome.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.8/docHome.html
+++ b/docs/2.5.8/docHome.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.8/docHome.html
+++ b/docs/2.5.8/docHome.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.8/docHome.html
+++ b/docs/2.5.8/docHome.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.8/equalConstraint.html
+++ b/docs/2.5.8/equalConstraint.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.8/equalConstraint.html
+++ b/docs/2.5.8/equalConstraint.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.8/equalConstraint.html
+++ b/docs/2.5.8/equalConstraint.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.8/equalConstraint.html
+++ b/docs/2.5.8/equalConstraint.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.8/equalityAsserts.html
+++ b/docs/2.5.8/equalityAsserts.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.8/equalityAsserts.html
+++ b/docs/2.5.8/equalityAsserts.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.8/equalityAsserts.html
+++ b/docs/2.5.8/equalityAsserts.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.8/equalityAsserts.html
+++ b/docs/2.5.8/equalityAsserts.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.8/eventListeners.html
+++ b/docs/2.5.8/eventListeners.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.8/eventListeners.html
+++ b/docs/2.5.8/eventListeners.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.8/eventListeners.html
+++ b/docs/2.5.8/eventListeners.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.8/eventListeners.html
+++ b/docs/2.5.8/eventListeners.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.8/exception.html
+++ b/docs/2.5.8/exception.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.8/exception.html
+++ b/docs/2.5.8/exception.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.8/exception.html
+++ b/docs/2.5.8/exception.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.8/exception.html
+++ b/docs/2.5.8/exception.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.8/exceptionAsserts.html
+++ b/docs/2.5.8/exceptionAsserts.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.8/exceptionAsserts.html
+++ b/docs/2.5.8/exceptionAsserts.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.8/exceptionAsserts.html
+++ b/docs/2.5.8/exceptionAsserts.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.8/exceptionAsserts.html
+++ b/docs/2.5.8/exceptionAsserts.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.8/explicit.html
+++ b/docs/2.5.8/explicit.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.8/explicit.html
+++ b/docs/2.5.8/explicit.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.8/explicit.html
+++ b/docs/2.5.8/explicit.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.8/explicit.html
+++ b/docs/2.5.8/explicit.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.8/extensibility.html
+++ b/docs/2.5.8/extensibility.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.8/extensibility.html
+++ b/docs/2.5.8/extensibility.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.8/extensibility.html
+++ b/docs/2.5.8/extensibility.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.8/extensibility.html
+++ b/docs/2.5.8/extensibility.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.8/extensionTips.html
+++ b/docs/2.5.8/extensionTips.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.8/extensionTips.html
+++ b/docs/2.5.8/extensionTips.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.8/extensionTips.html
+++ b/docs/2.5.8/extensionTips.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.8/extensionTips.html
+++ b/docs/2.5.8/extensionTips.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.8/fileAssert.html
+++ b/docs/2.5.8/fileAssert.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.8/fileAssert.html
+++ b/docs/2.5.8/fileAssert.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.8/fileAssert.html
+++ b/docs/2.5.8/fileAssert.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.8/fileAssert.html
+++ b/docs/2.5.8/fileAssert.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.8/fixtureSetup.html
+++ b/docs/2.5.8/fixtureSetup.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.8/fixtureSetup.html
+++ b/docs/2.5.8/fixtureSetup.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.8/fixtureSetup.html
+++ b/docs/2.5.8/fixtureSetup.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.8/fixtureSetup.html
+++ b/docs/2.5.8/fixtureSetup.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.8/fixtureTeardown.html
+++ b/docs/2.5.8/fixtureTeardown.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.8/fixtureTeardown.html
+++ b/docs/2.5.8/fixtureTeardown.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.8/fixtureTeardown.html
+++ b/docs/2.5.8/fixtureTeardown.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.8/fixtureTeardown.html
+++ b/docs/2.5.8/fixtureTeardown.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.8/getStarted.html
+++ b/docs/2.5.8/getStarted.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.8/getStarted.html
+++ b/docs/2.5.8/getStarted.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.8/getStarted.html
+++ b/docs/2.5.8/getStarted.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.8/getStarted.html
+++ b/docs/2.5.8/getStarted.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.8/guiCommandLine.html
+++ b/docs/2.5.8/guiCommandLine.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.8/guiCommandLine.html
+++ b/docs/2.5.8/guiCommandLine.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.8/guiCommandLine.html
+++ b/docs/2.5.8/guiCommandLine.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.8/guiCommandLine.html
+++ b/docs/2.5.8/guiCommandLine.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.8/identityAsserts.html
+++ b/docs/2.5.8/identityAsserts.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.8/identityAsserts.html
+++ b/docs/2.5.8/identityAsserts.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.8/identityAsserts.html
+++ b/docs/2.5.8/identityAsserts.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.8/identityAsserts.html
+++ b/docs/2.5.8/identityAsserts.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.8/ignore.html
+++ b/docs/2.5.8/ignore.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.8/ignore.html
+++ b/docs/2.5.8/ignore.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.8/ignore.html
+++ b/docs/2.5.8/ignore.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.8/ignore.html
+++ b/docs/2.5.8/ignore.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.8/installation.html
+++ b/docs/2.5.8/installation.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.8/installation.html
+++ b/docs/2.5.8/installation.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.8/installation.html
+++ b/docs/2.5.8/installation.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.8/installation.html
+++ b/docs/2.5.8/installation.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.8/license.html
+++ b/docs/2.5.8/license.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.8/license.html
+++ b/docs/2.5.8/license.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.8/license.html
+++ b/docs/2.5.8/license.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.8/license.html
+++ b/docs/2.5.8/license.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.8/listMapper.html
+++ b/docs/2.5.8/listMapper.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.8/listMapper.html
+++ b/docs/2.5.8/listMapper.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.8/listMapper.html
+++ b/docs/2.5.8/listMapper.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.8/listMapper.html
+++ b/docs/2.5.8/listMapper.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.8/mainMenu.html
+++ b/docs/2.5.8/mainMenu.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.8/mainMenu.html
+++ b/docs/2.5.8/mainMenu.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.8/mainMenu.html
+++ b/docs/2.5.8/mainMenu.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.8/mainMenu.html
+++ b/docs/2.5.8/mainMenu.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.8/maxtime.html
+++ b/docs/2.5.8/maxtime.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.8/maxtime.html
+++ b/docs/2.5.8/maxtime.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.8/maxtime.html
+++ b/docs/2.5.8/maxtime.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.8/maxtime.html
+++ b/docs/2.5.8/maxtime.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.8/multiAssembly.html
+++ b/docs/2.5.8/multiAssembly.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.8/multiAssembly.html
+++ b/docs/2.5.8/multiAssembly.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.8/multiAssembly.html
+++ b/docs/2.5.8/multiAssembly.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.8/multiAssembly.html
+++ b/docs/2.5.8/multiAssembly.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.8/nunit-console.html
+++ b/docs/2.5.8/nunit-console.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.8/nunit-console.html
+++ b/docs/2.5.8/nunit-console.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.8/nunit-console.html
+++ b/docs/2.5.8/nunit-console.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.8/nunit-console.html
+++ b/docs/2.5.8/nunit-console.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.8/nunit-gui.html
+++ b/docs/2.5.8/nunit-gui.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.8/nunit-gui.html
+++ b/docs/2.5.8/nunit-gui.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.8/nunit-gui.html
+++ b/docs/2.5.8/nunit-gui.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.8/nunit-gui.html
+++ b/docs/2.5.8/nunit-gui.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.8/nunitAddins.html
+++ b/docs/2.5.8/nunitAddins.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.8/nunitAddins.html
+++ b/docs/2.5.8/nunitAddins.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.8/nunitAddins.html
+++ b/docs/2.5.8/nunitAddins.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.8/nunitAddins.html
+++ b/docs/2.5.8/nunitAddins.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.8/pairwise.html
+++ b/docs/2.5.8/pairwise.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.8/pairwise.html
+++ b/docs/2.5.8/pairwise.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.8/pairwise.html
+++ b/docs/2.5.8/pairwise.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.8/pairwise.html
+++ b/docs/2.5.8/pairwise.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.8/parameterizedTests.html
+++ b/docs/2.5.8/parameterizedTests.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.8/parameterizedTests.html
+++ b/docs/2.5.8/parameterizedTests.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.8/parameterizedTests.html
+++ b/docs/2.5.8/parameterizedTests.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.8/parameterizedTests.html
+++ b/docs/2.5.8/parameterizedTests.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.8/pathConstraints.html
+++ b/docs/2.5.8/pathConstraints.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.8/pathConstraints.html
+++ b/docs/2.5.8/pathConstraints.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.8/pathConstraints.html
+++ b/docs/2.5.8/pathConstraints.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.8/pathConstraints.html
+++ b/docs/2.5.8/pathConstraints.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.8/platform.html
+++ b/docs/2.5.8/platform.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.8/platform.html
+++ b/docs/2.5.8/platform.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.8/platform.html
+++ b/docs/2.5.8/platform.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.8/platform.html
+++ b/docs/2.5.8/platform.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.8/pnunit.html
+++ b/docs/2.5.8/pnunit.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.8/pnunit.html
+++ b/docs/2.5.8/pnunit.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.8/pnunit.html
+++ b/docs/2.5.8/pnunit.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.8/pnunit.html
+++ b/docs/2.5.8/pnunit.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.8/projectEditor.html
+++ b/docs/2.5.8/projectEditor.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.8/projectEditor.html
+++ b/docs/2.5.8/projectEditor.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.8/projectEditor.html
+++ b/docs/2.5.8/projectEditor.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.8/projectEditor.html
+++ b/docs/2.5.8/projectEditor.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.8/property.html
+++ b/docs/2.5.8/property.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.8/property.html
+++ b/docs/2.5.8/property.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.8/property.html
+++ b/docs/2.5.8/property.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.8/property.html
+++ b/docs/2.5.8/property.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.8/propertyConstraint.html
+++ b/docs/2.5.8/propertyConstraint.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.8/propertyConstraint.html
+++ b/docs/2.5.8/propertyConstraint.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.8/propertyConstraint.html
+++ b/docs/2.5.8/propertyConstraint.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.8/propertyConstraint.html
+++ b/docs/2.5.8/propertyConstraint.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.8/quickStart.html
+++ b/docs/2.5.8/quickStart.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.8/quickStart.html
+++ b/docs/2.5.8/quickStart.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.8/quickStart.html
+++ b/docs/2.5.8/quickStart.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.8/quickStart.html
+++ b/docs/2.5.8/quickStart.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.8/quickStartSource.html
+++ b/docs/2.5.8/quickStartSource.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.8/quickStartSource.html
+++ b/docs/2.5.8/quickStartSource.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.8/quickStartSource.html
+++ b/docs/2.5.8/quickStartSource.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.8/quickStartSource.html
+++ b/docs/2.5.8/quickStartSource.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.8/random.html
+++ b/docs/2.5.8/random.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.8/random.html
+++ b/docs/2.5.8/random.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.8/random.html
+++ b/docs/2.5.8/random.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.8/random.html
+++ b/docs/2.5.8/random.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.8/range.html
+++ b/docs/2.5.8/range.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.8/range.html
+++ b/docs/2.5.8/range.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.8/range.html
+++ b/docs/2.5.8/range.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.8/range.html
+++ b/docs/2.5.8/range.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.8/releaseNotes.html
+++ b/docs/2.5.8/releaseNotes.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.8/releaseNotes.html
+++ b/docs/2.5.8/releaseNotes.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.8/releaseNotes.html
+++ b/docs/2.5.8/releaseNotes.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.8/releaseNotes.html
+++ b/docs/2.5.8/releaseNotes.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.8/repeat.html
+++ b/docs/2.5.8/repeat.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.8/repeat.html
+++ b/docs/2.5.8/repeat.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.8/repeat.html
+++ b/docs/2.5.8/repeat.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.8/repeat.html
+++ b/docs/2.5.8/repeat.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.8/requiredAddin.html
+++ b/docs/2.5.8/requiredAddin.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.8/requiredAddin.html
+++ b/docs/2.5.8/requiredAddin.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.8/requiredAddin.html
+++ b/docs/2.5.8/requiredAddin.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.8/requiredAddin.html
+++ b/docs/2.5.8/requiredAddin.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.8/requiresMTA.html
+++ b/docs/2.5.8/requiresMTA.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.8/requiresMTA.html
+++ b/docs/2.5.8/requiresMTA.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.8/requiresMTA.html
+++ b/docs/2.5.8/requiresMTA.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.8/requiresMTA.html
+++ b/docs/2.5.8/requiresMTA.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.8/requiresSTA.html
+++ b/docs/2.5.8/requiresSTA.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.8/requiresSTA.html
+++ b/docs/2.5.8/requiresSTA.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.8/requiresSTA.html
+++ b/docs/2.5.8/requiresSTA.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.8/requiresSTA.html
+++ b/docs/2.5.8/requiresSTA.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.8/requiresThread.html
+++ b/docs/2.5.8/requiresThread.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.8/requiresThread.html
+++ b/docs/2.5.8/requiresThread.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.8/requiresThread.html
+++ b/docs/2.5.8/requiresThread.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.8/requiresThread.html
+++ b/docs/2.5.8/requiresThread.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.8/reusableConstraint.html
+++ b/docs/2.5.8/reusableConstraint.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.8/reusableConstraint.html
+++ b/docs/2.5.8/reusableConstraint.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.8/reusableConstraint.html
+++ b/docs/2.5.8/reusableConstraint.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.8/reusableConstraint.html
+++ b/docs/2.5.8/reusableConstraint.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.8/runningTests.html
+++ b/docs/2.5.8/runningTests.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.8/runningTests.html
+++ b/docs/2.5.8/runningTests.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.8/runningTests.html
+++ b/docs/2.5.8/runningTests.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.8/runningTests.html
+++ b/docs/2.5.8/runningTests.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.8/runtimeSelection.html
+++ b/docs/2.5.8/runtimeSelection.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.8/runtimeSelection.html
+++ b/docs/2.5.8/runtimeSelection.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.8/runtimeSelection.html
+++ b/docs/2.5.8/runtimeSelection.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.8/runtimeSelection.html
+++ b/docs/2.5.8/runtimeSelection.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.8/sameasConstraint.html
+++ b/docs/2.5.8/sameasConstraint.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.8/sameasConstraint.html
+++ b/docs/2.5.8/sameasConstraint.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.8/sameasConstraint.html
+++ b/docs/2.5.8/sameasConstraint.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.8/sameasConstraint.html
+++ b/docs/2.5.8/sameasConstraint.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.8/samples.html
+++ b/docs/2.5.8/samples.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.8/samples.html
+++ b/docs/2.5.8/samples.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.8/samples.html
+++ b/docs/2.5.8/samples.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.8/samples.html
+++ b/docs/2.5.8/samples.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.8/sequential.html
+++ b/docs/2.5.8/sequential.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.8/sequential.html
+++ b/docs/2.5.8/sequential.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.8/sequential.html
+++ b/docs/2.5.8/sequential.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.8/sequential.html
+++ b/docs/2.5.8/sequential.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.8/setCulture.html
+++ b/docs/2.5.8/setCulture.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.8/setCulture.html
+++ b/docs/2.5.8/setCulture.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.8/setCulture.html
+++ b/docs/2.5.8/setCulture.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.8/setCulture.html
+++ b/docs/2.5.8/setCulture.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.8/setUICulture.html
+++ b/docs/2.5.8/setUICulture.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.8/setUICulture.html
+++ b/docs/2.5.8/setUICulture.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.8/setUICulture.html
+++ b/docs/2.5.8/setUICulture.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.8/setUICulture.html
+++ b/docs/2.5.8/setUICulture.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.8/settingsDialog.html
+++ b/docs/2.5.8/settingsDialog.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.8/settingsDialog.html
+++ b/docs/2.5.8/settingsDialog.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.8/settingsDialog.html
+++ b/docs/2.5.8/settingsDialog.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.8/settingsDialog.html
+++ b/docs/2.5.8/settingsDialog.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.8/setup.html
+++ b/docs/2.5.8/setup.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.8/setup.html
+++ b/docs/2.5.8/setup.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.8/setup.html
+++ b/docs/2.5.8/setup.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.8/setup.html
+++ b/docs/2.5.8/setup.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.8/setupFixture.html
+++ b/docs/2.5.8/setupFixture.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.8/setupFixture.html
+++ b/docs/2.5.8/setupFixture.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.8/setupFixture.html
+++ b/docs/2.5.8/setupFixture.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.8/setupFixture.html
+++ b/docs/2.5.8/setupFixture.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.8/stringAssert.html
+++ b/docs/2.5.8/stringAssert.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.8/stringAssert.html
+++ b/docs/2.5.8/stringAssert.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.8/stringAssert.html
+++ b/docs/2.5.8/stringAssert.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.8/stringAssert.html
+++ b/docs/2.5.8/stringAssert.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.8/stringConstraints.html
+++ b/docs/2.5.8/stringConstraints.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.8/stringConstraints.html
+++ b/docs/2.5.8/stringConstraints.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.8/stringConstraints.html
+++ b/docs/2.5.8/stringConstraints.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.8/stringConstraints.html
+++ b/docs/2.5.8/stringConstraints.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.8/suite.html
+++ b/docs/2.5.8/suite.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.8/suite.html
+++ b/docs/2.5.8/suite.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.8/suite.html
+++ b/docs/2.5.8/suite.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.8/suite.html
+++ b/docs/2.5.8/suite.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.8/suiteBuilders.html
+++ b/docs/2.5.8/suiteBuilders.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.8/suiteBuilders.html
+++ b/docs/2.5.8/suiteBuilders.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.8/suiteBuilders.html
+++ b/docs/2.5.8/suiteBuilders.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.8/suiteBuilders.html
+++ b/docs/2.5.8/suiteBuilders.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.8/teardown.html
+++ b/docs/2.5.8/teardown.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.8/teardown.html
+++ b/docs/2.5.8/teardown.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.8/teardown.html
+++ b/docs/2.5.8/teardown.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.8/teardown.html
+++ b/docs/2.5.8/teardown.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.8/test.html
+++ b/docs/2.5.8/test.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.8/test.html
+++ b/docs/2.5.8/test.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.8/test.html
+++ b/docs/2.5.8/test.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.8/test.html
+++ b/docs/2.5.8/test.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.8/testCase.html
+++ b/docs/2.5.8/testCase.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.8/testCase.html
+++ b/docs/2.5.8/testCase.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.8/testCase.html
+++ b/docs/2.5.8/testCase.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.8/testCase.html
+++ b/docs/2.5.8/testCase.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.8/testCaseSource.html
+++ b/docs/2.5.8/testCaseSource.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.8/testCaseSource.html
+++ b/docs/2.5.8/testCaseSource.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.8/testCaseSource.html
+++ b/docs/2.5.8/testCaseSource.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.8/testCaseSource.html
+++ b/docs/2.5.8/testCaseSource.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.8/testDecorators.html
+++ b/docs/2.5.8/testDecorators.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.8/testDecorators.html
+++ b/docs/2.5.8/testDecorators.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.8/testDecorators.html
+++ b/docs/2.5.8/testDecorators.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.8/testDecorators.html
+++ b/docs/2.5.8/testDecorators.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.8/testFixture.html
+++ b/docs/2.5.8/testFixture.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.8/testFixture.html
+++ b/docs/2.5.8/testFixture.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.8/testFixture.html
+++ b/docs/2.5.8/testFixture.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.8/testFixture.html
+++ b/docs/2.5.8/testFixture.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.8/testProperties.html
+++ b/docs/2.5.8/testProperties.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.8/testProperties.html
+++ b/docs/2.5.8/testProperties.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.8/testProperties.html
+++ b/docs/2.5.8/testProperties.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.8/testProperties.html
+++ b/docs/2.5.8/testProperties.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.8/testcaseBuilders.html
+++ b/docs/2.5.8/testcaseBuilders.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.8/testcaseBuilders.html
+++ b/docs/2.5.8/testcaseBuilders.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.8/testcaseBuilders.html
+++ b/docs/2.5.8/testcaseBuilders.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.8/testcaseBuilders.html
+++ b/docs/2.5.8/testcaseBuilders.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.8/testcaseProviders.html
+++ b/docs/2.5.8/testcaseProviders.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.8/testcaseProviders.html
+++ b/docs/2.5.8/testcaseProviders.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.8/testcaseProviders.html
+++ b/docs/2.5.8/testcaseProviders.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.8/testcaseProviders.html
+++ b/docs/2.5.8/testcaseProviders.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.8/theory.html
+++ b/docs/2.5.8/theory.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.8/theory.html
+++ b/docs/2.5.8/theory.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.8/theory.html
+++ b/docs/2.5.8/theory.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.8/theory.html
+++ b/docs/2.5.8/theory.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.8/throwsConstraint.html
+++ b/docs/2.5.8/throwsConstraint.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.8/throwsConstraint.html
+++ b/docs/2.5.8/throwsConstraint.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.8/throwsConstraint.html
+++ b/docs/2.5.8/throwsConstraint.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.8/throwsConstraint.html
+++ b/docs/2.5.8/throwsConstraint.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.8/timeout.html
+++ b/docs/2.5.8/timeout.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.8/timeout.html
+++ b/docs/2.5.8/timeout.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.8/timeout.html
+++ b/docs/2.5.8/timeout.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.8/timeout.html
+++ b/docs/2.5.8/timeout.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.8/typeAsserts.html
+++ b/docs/2.5.8/typeAsserts.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.8/typeAsserts.html
+++ b/docs/2.5.8/typeAsserts.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.8/typeAsserts.html
+++ b/docs/2.5.8/typeAsserts.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.8/typeAsserts.html
+++ b/docs/2.5.8/typeAsserts.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.8/typeConstraints.html
+++ b/docs/2.5.8/typeConstraints.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.8/typeConstraints.html
+++ b/docs/2.5.8/typeConstraints.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.8/typeConstraints.html
+++ b/docs/2.5.8/typeConstraints.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.8/typeConstraints.html
+++ b/docs/2.5.8/typeConstraints.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.8/upgrade.html
+++ b/docs/2.5.8/upgrade.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.8/upgrade.html
+++ b/docs/2.5.8/upgrade.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.8/upgrade.html
+++ b/docs/2.5.8/upgrade.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.8/upgrade.html
+++ b/docs/2.5.8/upgrade.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.8/utilityAsserts.html
+++ b/docs/2.5.8/utilityAsserts.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.8/utilityAsserts.html
+++ b/docs/2.5.8/utilityAsserts.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.8/utilityAsserts.html
+++ b/docs/2.5.8/utilityAsserts.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.8/utilityAsserts.html
+++ b/docs/2.5.8/utilityAsserts.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.8/valueSource.html
+++ b/docs/2.5.8/valueSource.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.8/valueSource.html
+++ b/docs/2.5.8/valueSource.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.8/valueSource.html
+++ b/docs/2.5.8/valueSource.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.8/valueSource.html
+++ b/docs/2.5.8/valueSource.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.8/values.html
+++ b/docs/2.5.8/values.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.8/values.html
+++ b/docs/2.5.8/values.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.8/values.html
+++ b/docs/2.5.8/values.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.8/values.html
+++ b/docs/2.5.8/values.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.8/vsSupport.html
+++ b/docs/2.5.8/vsSupport.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.8/vsSupport.html
+++ b/docs/2.5.8/vsSupport.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.8/vsSupport.html
+++ b/docs/2.5.8/vsSupport.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.8/vsSupport.html
+++ b/docs/2.5.8/vsSupport.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.9/addinsDialog.html
+++ b/docs/2.5.9/addinsDialog.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.9/addinsDialog.html
+++ b/docs/2.5.9/addinsDialog.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.9/addinsDialog.html
+++ b/docs/2.5.9/addinsDialog.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.9/addinsDialog.html
+++ b/docs/2.5.9/addinsDialog.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.9/assemblyIsolation.html
+++ b/docs/2.5.9/assemblyIsolation.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.9/assemblyIsolation.html
+++ b/docs/2.5.9/assemblyIsolation.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.9/assemblyIsolation.html
+++ b/docs/2.5.9/assemblyIsolation.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.9/assemblyIsolation.html
+++ b/docs/2.5.9/assemblyIsolation.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.9/assertions.html
+++ b/docs/2.5.9/assertions.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.9/assertions.html
+++ b/docs/2.5.9/assertions.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.9/assertions.html
+++ b/docs/2.5.9/assertions.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.9/assertions.html
+++ b/docs/2.5.9/assertions.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.9/attributes.html
+++ b/docs/2.5.9/attributes.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.9/attributes.html
+++ b/docs/2.5.9/attributes.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.9/attributes.html
+++ b/docs/2.5.9/attributes.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.9/attributes.html
+++ b/docs/2.5.9/attributes.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.9/category.html
+++ b/docs/2.5.9/category.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.9/category.html
+++ b/docs/2.5.9/category.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.9/category.html
+++ b/docs/2.5.9/category.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.9/category.html
+++ b/docs/2.5.9/category.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.9/collectionAssert.html
+++ b/docs/2.5.9/collectionAssert.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.9/collectionAssert.html
+++ b/docs/2.5.9/collectionAssert.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.9/collectionAssert.html
+++ b/docs/2.5.9/collectionAssert.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.9/collectionAssert.html
+++ b/docs/2.5.9/collectionAssert.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.9/collectionConstraints.html
+++ b/docs/2.5.9/collectionConstraints.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.9/collectionConstraints.html
+++ b/docs/2.5.9/collectionConstraints.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.9/collectionConstraints.html
+++ b/docs/2.5.9/collectionConstraints.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.9/collectionConstraints.html
+++ b/docs/2.5.9/collectionConstraints.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.9/combinatorial.html
+++ b/docs/2.5.9/combinatorial.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.9/combinatorial.html
+++ b/docs/2.5.9/combinatorial.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.9/combinatorial.html
+++ b/docs/2.5.9/combinatorial.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.9/combinatorial.html
+++ b/docs/2.5.9/combinatorial.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.9/comparisonAsserts.html
+++ b/docs/2.5.9/comparisonAsserts.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.9/comparisonAsserts.html
+++ b/docs/2.5.9/comparisonAsserts.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.9/comparisonAsserts.html
+++ b/docs/2.5.9/comparisonAsserts.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.9/comparisonAsserts.html
+++ b/docs/2.5.9/comparisonAsserts.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.9/comparisonConstraints.html
+++ b/docs/2.5.9/comparisonConstraints.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.9/comparisonConstraints.html
+++ b/docs/2.5.9/comparisonConstraints.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.9/comparisonConstraints.html
+++ b/docs/2.5.9/comparisonConstraints.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.9/comparisonConstraints.html
+++ b/docs/2.5.9/comparisonConstraints.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.9/compoundConstraints.html
+++ b/docs/2.5.9/compoundConstraints.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.9/compoundConstraints.html
+++ b/docs/2.5.9/compoundConstraints.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.9/compoundConstraints.html
+++ b/docs/2.5.9/compoundConstraints.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.9/compoundConstraints.html
+++ b/docs/2.5.9/compoundConstraints.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.9/conditionAsserts.html
+++ b/docs/2.5.9/conditionAsserts.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.9/conditionAsserts.html
+++ b/docs/2.5.9/conditionAsserts.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.9/conditionAsserts.html
+++ b/docs/2.5.9/conditionAsserts.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.9/conditionAsserts.html
+++ b/docs/2.5.9/conditionAsserts.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.9/conditionConstraints.html
+++ b/docs/2.5.9/conditionConstraints.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.9/conditionConstraints.html
+++ b/docs/2.5.9/conditionConstraints.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.9/conditionConstraints.html
+++ b/docs/2.5.9/conditionConstraints.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.9/conditionConstraints.html
+++ b/docs/2.5.9/conditionConstraints.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.9/configEditor.html
+++ b/docs/2.5.9/configEditor.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.9/configEditor.html
+++ b/docs/2.5.9/configEditor.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.9/configEditor.html
+++ b/docs/2.5.9/configEditor.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.9/configEditor.html
+++ b/docs/2.5.9/configEditor.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.9/configFiles.html
+++ b/docs/2.5.9/configFiles.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.9/configFiles.html
+++ b/docs/2.5.9/configFiles.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.9/configFiles.html
+++ b/docs/2.5.9/configFiles.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.9/configFiles.html
+++ b/docs/2.5.9/configFiles.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.9/consoleCommandLine.html
+++ b/docs/2.5.9/consoleCommandLine.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.9/consoleCommandLine.html
+++ b/docs/2.5.9/consoleCommandLine.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.9/consoleCommandLine.html
+++ b/docs/2.5.9/consoleCommandLine.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.9/consoleCommandLine.html
+++ b/docs/2.5.9/consoleCommandLine.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.9/constraintModel.html
+++ b/docs/2.5.9/constraintModel.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.9/constraintModel.html
+++ b/docs/2.5.9/constraintModel.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.9/constraintModel.html
+++ b/docs/2.5.9/constraintModel.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.9/constraintModel.html
+++ b/docs/2.5.9/constraintModel.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.9/contextMenu.html
+++ b/docs/2.5.9/contextMenu.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.9/contextMenu.html
+++ b/docs/2.5.9/contextMenu.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.9/contextMenu.html
+++ b/docs/2.5.9/contextMenu.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.9/contextMenu.html
+++ b/docs/2.5.9/contextMenu.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.9/culture.html
+++ b/docs/2.5.9/culture.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.9/culture.html
+++ b/docs/2.5.9/culture.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.9/culture.html
+++ b/docs/2.5.9/culture.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.9/culture.html
+++ b/docs/2.5.9/culture.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.9/customConstraints.html
+++ b/docs/2.5.9/customConstraints.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.9/customConstraints.html
+++ b/docs/2.5.9/customConstraints.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.9/customConstraints.html
+++ b/docs/2.5.9/customConstraints.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.9/customConstraints.html
+++ b/docs/2.5.9/customConstraints.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.9/datapoint.html
+++ b/docs/2.5.9/datapoint.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.9/datapoint.html
+++ b/docs/2.5.9/datapoint.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.9/datapoint.html
+++ b/docs/2.5.9/datapoint.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.9/datapoint.html
+++ b/docs/2.5.9/datapoint.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.9/datapointProviders.html
+++ b/docs/2.5.9/datapointProviders.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.9/datapointProviders.html
+++ b/docs/2.5.9/datapointProviders.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.9/datapointProviders.html
+++ b/docs/2.5.9/datapointProviders.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.9/datapointProviders.html
+++ b/docs/2.5.9/datapointProviders.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.9/delayedConstraint.html
+++ b/docs/2.5.9/delayedConstraint.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.9/delayedConstraint.html
+++ b/docs/2.5.9/delayedConstraint.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.9/delayedConstraint.html
+++ b/docs/2.5.9/delayedConstraint.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.9/delayedConstraint.html
+++ b/docs/2.5.9/delayedConstraint.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.9/description.html
+++ b/docs/2.5.9/description.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.9/description.html
+++ b/docs/2.5.9/description.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.9/description.html
+++ b/docs/2.5.9/description.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.9/description.html
+++ b/docs/2.5.9/description.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.9/directoryAssert.html
+++ b/docs/2.5.9/directoryAssert.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.9/directoryAssert.html
+++ b/docs/2.5.9/directoryAssert.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.9/directoryAssert.html
+++ b/docs/2.5.9/directoryAssert.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.9/directoryAssert.html
+++ b/docs/2.5.9/directoryAssert.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.9/docHome.html
+++ b/docs/2.5.9/docHome.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.9/docHome.html
+++ b/docs/2.5.9/docHome.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.9/docHome.html
+++ b/docs/2.5.9/docHome.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.9/docHome.html
+++ b/docs/2.5.9/docHome.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.9/equalConstraint.html
+++ b/docs/2.5.9/equalConstraint.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.9/equalConstraint.html
+++ b/docs/2.5.9/equalConstraint.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.9/equalConstraint.html
+++ b/docs/2.5.9/equalConstraint.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.9/equalConstraint.html
+++ b/docs/2.5.9/equalConstraint.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.9/equalityAsserts.html
+++ b/docs/2.5.9/equalityAsserts.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.9/equalityAsserts.html
+++ b/docs/2.5.9/equalityAsserts.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.9/equalityAsserts.html
+++ b/docs/2.5.9/equalityAsserts.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.9/equalityAsserts.html
+++ b/docs/2.5.9/equalityAsserts.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.9/eventListeners.html
+++ b/docs/2.5.9/eventListeners.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.9/eventListeners.html
+++ b/docs/2.5.9/eventListeners.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.9/eventListeners.html
+++ b/docs/2.5.9/eventListeners.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.9/eventListeners.html
+++ b/docs/2.5.9/eventListeners.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.9/exception.html
+++ b/docs/2.5.9/exception.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.9/exception.html
+++ b/docs/2.5.9/exception.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.9/exception.html
+++ b/docs/2.5.9/exception.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.9/exception.html
+++ b/docs/2.5.9/exception.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.9/exceptionAsserts.html
+++ b/docs/2.5.9/exceptionAsserts.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.9/exceptionAsserts.html
+++ b/docs/2.5.9/exceptionAsserts.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.9/exceptionAsserts.html
+++ b/docs/2.5.9/exceptionAsserts.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.9/exceptionAsserts.html
+++ b/docs/2.5.9/exceptionAsserts.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.9/explicit.html
+++ b/docs/2.5.9/explicit.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.9/explicit.html
+++ b/docs/2.5.9/explicit.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.9/explicit.html
+++ b/docs/2.5.9/explicit.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.9/explicit.html
+++ b/docs/2.5.9/explicit.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.9/extensibility.html
+++ b/docs/2.5.9/extensibility.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.9/extensibility.html
+++ b/docs/2.5.9/extensibility.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.9/extensibility.html
+++ b/docs/2.5.9/extensibility.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.9/extensibility.html
+++ b/docs/2.5.9/extensibility.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.9/extensionTips.html
+++ b/docs/2.5.9/extensionTips.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.9/extensionTips.html
+++ b/docs/2.5.9/extensionTips.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.9/extensionTips.html
+++ b/docs/2.5.9/extensionTips.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.9/extensionTips.html
+++ b/docs/2.5.9/extensionTips.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.9/fileAssert.html
+++ b/docs/2.5.9/fileAssert.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.9/fileAssert.html
+++ b/docs/2.5.9/fileAssert.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.9/fileAssert.html
+++ b/docs/2.5.9/fileAssert.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.9/fileAssert.html
+++ b/docs/2.5.9/fileAssert.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.9/fixtureSetup.html
+++ b/docs/2.5.9/fixtureSetup.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.9/fixtureSetup.html
+++ b/docs/2.5.9/fixtureSetup.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.9/fixtureSetup.html
+++ b/docs/2.5.9/fixtureSetup.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.9/fixtureSetup.html
+++ b/docs/2.5.9/fixtureSetup.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.9/fixtureTeardown.html
+++ b/docs/2.5.9/fixtureTeardown.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.9/fixtureTeardown.html
+++ b/docs/2.5.9/fixtureTeardown.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.9/fixtureTeardown.html
+++ b/docs/2.5.9/fixtureTeardown.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.9/fixtureTeardown.html
+++ b/docs/2.5.9/fixtureTeardown.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.9/getStarted.html
+++ b/docs/2.5.9/getStarted.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.9/getStarted.html
+++ b/docs/2.5.9/getStarted.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.9/getStarted.html
+++ b/docs/2.5.9/getStarted.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.9/getStarted.html
+++ b/docs/2.5.9/getStarted.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.9/guiCommandLine.html
+++ b/docs/2.5.9/guiCommandLine.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.9/guiCommandLine.html
+++ b/docs/2.5.9/guiCommandLine.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.9/guiCommandLine.html
+++ b/docs/2.5.9/guiCommandLine.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.9/guiCommandLine.html
+++ b/docs/2.5.9/guiCommandLine.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.9/identityAsserts.html
+++ b/docs/2.5.9/identityAsserts.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.9/identityAsserts.html
+++ b/docs/2.5.9/identityAsserts.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.9/identityAsserts.html
+++ b/docs/2.5.9/identityAsserts.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.9/identityAsserts.html
+++ b/docs/2.5.9/identityAsserts.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.9/ignore.html
+++ b/docs/2.5.9/ignore.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.9/ignore.html
+++ b/docs/2.5.9/ignore.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.9/ignore.html
+++ b/docs/2.5.9/ignore.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.9/ignore.html
+++ b/docs/2.5.9/ignore.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.9/installation.html
+++ b/docs/2.5.9/installation.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.9/installation.html
+++ b/docs/2.5.9/installation.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.9/installation.html
+++ b/docs/2.5.9/installation.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.9/installation.html
+++ b/docs/2.5.9/installation.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.9/license.html
+++ b/docs/2.5.9/license.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.9/license.html
+++ b/docs/2.5.9/license.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.9/license.html
+++ b/docs/2.5.9/license.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.9/license.html
+++ b/docs/2.5.9/license.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.9/listMapper.html
+++ b/docs/2.5.9/listMapper.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.9/listMapper.html
+++ b/docs/2.5.9/listMapper.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.9/listMapper.html
+++ b/docs/2.5.9/listMapper.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.9/listMapper.html
+++ b/docs/2.5.9/listMapper.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.9/mainMenu.html
+++ b/docs/2.5.9/mainMenu.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.9/mainMenu.html
+++ b/docs/2.5.9/mainMenu.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.9/mainMenu.html
+++ b/docs/2.5.9/mainMenu.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.9/mainMenu.html
+++ b/docs/2.5.9/mainMenu.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.9/maxtime.html
+++ b/docs/2.5.9/maxtime.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.9/maxtime.html
+++ b/docs/2.5.9/maxtime.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.9/maxtime.html
+++ b/docs/2.5.9/maxtime.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.9/maxtime.html
+++ b/docs/2.5.9/maxtime.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.9/multiAssembly.html
+++ b/docs/2.5.9/multiAssembly.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.9/multiAssembly.html
+++ b/docs/2.5.9/multiAssembly.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.9/multiAssembly.html
+++ b/docs/2.5.9/multiAssembly.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.9/multiAssembly.html
+++ b/docs/2.5.9/multiAssembly.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.9/nunit-agent.html
+++ b/docs/2.5.9/nunit-agent.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.9/nunit-agent.html
+++ b/docs/2.5.9/nunit-agent.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.9/nunit-agent.html
+++ b/docs/2.5.9/nunit-agent.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.9/nunit-agent.html
+++ b/docs/2.5.9/nunit-agent.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.9/nunit-console.html
+++ b/docs/2.5.9/nunit-console.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.9/nunit-console.html
+++ b/docs/2.5.9/nunit-console.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.9/nunit-console.html
+++ b/docs/2.5.9/nunit-console.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.9/nunit-console.html
+++ b/docs/2.5.9/nunit-console.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.9/nunit-gui.html
+++ b/docs/2.5.9/nunit-gui.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.9/nunit-gui.html
+++ b/docs/2.5.9/nunit-gui.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.9/nunit-gui.html
+++ b/docs/2.5.9/nunit-gui.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.9/nunit-gui.html
+++ b/docs/2.5.9/nunit-gui.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.9/nunitAddins.html
+++ b/docs/2.5.9/nunitAddins.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.9/nunitAddins.html
+++ b/docs/2.5.9/nunitAddins.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.9/nunitAddins.html
+++ b/docs/2.5.9/nunitAddins.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.9/nunitAddins.html
+++ b/docs/2.5.9/nunitAddins.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.9/pairwise.html
+++ b/docs/2.5.9/pairwise.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.9/pairwise.html
+++ b/docs/2.5.9/pairwise.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.9/pairwise.html
+++ b/docs/2.5.9/pairwise.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.9/pairwise.html
+++ b/docs/2.5.9/pairwise.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.9/parameterizedTests.html
+++ b/docs/2.5.9/parameterizedTests.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.9/parameterizedTests.html
+++ b/docs/2.5.9/parameterizedTests.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.9/parameterizedTests.html
+++ b/docs/2.5.9/parameterizedTests.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.9/parameterizedTests.html
+++ b/docs/2.5.9/parameterizedTests.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.9/pathConstraints.html
+++ b/docs/2.5.9/pathConstraints.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.9/pathConstraints.html
+++ b/docs/2.5.9/pathConstraints.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.9/pathConstraints.html
+++ b/docs/2.5.9/pathConstraints.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.9/pathConstraints.html
+++ b/docs/2.5.9/pathConstraints.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.9/platform.html
+++ b/docs/2.5.9/platform.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.9/platform.html
+++ b/docs/2.5.9/platform.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.9/platform.html
+++ b/docs/2.5.9/platform.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.9/platform.html
+++ b/docs/2.5.9/platform.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.9/pnunit.html
+++ b/docs/2.5.9/pnunit.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.9/pnunit.html
+++ b/docs/2.5.9/pnunit.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.9/pnunit.html
+++ b/docs/2.5.9/pnunit.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.9/pnunit.html
+++ b/docs/2.5.9/pnunit.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.9/projectEditor.html
+++ b/docs/2.5.9/projectEditor.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.9/projectEditor.html
+++ b/docs/2.5.9/projectEditor.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.9/projectEditor.html
+++ b/docs/2.5.9/projectEditor.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.9/projectEditor.html
+++ b/docs/2.5.9/projectEditor.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.9/property.html
+++ b/docs/2.5.9/property.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.9/property.html
+++ b/docs/2.5.9/property.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.9/property.html
+++ b/docs/2.5.9/property.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.9/property.html
+++ b/docs/2.5.9/property.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.9/propertyConstraint.html
+++ b/docs/2.5.9/propertyConstraint.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.9/propertyConstraint.html
+++ b/docs/2.5.9/propertyConstraint.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.9/propertyConstraint.html
+++ b/docs/2.5.9/propertyConstraint.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.9/propertyConstraint.html
+++ b/docs/2.5.9/propertyConstraint.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.9/quickStart.html
+++ b/docs/2.5.9/quickStart.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.9/quickStart.html
+++ b/docs/2.5.9/quickStart.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.9/quickStart.html
+++ b/docs/2.5.9/quickStart.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.9/quickStart.html
+++ b/docs/2.5.9/quickStart.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.9/quickStartSource.html
+++ b/docs/2.5.9/quickStartSource.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.9/quickStartSource.html
+++ b/docs/2.5.9/quickStartSource.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.9/quickStartSource.html
+++ b/docs/2.5.9/quickStartSource.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.9/quickStartSource.html
+++ b/docs/2.5.9/quickStartSource.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.9/random.html
+++ b/docs/2.5.9/random.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.9/random.html
+++ b/docs/2.5.9/random.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.9/random.html
+++ b/docs/2.5.9/random.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.9/random.html
+++ b/docs/2.5.9/random.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.9/range.html
+++ b/docs/2.5.9/range.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.9/range.html
+++ b/docs/2.5.9/range.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.9/range.html
+++ b/docs/2.5.9/range.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.9/range.html
+++ b/docs/2.5.9/range.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.9/releaseNotes.html
+++ b/docs/2.5.9/releaseNotes.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.9/releaseNotes.html
+++ b/docs/2.5.9/releaseNotes.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.9/releaseNotes.html
+++ b/docs/2.5.9/releaseNotes.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.9/releaseNotes.html
+++ b/docs/2.5.9/releaseNotes.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.9/repeat.html
+++ b/docs/2.5.9/repeat.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.9/repeat.html
+++ b/docs/2.5.9/repeat.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.9/repeat.html
+++ b/docs/2.5.9/repeat.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.9/repeat.html
+++ b/docs/2.5.9/repeat.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.9/requiredAddin.html
+++ b/docs/2.5.9/requiredAddin.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.9/requiredAddin.html
+++ b/docs/2.5.9/requiredAddin.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.9/requiredAddin.html
+++ b/docs/2.5.9/requiredAddin.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.9/requiredAddin.html
+++ b/docs/2.5.9/requiredAddin.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.9/requiresMTA.html
+++ b/docs/2.5.9/requiresMTA.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.9/requiresMTA.html
+++ b/docs/2.5.9/requiresMTA.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.9/requiresMTA.html
+++ b/docs/2.5.9/requiresMTA.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.9/requiresMTA.html
+++ b/docs/2.5.9/requiresMTA.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.9/requiresSTA.html
+++ b/docs/2.5.9/requiresSTA.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.9/requiresSTA.html
+++ b/docs/2.5.9/requiresSTA.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.9/requiresSTA.html
+++ b/docs/2.5.9/requiresSTA.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.9/requiresSTA.html
+++ b/docs/2.5.9/requiresSTA.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.9/requiresThread.html
+++ b/docs/2.5.9/requiresThread.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.9/requiresThread.html
+++ b/docs/2.5.9/requiresThread.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.9/requiresThread.html
+++ b/docs/2.5.9/requiresThread.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.9/requiresThread.html
+++ b/docs/2.5.9/requiresThread.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.9/reusableConstraint.html
+++ b/docs/2.5.9/reusableConstraint.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.9/reusableConstraint.html
+++ b/docs/2.5.9/reusableConstraint.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.9/reusableConstraint.html
+++ b/docs/2.5.9/reusableConstraint.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.9/reusableConstraint.html
+++ b/docs/2.5.9/reusableConstraint.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.9/runningTests.html
+++ b/docs/2.5.9/runningTests.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.9/runningTests.html
+++ b/docs/2.5.9/runningTests.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.9/runningTests.html
+++ b/docs/2.5.9/runningTests.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.9/runningTests.html
+++ b/docs/2.5.9/runningTests.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.9/runtimeSelection.html
+++ b/docs/2.5.9/runtimeSelection.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.9/runtimeSelection.html
+++ b/docs/2.5.9/runtimeSelection.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.9/runtimeSelection.html
+++ b/docs/2.5.9/runtimeSelection.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.9/runtimeSelection.html
+++ b/docs/2.5.9/runtimeSelection.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.9/sameasConstraint.html
+++ b/docs/2.5.9/sameasConstraint.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.9/sameasConstraint.html
+++ b/docs/2.5.9/sameasConstraint.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.9/sameasConstraint.html
+++ b/docs/2.5.9/sameasConstraint.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.9/sameasConstraint.html
+++ b/docs/2.5.9/sameasConstraint.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.9/samples.html
+++ b/docs/2.5.9/samples.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.9/samples.html
+++ b/docs/2.5.9/samples.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.9/samples.html
+++ b/docs/2.5.9/samples.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.9/samples.html
+++ b/docs/2.5.9/samples.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.9/sequential.html
+++ b/docs/2.5.9/sequential.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.9/sequential.html
+++ b/docs/2.5.9/sequential.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.9/sequential.html
+++ b/docs/2.5.9/sequential.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.9/sequential.html
+++ b/docs/2.5.9/sequential.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.9/setCulture.html
+++ b/docs/2.5.9/setCulture.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.9/setCulture.html
+++ b/docs/2.5.9/setCulture.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.9/setCulture.html
+++ b/docs/2.5.9/setCulture.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.9/setCulture.html
+++ b/docs/2.5.9/setCulture.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.9/setUICulture.html
+++ b/docs/2.5.9/setUICulture.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.9/setUICulture.html
+++ b/docs/2.5.9/setUICulture.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.9/setUICulture.html
+++ b/docs/2.5.9/setUICulture.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.9/setUICulture.html
+++ b/docs/2.5.9/setUICulture.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.9/settingsDialog.html
+++ b/docs/2.5.9/settingsDialog.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.9/settingsDialog.html
+++ b/docs/2.5.9/settingsDialog.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.9/settingsDialog.html
+++ b/docs/2.5.9/settingsDialog.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.9/settingsDialog.html
+++ b/docs/2.5.9/settingsDialog.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.9/setup.html
+++ b/docs/2.5.9/setup.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.9/setup.html
+++ b/docs/2.5.9/setup.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.9/setup.html
+++ b/docs/2.5.9/setup.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.9/setup.html
+++ b/docs/2.5.9/setup.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.9/setupFixture.html
+++ b/docs/2.5.9/setupFixture.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.9/setupFixture.html
+++ b/docs/2.5.9/setupFixture.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.9/setupFixture.html
+++ b/docs/2.5.9/setupFixture.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.9/setupFixture.html
+++ b/docs/2.5.9/setupFixture.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.9/stringAssert.html
+++ b/docs/2.5.9/stringAssert.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.9/stringAssert.html
+++ b/docs/2.5.9/stringAssert.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.9/stringAssert.html
+++ b/docs/2.5.9/stringAssert.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.9/stringAssert.html
+++ b/docs/2.5.9/stringAssert.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.9/stringConstraints.html
+++ b/docs/2.5.9/stringConstraints.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.9/stringConstraints.html
+++ b/docs/2.5.9/stringConstraints.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.9/stringConstraints.html
+++ b/docs/2.5.9/stringConstraints.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.9/stringConstraints.html
+++ b/docs/2.5.9/stringConstraints.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.9/suite.html
+++ b/docs/2.5.9/suite.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.9/suite.html
+++ b/docs/2.5.9/suite.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.9/suite.html
+++ b/docs/2.5.9/suite.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.9/suite.html
+++ b/docs/2.5.9/suite.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.9/suiteBuilders.html
+++ b/docs/2.5.9/suiteBuilders.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.9/suiteBuilders.html
+++ b/docs/2.5.9/suiteBuilders.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.9/suiteBuilders.html
+++ b/docs/2.5.9/suiteBuilders.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.9/suiteBuilders.html
+++ b/docs/2.5.9/suiteBuilders.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.9/teardown.html
+++ b/docs/2.5.9/teardown.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.9/teardown.html
+++ b/docs/2.5.9/teardown.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.9/teardown.html
+++ b/docs/2.5.9/teardown.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.9/teardown.html
+++ b/docs/2.5.9/teardown.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.9/test.html
+++ b/docs/2.5.9/test.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.9/test.html
+++ b/docs/2.5.9/test.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.9/test.html
+++ b/docs/2.5.9/test.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.9/test.html
+++ b/docs/2.5.9/test.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.9/testCase.html
+++ b/docs/2.5.9/testCase.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.9/testCase.html
+++ b/docs/2.5.9/testCase.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.9/testCase.html
+++ b/docs/2.5.9/testCase.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.9/testCase.html
+++ b/docs/2.5.9/testCase.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.9/testCaseSource.html
+++ b/docs/2.5.9/testCaseSource.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.9/testCaseSource.html
+++ b/docs/2.5.9/testCaseSource.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.9/testCaseSource.html
+++ b/docs/2.5.9/testCaseSource.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.9/testCaseSource.html
+++ b/docs/2.5.9/testCaseSource.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.9/testDecorators.html
+++ b/docs/2.5.9/testDecorators.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.9/testDecorators.html
+++ b/docs/2.5.9/testDecorators.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.9/testDecorators.html
+++ b/docs/2.5.9/testDecorators.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.9/testDecorators.html
+++ b/docs/2.5.9/testDecorators.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.9/testFixture.html
+++ b/docs/2.5.9/testFixture.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.9/testFixture.html
+++ b/docs/2.5.9/testFixture.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.9/testFixture.html
+++ b/docs/2.5.9/testFixture.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.9/testFixture.html
+++ b/docs/2.5.9/testFixture.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.9/testProperties.html
+++ b/docs/2.5.9/testProperties.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.9/testProperties.html
+++ b/docs/2.5.9/testProperties.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.9/testProperties.html
+++ b/docs/2.5.9/testProperties.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.9/testProperties.html
+++ b/docs/2.5.9/testProperties.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.9/testcaseBuilders.html
+++ b/docs/2.5.9/testcaseBuilders.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.9/testcaseBuilders.html
+++ b/docs/2.5.9/testcaseBuilders.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.9/testcaseBuilders.html
+++ b/docs/2.5.9/testcaseBuilders.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.9/testcaseBuilders.html
+++ b/docs/2.5.9/testcaseBuilders.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.9/testcaseProviders.html
+++ b/docs/2.5.9/testcaseProviders.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.9/testcaseProviders.html
+++ b/docs/2.5.9/testcaseProviders.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.9/testcaseProviders.html
+++ b/docs/2.5.9/testcaseProviders.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.9/testcaseProviders.html
+++ b/docs/2.5.9/testcaseProviders.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.9/theory.html
+++ b/docs/2.5.9/theory.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.9/theory.html
+++ b/docs/2.5.9/theory.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.9/theory.html
+++ b/docs/2.5.9/theory.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.9/theory.html
+++ b/docs/2.5.9/theory.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.9/throwsConstraint.html
+++ b/docs/2.5.9/throwsConstraint.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.9/throwsConstraint.html
+++ b/docs/2.5.9/throwsConstraint.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.9/throwsConstraint.html
+++ b/docs/2.5.9/throwsConstraint.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.9/throwsConstraint.html
+++ b/docs/2.5.9/throwsConstraint.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.9/timeout.html
+++ b/docs/2.5.9/timeout.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.9/timeout.html
+++ b/docs/2.5.9/timeout.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.9/timeout.html
+++ b/docs/2.5.9/timeout.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.9/timeout.html
+++ b/docs/2.5.9/timeout.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.9/typeAsserts.html
+++ b/docs/2.5.9/typeAsserts.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.9/typeAsserts.html
+++ b/docs/2.5.9/typeAsserts.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.9/typeAsserts.html
+++ b/docs/2.5.9/typeAsserts.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.9/typeAsserts.html
+++ b/docs/2.5.9/typeAsserts.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.9/typeConstraints.html
+++ b/docs/2.5.9/typeConstraints.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.9/typeConstraints.html
+++ b/docs/2.5.9/typeConstraints.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.9/typeConstraints.html
+++ b/docs/2.5.9/typeConstraints.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.9/typeConstraints.html
+++ b/docs/2.5.9/typeConstraints.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.9/upgrade.html
+++ b/docs/2.5.9/upgrade.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.9/upgrade.html
+++ b/docs/2.5.9/upgrade.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.9/upgrade.html
+++ b/docs/2.5.9/upgrade.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.9/upgrade.html
+++ b/docs/2.5.9/upgrade.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.9/utilityAsserts.html
+++ b/docs/2.5.9/utilityAsserts.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.9/utilityAsserts.html
+++ b/docs/2.5.9/utilityAsserts.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.9/utilityAsserts.html
+++ b/docs/2.5.9/utilityAsserts.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.9/utilityAsserts.html
+++ b/docs/2.5.9/utilityAsserts.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.9/valueSource.html
+++ b/docs/2.5.9/valueSource.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.9/valueSource.html
+++ b/docs/2.5.9/valueSource.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.9/valueSource.html
+++ b/docs/2.5.9/valueSource.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.9/valueSource.html
+++ b/docs/2.5.9/valueSource.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.9/values.html
+++ b/docs/2.5.9/values.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.9/values.html
+++ b/docs/2.5.9/values.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.9/values.html
+++ b/docs/2.5.9/values.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.9/values.html
+++ b/docs/2.5.9/values.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5.9/vsSupport.html
+++ b/docs/2.5.9/vsSupport.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5.9/vsSupport.html
+++ b/docs/2.5.9/vsSupport.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5.9/vsSupport.html
+++ b/docs/2.5.9/vsSupport.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5.9/vsSupport.html
+++ b/docs/2.5.9/vsSupport.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5/addinsDialog.html
+++ b/docs/2.5/addinsDialog.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5/addinsDialog.html
+++ b/docs/2.5/addinsDialog.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5/addinsDialog.html
+++ b/docs/2.5/addinsDialog.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5/addinsDialog.html
+++ b/docs/2.5/addinsDialog.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5/assertions.html
+++ b/docs/2.5/assertions.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5/assertions.html
+++ b/docs/2.5/assertions.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5/assertions.html
+++ b/docs/2.5/assertions.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5/assertions.html
+++ b/docs/2.5/assertions.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5/attributes.html
+++ b/docs/2.5/attributes.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5/attributes.html
+++ b/docs/2.5/attributes.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5/attributes.html
+++ b/docs/2.5/attributes.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5/attributes.html
+++ b/docs/2.5/attributes.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5/category.html
+++ b/docs/2.5/category.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5/category.html
+++ b/docs/2.5/category.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5/category.html
+++ b/docs/2.5/category.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5/category.html
+++ b/docs/2.5/category.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5/collectionAssert.html
+++ b/docs/2.5/collectionAssert.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5/collectionAssert.html
+++ b/docs/2.5/collectionAssert.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5/collectionAssert.html
+++ b/docs/2.5/collectionAssert.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5/collectionAssert.html
+++ b/docs/2.5/collectionAssert.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5/collectionConstraints.html
+++ b/docs/2.5/collectionConstraints.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5/collectionConstraints.html
+++ b/docs/2.5/collectionConstraints.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5/collectionConstraints.html
+++ b/docs/2.5/collectionConstraints.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5/collectionConstraints.html
+++ b/docs/2.5/collectionConstraints.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5/combinatorial.html
+++ b/docs/2.5/combinatorial.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5/combinatorial.html
+++ b/docs/2.5/combinatorial.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5/combinatorial.html
+++ b/docs/2.5/combinatorial.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5/combinatorial.html
+++ b/docs/2.5/combinatorial.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5/comparisonAsserts.html
+++ b/docs/2.5/comparisonAsserts.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5/comparisonAsserts.html
+++ b/docs/2.5/comparisonAsserts.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5/comparisonAsserts.html
+++ b/docs/2.5/comparisonAsserts.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5/comparisonAsserts.html
+++ b/docs/2.5/comparisonAsserts.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5/comparisonConstraints.html
+++ b/docs/2.5/comparisonConstraints.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5/comparisonConstraints.html
+++ b/docs/2.5/comparisonConstraints.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5/comparisonConstraints.html
+++ b/docs/2.5/comparisonConstraints.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5/comparisonConstraints.html
+++ b/docs/2.5/comparisonConstraints.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5/compoundConstraints.html
+++ b/docs/2.5/compoundConstraints.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5/compoundConstraints.html
+++ b/docs/2.5/compoundConstraints.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5/compoundConstraints.html
+++ b/docs/2.5/compoundConstraints.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5/compoundConstraints.html
+++ b/docs/2.5/compoundConstraints.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5/conditionAsserts.html
+++ b/docs/2.5/conditionAsserts.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5/conditionAsserts.html
+++ b/docs/2.5/conditionAsserts.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5/conditionAsserts.html
+++ b/docs/2.5/conditionAsserts.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5/conditionAsserts.html
+++ b/docs/2.5/conditionAsserts.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5/conditionConstraints.html
+++ b/docs/2.5/conditionConstraints.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5/conditionConstraints.html
+++ b/docs/2.5/conditionConstraints.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5/conditionConstraints.html
+++ b/docs/2.5/conditionConstraints.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5/conditionConstraints.html
+++ b/docs/2.5/conditionConstraints.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5/configEditor.html
+++ b/docs/2.5/configEditor.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5/configEditor.html
+++ b/docs/2.5/configEditor.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5/configEditor.html
+++ b/docs/2.5/configEditor.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5/configEditor.html
+++ b/docs/2.5/configEditor.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5/configFiles.html
+++ b/docs/2.5/configFiles.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5/configFiles.html
+++ b/docs/2.5/configFiles.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5/configFiles.html
+++ b/docs/2.5/configFiles.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5/configFiles.html
+++ b/docs/2.5/configFiles.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5/consoleCommandLine.html
+++ b/docs/2.5/consoleCommandLine.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5/consoleCommandLine.html
+++ b/docs/2.5/consoleCommandLine.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5/consoleCommandLine.html
+++ b/docs/2.5/consoleCommandLine.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5/consoleCommandLine.html
+++ b/docs/2.5/consoleCommandLine.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5/constraintModel.html
+++ b/docs/2.5/constraintModel.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5/constraintModel.html
+++ b/docs/2.5/constraintModel.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5/constraintModel.html
+++ b/docs/2.5/constraintModel.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5/constraintModel.html
+++ b/docs/2.5/constraintModel.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5/contextMenu.html
+++ b/docs/2.5/contextMenu.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5/contextMenu.html
+++ b/docs/2.5/contextMenu.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5/contextMenu.html
+++ b/docs/2.5/contextMenu.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5/contextMenu.html
+++ b/docs/2.5/contextMenu.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5/culture.html
+++ b/docs/2.5/culture.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5/culture.html
+++ b/docs/2.5/culture.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5/culture.html
+++ b/docs/2.5/culture.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5/culture.html
+++ b/docs/2.5/culture.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5/customConstraints.html
+++ b/docs/2.5/customConstraints.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5/customConstraints.html
+++ b/docs/2.5/customConstraints.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5/customConstraints.html
+++ b/docs/2.5/customConstraints.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5/customConstraints.html
+++ b/docs/2.5/customConstraints.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5/datapoint.html
+++ b/docs/2.5/datapoint.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5/datapoint.html
+++ b/docs/2.5/datapoint.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5/datapoint.html
+++ b/docs/2.5/datapoint.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5/datapoint.html
+++ b/docs/2.5/datapoint.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5/datapointProviders.html
+++ b/docs/2.5/datapointProviders.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5/datapointProviders.html
+++ b/docs/2.5/datapointProviders.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5/datapointProviders.html
+++ b/docs/2.5/datapointProviders.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5/datapointProviders.html
+++ b/docs/2.5/datapointProviders.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5/delayedConstraint.html
+++ b/docs/2.5/delayedConstraint.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5/delayedConstraint.html
+++ b/docs/2.5/delayedConstraint.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5/delayedConstraint.html
+++ b/docs/2.5/delayedConstraint.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5/delayedConstraint.html
+++ b/docs/2.5/delayedConstraint.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5/description.html
+++ b/docs/2.5/description.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5/description.html
+++ b/docs/2.5/description.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5/description.html
+++ b/docs/2.5/description.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5/description.html
+++ b/docs/2.5/description.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5/directoryAssert.html
+++ b/docs/2.5/directoryAssert.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5/directoryAssert.html
+++ b/docs/2.5/directoryAssert.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5/directoryAssert.html
+++ b/docs/2.5/directoryAssert.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5/directoryAssert.html
+++ b/docs/2.5/directoryAssert.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5/docHome.html
+++ b/docs/2.5/docHome.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5/docHome.html
+++ b/docs/2.5/docHome.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5/docHome.html
+++ b/docs/2.5/docHome.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5/docHome.html
+++ b/docs/2.5/docHome.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5/equalConstraint.html
+++ b/docs/2.5/equalConstraint.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5/equalConstraint.html
+++ b/docs/2.5/equalConstraint.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5/equalConstraint.html
+++ b/docs/2.5/equalConstraint.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5/equalConstraint.html
+++ b/docs/2.5/equalConstraint.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5/equalityAsserts.html
+++ b/docs/2.5/equalityAsserts.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5/equalityAsserts.html
+++ b/docs/2.5/equalityAsserts.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5/equalityAsserts.html
+++ b/docs/2.5/equalityAsserts.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5/equalityAsserts.html
+++ b/docs/2.5/equalityAsserts.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5/eventListeners.html
+++ b/docs/2.5/eventListeners.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5/eventListeners.html
+++ b/docs/2.5/eventListeners.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5/eventListeners.html
+++ b/docs/2.5/eventListeners.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5/eventListeners.html
+++ b/docs/2.5/eventListeners.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5/exception.html
+++ b/docs/2.5/exception.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5/exception.html
+++ b/docs/2.5/exception.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5/exception.html
+++ b/docs/2.5/exception.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5/exception.html
+++ b/docs/2.5/exception.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5/exceptionAsserts.html
+++ b/docs/2.5/exceptionAsserts.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5/exceptionAsserts.html
+++ b/docs/2.5/exceptionAsserts.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5/exceptionAsserts.html
+++ b/docs/2.5/exceptionAsserts.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5/exceptionAsserts.html
+++ b/docs/2.5/exceptionAsserts.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5/explicit.html
+++ b/docs/2.5/explicit.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5/explicit.html
+++ b/docs/2.5/explicit.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5/explicit.html
+++ b/docs/2.5/explicit.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5/explicit.html
+++ b/docs/2.5/explicit.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5/extensibility.html
+++ b/docs/2.5/extensibility.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5/extensibility.html
+++ b/docs/2.5/extensibility.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5/extensibility.html
+++ b/docs/2.5/extensibility.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5/extensibility.html
+++ b/docs/2.5/extensibility.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5/extensionTips.html
+++ b/docs/2.5/extensionTips.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5/extensionTips.html
+++ b/docs/2.5/extensionTips.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5/extensionTips.html
+++ b/docs/2.5/extensionTips.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5/extensionTips.html
+++ b/docs/2.5/extensionTips.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5/fileAssert.html
+++ b/docs/2.5/fileAssert.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5/fileAssert.html
+++ b/docs/2.5/fileAssert.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5/fileAssert.html
+++ b/docs/2.5/fileAssert.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5/fileAssert.html
+++ b/docs/2.5/fileAssert.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5/fixtureSetup.html
+++ b/docs/2.5/fixtureSetup.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5/fixtureSetup.html
+++ b/docs/2.5/fixtureSetup.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5/fixtureSetup.html
+++ b/docs/2.5/fixtureSetup.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5/fixtureSetup.html
+++ b/docs/2.5/fixtureSetup.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5/fixtureTeardown.html
+++ b/docs/2.5/fixtureTeardown.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5/fixtureTeardown.html
+++ b/docs/2.5/fixtureTeardown.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5/fixtureTeardown.html
+++ b/docs/2.5/fixtureTeardown.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5/fixtureTeardown.html
+++ b/docs/2.5/fixtureTeardown.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5/getStarted.html
+++ b/docs/2.5/getStarted.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5/getStarted.html
+++ b/docs/2.5/getStarted.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5/getStarted.html
+++ b/docs/2.5/getStarted.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5/getStarted.html
+++ b/docs/2.5/getStarted.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5/guiCommandLine.html
+++ b/docs/2.5/guiCommandLine.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5/guiCommandLine.html
+++ b/docs/2.5/guiCommandLine.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5/guiCommandLine.html
+++ b/docs/2.5/guiCommandLine.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5/guiCommandLine.html
+++ b/docs/2.5/guiCommandLine.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5/identityAsserts.html
+++ b/docs/2.5/identityAsserts.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5/identityAsserts.html
+++ b/docs/2.5/identityAsserts.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5/identityAsserts.html
+++ b/docs/2.5/identityAsserts.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5/identityAsserts.html
+++ b/docs/2.5/identityAsserts.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5/ignore.html
+++ b/docs/2.5/ignore.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5/ignore.html
+++ b/docs/2.5/ignore.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5/ignore.html
+++ b/docs/2.5/ignore.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5/ignore.html
+++ b/docs/2.5/ignore.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5/installation.html
+++ b/docs/2.5/installation.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5/installation.html
+++ b/docs/2.5/installation.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5/installation.html
+++ b/docs/2.5/installation.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5/installation.html
+++ b/docs/2.5/installation.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5/license.html
+++ b/docs/2.5/license.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5/license.html
+++ b/docs/2.5/license.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5/license.html
+++ b/docs/2.5/license.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5/license.html
+++ b/docs/2.5/license.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5/listMapper.html
+++ b/docs/2.5/listMapper.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5/listMapper.html
+++ b/docs/2.5/listMapper.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5/listMapper.html
+++ b/docs/2.5/listMapper.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5/listMapper.html
+++ b/docs/2.5/listMapper.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5/mainMenu.html
+++ b/docs/2.5/mainMenu.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5/mainMenu.html
+++ b/docs/2.5/mainMenu.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5/mainMenu.html
+++ b/docs/2.5/mainMenu.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5/mainMenu.html
+++ b/docs/2.5/mainMenu.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5/maxtime.html
+++ b/docs/2.5/maxtime.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5/maxtime.html
+++ b/docs/2.5/maxtime.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5/maxtime.html
+++ b/docs/2.5/maxtime.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5/maxtime.html
+++ b/docs/2.5/maxtime.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5/multiAssembly.html
+++ b/docs/2.5/multiAssembly.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5/multiAssembly.html
+++ b/docs/2.5/multiAssembly.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5/multiAssembly.html
+++ b/docs/2.5/multiAssembly.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5/multiAssembly.html
+++ b/docs/2.5/multiAssembly.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5/nunit-console.html
+++ b/docs/2.5/nunit-console.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5/nunit-console.html
+++ b/docs/2.5/nunit-console.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5/nunit-console.html
+++ b/docs/2.5/nunit-console.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5/nunit-console.html
+++ b/docs/2.5/nunit-console.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5/nunit-gui.html
+++ b/docs/2.5/nunit-gui.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5/nunit-gui.html
+++ b/docs/2.5/nunit-gui.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5/nunit-gui.html
+++ b/docs/2.5/nunit-gui.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5/nunit-gui.html
+++ b/docs/2.5/nunit-gui.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5/nunitAddins.html
+++ b/docs/2.5/nunitAddins.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5/nunitAddins.html
+++ b/docs/2.5/nunitAddins.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5/nunitAddins.html
+++ b/docs/2.5/nunitAddins.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5/nunitAddins.html
+++ b/docs/2.5/nunitAddins.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5/pairwise.html
+++ b/docs/2.5/pairwise.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5/pairwise.html
+++ b/docs/2.5/pairwise.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5/pairwise.html
+++ b/docs/2.5/pairwise.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5/pairwise.html
+++ b/docs/2.5/pairwise.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5/parameterizedTests.html
+++ b/docs/2.5/parameterizedTests.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5/parameterizedTests.html
+++ b/docs/2.5/parameterizedTests.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5/parameterizedTests.html
+++ b/docs/2.5/parameterizedTests.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5/parameterizedTests.html
+++ b/docs/2.5/parameterizedTests.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5/pathConstraints.html
+++ b/docs/2.5/pathConstraints.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5/pathConstraints.html
+++ b/docs/2.5/pathConstraints.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5/pathConstraints.html
+++ b/docs/2.5/pathConstraints.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5/pathConstraints.html
+++ b/docs/2.5/pathConstraints.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5/platform.html
+++ b/docs/2.5/platform.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5/platform.html
+++ b/docs/2.5/platform.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5/platform.html
+++ b/docs/2.5/platform.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5/platform.html
+++ b/docs/2.5/platform.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5/pnunit.html
+++ b/docs/2.5/pnunit.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5/pnunit.html
+++ b/docs/2.5/pnunit.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5/pnunit.html
+++ b/docs/2.5/pnunit.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5/pnunit.html
+++ b/docs/2.5/pnunit.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5/projectEditor.html
+++ b/docs/2.5/projectEditor.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5/projectEditor.html
+++ b/docs/2.5/projectEditor.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5/projectEditor.html
+++ b/docs/2.5/projectEditor.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5/projectEditor.html
+++ b/docs/2.5/projectEditor.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5/property.html
+++ b/docs/2.5/property.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5/property.html
+++ b/docs/2.5/property.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5/property.html
+++ b/docs/2.5/property.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5/property.html
+++ b/docs/2.5/property.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5/propertyConstraint.html
+++ b/docs/2.5/propertyConstraint.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5/propertyConstraint.html
+++ b/docs/2.5/propertyConstraint.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5/propertyConstraint.html
+++ b/docs/2.5/propertyConstraint.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5/propertyConstraint.html
+++ b/docs/2.5/propertyConstraint.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5/quickStart.html
+++ b/docs/2.5/quickStart.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5/quickStart.html
+++ b/docs/2.5/quickStart.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5/quickStart.html
+++ b/docs/2.5/quickStart.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5/quickStart.html
+++ b/docs/2.5/quickStart.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5/quickStartSource.html
+++ b/docs/2.5/quickStartSource.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5/quickStartSource.html
+++ b/docs/2.5/quickStartSource.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5/quickStartSource.html
+++ b/docs/2.5/quickStartSource.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5/quickStartSource.html
+++ b/docs/2.5/quickStartSource.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5/random.html
+++ b/docs/2.5/random.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5/random.html
+++ b/docs/2.5/random.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5/random.html
+++ b/docs/2.5/random.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5/random.html
+++ b/docs/2.5/random.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5/range.html
+++ b/docs/2.5/range.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5/range.html
+++ b/docs/2.5/range.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5/range.html
+++ b/docs/2.5/range.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5/range.html
+++ b/docs/2.5/range.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5/releaseBreakdown.html
+++ b/docs/2.5/releaseBreakdown.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5/releaseBreakdown.html
+++ b/docs/2.5/releaseBreakdown.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5/releaseBreakdown.html
+++ b/docs/2.5/releaseBreakdown.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5/releaseBreakdown.html
+++ b/docs/2.5/releaseBreakdown.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5/releaseNotes.html
+++ b/docs/2.5/releaseNotes.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5/releaseNotes.html
+++ b/docs/2.5/releaseNotes.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5/releaseNotes.html
+++ b/docs/2.5/releaseNotes.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5/releaseNotes.html
+++ b/docs/2.5/releaseNotes.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5/repeat.html
+++ b/docs/2.5/repeat.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5/repeat.html
+++ b/docs/2.5/repeat.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5/repeat.html
+++ b/docs/2.5/repeat.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5/repeat.html
+++ b/docs/2.5/repeat.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5/requiredAddin.html
+++ b/docs/2.5/requiredAddin.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5/requiredAddin.html
+++ b/docs/2.5/requiredAddin.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5/requiredAddin.html
+++ b/docs/2.5/requiredAddin.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5/requiredAddin.html
+++ b/docs/2.5/requiredAddin.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5/requiresMTA.html
+++ b/docs/2.5/requiresMTA.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5/requiresMTA.html
+++ b/docs/2.5/requiresMTA.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5/requiresMTA.html
+++ b/docs/2.5/requiresMTA.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5/requiresMTA.html
+++ b/docs/2.5/requiresMTA.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5/requiresSTA.html
+++ b/docs/2.5/requiresSTA.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5/requiresSTA.html
+++ b/docs/2.5/requiresSTA.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5/requiresSTA.html
+++ b/docs/2.5/requiresSTA.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5/requiresSTA.html
+++ b/docs/2.5/requiresSTA.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5/requiresThread.html
+++ b/docs/2.5/requiresThread.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5/requiresThread.html
+++ b/docs/2.5/requiresThread.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5/requiresThread.html
+++ b/docs/2.5/requiresThread.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5/requiresThread.html
+++ b/docs/2.5/requiresThread.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5/sameasConstraint.html
+++ b/docs/2.5/sameasConstraint.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5/sameasConstraint.html
+++ b/docs/2.5/sameasConstraint.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5/sameasConstraint.html
+++ b/docs/2.5/sameasConstraint.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5/sameasConstraint.html
+++ b/docs/2.5/sameasConstraint.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5/samples.html
+++ b/docs/2.5/samples.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5/samples.html
+++ b/docs/2.5/samples.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5/samples.html
+++ b/docs/2.5/samples.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5/samples.html
+++ b/docs/2.5/samples.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5/sequential.html
+++ b/docs/2.5/sequential.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5/sequential.html
+++ b/docs/2.5/sequential.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5/sequential.html
+++ b/docs/2.5/sequential.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5/sequential.html
+++ b/docs/2.5/sequential.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5/setCulture.html
+++ b/docs/2.5/setCulture.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5/setCulture.html
+++ b/docs/2.5/setCulture.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5/setCulture.html
+++ b/docs/2.5/setCulture.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5/setCulture.html
+++ b/docs/2.5/setCulture.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5/settingsDialog.html
+++ b/docs/2.5/settingsDialog.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5/settingsDialog.html
+++ b/docs/2.5/settingsDialog.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5/settingsDialog.html
+++ b/docs/2.5/settingsDialog.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5/settingsDialog.html
+++ b/docs/2.5/settingsDialog.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5/setup.html
+++ b/docs/2.5/setup.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5/setup.html
+++ b/docs/2.5/setup.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5/setup.html
+++ b/docs/2.5/setup.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5/setup.html
+++ b/docs/2.5/setup.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5/setupFixture.html
+++ b/docs/2.5/setupFixture.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5/setupFixture.html
+++ b/docs/2.5/setupFixture.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5/setupFixture.html
+++ b/docs/2.5/setupFixture.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5/setupFixture.html
+++ b/docs/2.5/setupFixture.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5/stringAssert.html
+++ b/docs/2.5/stringAssert.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5/stringAssert.html
+++ b/docs/2.5/stringAssert.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5/stringAssert.html
+++ b/docs/2.5/stringAssert.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5/stringAssert.html
+++ b/docs/2.5/stringAssert.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5/stringConstraints.html
+++ b/docs/2.5/stringConstraints.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5/stringConstraints.html
+++ b/docs/2.5/stringConstraints.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5/stringConstraints.html
+++ b/docs/2.5/stringConstraints.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5/stringConstraints.html
+++ b/docs/2.5/stringConstraints.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5/suite.html
+++ b/docs/2.5/suite.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5/suite.html
+++ b/docs/2.5/suite.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5/suite.html
+++ b/docs/2.5/suite.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5/suite.html
+++ b/docs/2.5/suite.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5/suiteBuilders.html
+++ b/docs/2.5/suiteBuilders.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5/suiteBuilders.html
+++ b/docs/2.5/suiteBuilders.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5/suiteBuilders.html
+++ b/docs/2.5/suiteBuilders.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5/suiteBuilders.html
+++ b/docs/2.5/suiteBuilders.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5/teardown.html
+++ b/docs/2.5/teardown.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5/teardown.html
+++ b/docs/2.5/teardown.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5/teardown.html
+++ b/docs/2.5/teardown.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5/teardown.html
+++ b/docs/2.5/teardown.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5/test.html
+++ b/docs/2.5/test.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5/test.html
+++ b/docs/2.5/test.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5/test.html
+++ b/docs/2.5/test.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5/test.html
+++ b/docs/2.5/test.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5/testCase.html
+++ b/docs/2.5/testCase.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5/testCase.html
+++ b/docs/2.5/testCase.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5/testCase.html
+++ b/docs/2.5/testCase.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5/testCase.html
+++ b/docs/2.5/testCase.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5/testCaseSource.html
+++ b/docs/2.5/testCaseSource.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5/testCaseSource.html
+++ b/docs/2.5/testCaseSource.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5/testCaseSource.html
+++ b/docs/2.5/testCaseSource.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5/testCaseSource.html
+++ b/docs/2.5/testCaseSource.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5/testDecorators.html
+++ b/docs/2.5/testDecorators.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5/testDecorators.html
+++ b/docs/2.5/testDecorators.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5/testDecorators.html
+++ b/docs/2.5/testDecorators.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5/testDecorators.html
+++ b/docs/2.5/testDecorators.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5/testFixture.html
+++ b/docs/2.5/testFixture.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5/testFixture.html
+++ b/docs/2.5/testFixture.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5/testFixture.html
+++ b/docs/2.5/testFixture.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5/testFixture.html
+++ b/docs/2.5/testFixture.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5/testProperties.html
+++ b/docs/2.5/testProperties.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5/testProperties.html
+++ b/docs/2.5/testProperties.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5/testProperties.html
+++ b/docs/2.5/testProperties.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5/testProperties.html
+++ b/docs/2.5/testProperties.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5/testcaseBuilders.html
+++ b/docs/2.5/testcaseBuilders.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5/testcaseBuilders.html
+++ b/docs/2.5/testcaseBuilders.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5/testcaseBuilders.html
+++ b/docs/2.5/testcaseBuilders.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5/testcaseBuilders.html
+++ b/docs/2.5/testcaseBuilders.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5/testcaseProviders.html
+++ b/docs/2.5/testcaseProviders.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5/testcaseProviders.html
+++ b/docs/2.5/testcaseProviders.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5/testcaseProviders.html
+++ b/docs/2.5/testcaseProviders.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5/testcaseProviders.html
+++ b/docs/2.5/testcaseProviders.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5/theory.html
+++ b/docs/2.5/theory.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5/theory.html
+++ b/docs/2.5/theory.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5/theory.html
+++ b/docs/2.5/theory.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5/theory.html
+++ b/docs/2.5/theory.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5/throwsConstraint.html
+++ b/docs/2.5/throwsConstraint.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5/throwsConstraint.html
+++ b/docs/2.5/throwsConstraint.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5/throwsConstraint.html
+++ b/docs/2.5/throwsConstraint.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5/throwsConstraint.html
+++ b/docs/2.5/throwsConstraint.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5/timeout.html
+++ b/docs/2.5/timeout.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5/timeout.html
+++ b/docs/2.5/timeout.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5/timeout.html
+++ b/docs/2.5/timeout.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5/timeout.html
+++ b/docs/2.5/timeout.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5/typeAsserts.html
+++ b/docs/2.5/typeAsserts.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5/typeAsserts.html
+++ b/docs/2.5/typeAsserts.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5/typeAsserts.html
+++ b/docs/2.5/typeAsserts.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5/typeAsserts.html
+++ b/docs/2.5/typeAsserts.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5/typeConstraints.html
+++ b/docs/2.5/typeConstraints.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5/typeConstraints.html
+++ b/docs/2.5/typeConstraints.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5/typeConstraints.html
+++ b/docs/2.5/typeConstraints.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5/typeConstraints.html
+++ b/docs/2.5/typeConstraints.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5/upgrade.html
+++ b/docs/2.5/upgrade.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5/upgrade.html
+++ b/docs/2.5/upgrade.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5/upgrade.html
+++ b/docs/2.5/upgrade.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5/upgrade.html
+++ b/docs/2.5/upgrade.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5/utilityAsserts.html
+++ b/docs/2.5/utilityAsserts.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5/utilityAsserts.html
+++ b/docs/2.5/utilityAsserts.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5/utilityAsserts.html
+++ b/docs/2.5/utilityAsserts.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5/utilityAsserts.html
+++ b/docs/2.5/utilityAsserts.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5/valueSource.html
+++ b/docs/2.5/valueSource.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5/valueSource.html
+++ b/docs/2.5/valueSource.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5/valueSource.html
+++ b/docs/2.5/valueSource.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5/valueSource.html
+++ b/docs/2.5/valueSource.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5/values.html
+++ b/docs/2.5/values.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5/values.html
+++ b/docs/2.5/values.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5/values.html
+++ b/docs/2.5/values.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5/values.html
+++ b/docs/2.5/values.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.5/vsSupport.html
+++ b/docs/2.5/vsSupport.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.5/vsSupport.html
+++ b/docs/2.5/vsSupport.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.5/vsSupport.html
+++ b/docs/2.5/vsSupport.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.5/vsSupport.html
+++ b/docs/2.5/vsSupport.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.6.1/actionAttributes.html
+++ b/docs/2.6.1/actionAttributes.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.6.1/actionAttributes.html
+++ b/docs/2.6.1/actionAttributes.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.6.1/actionAttributes.html
+++ b/docs/2.6.1/actionAttributes.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.6.1/actionAttributes.html
+++ b/docs/2.6.1/actionAttributes.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.6.1/addinsDialog.html
+++ b/docs/2.6.1/addinsDialog.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.6.1/addinsDialog.html
+++ b/docs/2.6.1/addinsDialog.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.6.1/addinsDialog.html
+++ b/docs/2.6.1/addinsDialog.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.6.1/addinsDialog.html
+++ b/docs/2.6.1/addinsDialog.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.6.1/assemblyIsolation.html
+++ b/docs/2.6.1/assemblyIsolation.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.6.1/assemblyIsolation.html
+++ b/docs/2.6.1/assemblyIsolation.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.6.1/assemblyIsolation.html
+++ b/docs/2.6.1/assemblyIsolation.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.6.1/assemblyIsolation.html
+++ b/docs/2.6.1/assemblyIsolation.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.6.1/assertions.html
+++ b/docs/2.6.1/assertions.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.6.1/assertions.html
+++ b/docs/2.6.1/assertions.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.6.1/assertions.html
+++ b/docs/2.6.1/assertions.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.6.1/assertions.html
+++ b/docs/2.6.1/assertions.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.6.1/attributes.html
+++ b/docs/2.6.1/attributes.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.6.1/attributes.html
+++ b/docs/2.6.1/attributes.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.6.1/attributes.html
+++ b/docs/2.6.1/attributes.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.6.1/attributes.html
+++ b/docs/2.6.1/attributes.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.6.1/category.html
+++ b/docs/2.6.1/category.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.6.1/category.html
+++ b/docs/2.6.1/category.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.6.1/category.html
+++ b/docs/2.6.1/category.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.6.1/category.html
+++ b/docs/2.6.1/category.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.6.1/collectionAssert.html
+++ b/docs/2.6.1/collectionAssert.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.6.1/collectionAssert.html
+++ b/docs/2.6.1/collectionAssert.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.6.1/collectionAssert.html
+++ b/docs/2.6.1/collectionAssert.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.6.1/collectionAssert.html
+++ b/docs/2.6.1/collectionAssert.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.6.1/collectionConstraints.html
+++ b/docs/2.6.1/collectionConstraints.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.6.1/collectionConstraints.html
+++ b/docs/2.6.1/collectionConstraints.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.6.1/collectionConstraints.html
+++ b/docs/2.6.1/collectionConstraints.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.6.1/collectionConstraints.html
+++ b/docs/2.6.1/collectionConstraints.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.6.1/combinatorial.html
+++ b/docs/2.6.1/combinatorial.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.6.1/combinatorial.html
+++ b/docs/2.6.1/combinatorial.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.6.1/combinatorial.html
+++ b/docs/2.6.1/combinatorial.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.6.1/combinatorial.html
+++ b/docs/2.6.1/combinatorial.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.6.1/comparisonAsserts.html
+++ b/docs/2.6.1/comparisonAsserts.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.6.1/comparisonAsserts.html
+++ b/docs/2.6.1/comparisonAsserts.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.6.1/comparisonAsserts.html
+++ b/docs/2.6.1/comparisonAsserts.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.6.1/comparisonAsserts.html
+++ b/docs/2.6.1/comparisonAsserts.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.6.1/comparisonConstraints.html
+++ b/docs/2.6.1/comparisonConstraints.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.6.1/comparisonConstraints.html
+++ b/docs/2.6.1/comparisonConstraints.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.6.1/comparisonConstraints.html
+++ b/docs/2.6.1/comparisonConstraints.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.6.1/comparisonConstraints.html
+++ b/docs/2.6.1/comparisonConstraints.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.6.1/compoundConstraints.html
+++ b/docs/2.6.1/compoundConstraints.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.6.1/compoundConstraints.html
+++ b/docs/2.6.1/compoundConstraints.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.6.1/compoundConstraints.html
+++ b/docs/2.6.1/compoundConstraints.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.6.1/compoundConstraints.html
+++ b/docs/2.6.1/compoundConstraints.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.6.1/conditionAsserts.html
+++ b/docs/2.6.1/conditionAsserts.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.6.1/conditionAsserts.html
+++ b/docs/2.6.1/conditionAsserts.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.6.1/conditionAsserts.html
+++ b/docs/2.6.1/conditionAsserts.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.6.1/conditionAsserts.html
+++ b/docs/2.6.1/conditionAsserts.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.6.1/conditionConstraints.html
+++ b/docs/2.6.1/conditionConstraints.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.6.1/conditionConstraints.html
+++ b/docs/2.6.1/conditionConstraints.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.6.1/conditionConstraints.html
+++ b/docs/2.6.1/conditionConstraints.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.6.1/conditionConstraints.html
+++ b/docs/2.6.1/conditionConstraints.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.6.1/configEditor.html
+++ b/docs/2.6.1/configEditor.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.6.1/configEditor.html
+++ b/docs/2.6.1/configEditor.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.6.1/configEditor.html
+++ b/docs/2.6.1/configEditor.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.6.1/configEditor.html
+++ b/docs/2.6.1/configEditor.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.6.1/configFiles.html
+++ b/docs/2.6.1/configFiles.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.6.1/configFiles.html
+++ b/docs/2.6.1/configFiles.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.6.1/configFiles.html
+++ b/docs/2.6.1/configFiles.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.6.1/configFiles.html
+++ b/docs/2.6.1/configFiles.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.6.1/consoleCommandLine.html
+++ b/docs/2.6.1/consoleCommandLine.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.6.1/consoleCommandLine.html
+++ b/docs/2.6.1/consoleCommandLine.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.6.1/consoleCommandLine.html
+++ b/docs/2.6.1/consoleCommandLine.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.6.1/consoleCommandLine.html
+++ b/docs/2.6.1/consoleCommandLine.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.6.1/constraintModel.html
+++ b/docs/2.6.1/constraintModel.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.6.1/constraintModel.html
+++ b/docs/2.6.1/constraintModel.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.6.1/constraintModel.html
+++ b/docs/2.6.1/constraintModel.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.6.1/constraintModel.html
+++ b/docs/2.6.1/constraintModel.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.6.1/contextMenu.html
+++ b/docs/2.6.1/contextMenu.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.6.1/contextMenu.html
+++ b/docs/2.6.1/contextMenu.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.6.1/contextMenu.html
+++ b/docs/2.6.1/contextMenu.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.6.1/contextMenu.html
+++ b/docs/2.6.1/contextMenu.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.6.1/culture.html
+++ b/docs/2.6.1/culture.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.6.1/culture.html
+++ b/docs/2.6.1/culture.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.6.1/culture.html
+++ b/docs/2.6.1/culture.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.6.1/culture.html
+++ b/docs/2.6.1/culture.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.6.1/customConstraints.html
+++ b/docs/2.6.1/customConstraints.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.6.1/customConstraints.html
+++ b/docs/2.6.1/customConstraints.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.6.1/customConstraints.html
+++ b/docs/2.6.1/customConstraints.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.6.1/customConstraints.html
+++ b/docs/2.6.1/customConstraints.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.6.1/datapoint.html
+++ b/docs/2.6.1/datapoint.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.6.1/datapoint.html
+++ b/docs/2.6.1/datapoint.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.6.1/datapoint.html
+++ b/docs/2.6.1/datapoint.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.6.1/datapoint.html
+++ b/docs/2.6.1/datapoint.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.6.1/datapointProviders.html
+++ b/docs/2.6.1/datapointProviders.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.6.1/datapointProviders.html
+++ b/docs/2.6.1/datapointProviders.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.6.1/datapointProviders.html
+++ b/docs/2.6.1/datapointProviders.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.6.1/datapointProviders.html
+++ b/docs/2.6.1/datapointProviders.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.6.1/delayedConstraint.html
+++ b/docs/2.6.1/delayedConstraint.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.6.1/delayedConstraint.html
+++ b/docs/2.6.1/delayedConstraint.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.6.1/delayedConstraint.html
+++ b/docs/2.6.1/delayedConstraint.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.6.1/delayedConstraint.html
+++ b/docs/2.6.1/delayedConstraint.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.6.1/description.html
+++ b/docs/2.6.1/description.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.6.1/description.html
+++ b/docs/2.6.1/description.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.6.1/description.html
+++ b/docs/2.6.1/description.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.6.1/description.html
+++ b/docs/2.6.1/description.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.6.1/directoryAssert.html
+++ b/docs/2.6.1/directoryAssert.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.6.1/directoryAssert.html
+++ b/docs/2.6.1/directoryAssert.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.6.1/directoryAssert.html
+++ b/docs/2.6.1/directoryAssert.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.6.1/directoryAssert.html
+++ b/docs/2.6.1/directoryAssert.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.6.1/docHome.html
+++ b/docs/2.6.1/docHome.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.6.1/docHome.html
+++ b/docs/2.6.1/docHome.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.6.1/docHome.html
+++ b/docs/2.6.1/docHome.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.6.1/docHome.html
+++ b/docs/2.6.1/docHome.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.6.1/equalConstraint.html
+++ b/docs/2.6.1/equalConstraint.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.6.1/equalConstraint.html
+++ b/docs/2.6.1/equalConstraint.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.6.1/equalConstraint.html
+++ b/docs/2.6.1/equalConstraint.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.6.1/equalConstraint.html
+++ b/docs/2.6.1/equalConstraint.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.6.1/equalityAsserts.html
+++ b/docs/2.6.1/equalityAsserts.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.6.1/equalityAsserts.html
+++ b/docs/2.6.1/equalityAsserts.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.6.1/equalityAsserts.html
+++ b/docs/2.6.1/equalityAsserts.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.6.1/equalityAsserts.html
+++ b/docs/2.6.1/equalityAsserts.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.6.1/eventListeners.html
+++ b/docs/2.6.1/eventListeners.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.6.1/eventListeners.html
+++ b/docs/2.6.1/eventListeners.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.6.1/eventListeners.html
+++ b/docs/2.6.1/eventListeners.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.6.1/eventListeners.html
+++ b/docs/2.6.1/eventListeners.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.6.1/exception.html
+++ b/docs/2.6.1/exception.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.6.1/exception.html
+++ b/docs/2.6.1/exception.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.6.1/exception.html
+++ b/docs/2.6.1/exception.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.6.1/exception.html
+++ b/docs/2.6.1/exception.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.6.1/exceptionAsserts.html
+++ b/docs/2.6.1/exceptionAsserts.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.6.1/exceptionAsserts.html
+++ b/docs/2.6.1/exceptionAsserts.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.6.1/exceptionAsserts.html
+++ b/docs/2.6.1/exceptionAsserts.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.6.1/exceptionAsserts.html
+++ b/docs/2.6.1/exceptionAsserts.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.6.1/explicit.html
+++ b/docs/2.6.1/explicit.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.6.1/explicit.html
+++ b/docs/2.6.1/explicit.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.6.1/explicit.html
+++ b/docs/2.6.1/explicit.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.6.1/explicit.html
+++ b/docs/2.6.1/explicit.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.6.1/extensibility.html
+++ b/docs/2.6.1/extensibility.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.6.1/extensibility.html
+++ b/docs/2.6.1/extensibility.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.6.1/extensibility.html
+++ b/docs/2.6.1/extensibility.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.6.1/extensibility.html
+++ b/docs/2.6.1/extensibility.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.6.1/extensionTips.html
+++ b/docs/2.6.1/extensionTips.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.6.1/extensionTips.html
+++ b/docs/2.6.1/extensionTips.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.6.1/extensionTips.html
+++ b/docs/2.6.1/extensionTips.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.6.1/extensionTips.html
+++ b/docs/2.6.1/extensionTips.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.6.1/fileAssert.html
+++ b/docs/2.6.1/fileAssert.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.6.1/fileAssert.html
+++ b/docs/2.6.1/fileAssert.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.6.1/fileAssert.html
+++ b/docs/2.6.1/fileAssert.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.6.1/fileAssert.html
+++ b/docs/2.6.1/fileAssert.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.6.1/fixtureSetup.html
+++ b/docs/2.6.1/fixtureSetup.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.6.1/fixtureSetup.html
+++ b/docs/2.6.1/fixtureSetup.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.6.1/fixtureSetup.html
+++ b/docs/2.6.1/fixtureSetup.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.6.1/fixtureSetup.html
+++ b/docs/2.6.1/fixtureSetup.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.6.1/fixtureTeardown.html
+++ b/docs/2.6.1/fixtureTeardown.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.6.1/fixtureTeardown.html
+++ b/docs/2.6.1/fixtureTeardown.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.6.1/fixtureTeardown.html
+++ b/docs/2.6.1/fixtureTeardown.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.6.1/fixtureTeardown.html
+++ b/docs/2.6.1/fixtureTeardown.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.6.1/getStarted.html
+++ b/docs/2.6.1/getStarted.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.6.1/getStarted.html
+++ b/docs/2.6.1/getStarted.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.6.1/getStarted.html
+++ b/docs/2.6.1/getStarted.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.6.1/getStarted.html
+++ b/docs/2.6.1/getStarted.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.6.1/guiCommandLine.html
+++ b/docs/2.6.1/guiCommandLine.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.6.1/guiCommandLine.html
+++ b/docs/2.6.1/guiCommandLine.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.6.1/guiCommandLine.html
+++ b/docs/2.6.1/guiCommandLine.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.6.1/guiCommandLine.html
+++ b/docs/2.6.1/guiCommandLine.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.6.1/identityAsserts.html
+++ b/docs/2.6.1/identityAsserts.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.6.1/identityAsserts.html
+++ b/docs/2.6.1/identityAsserts.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.6.1/identityAsserts.html
+++ b/docs/2.6.1/identityAsserts.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.6.1/identityAsserts.html
+++ b/docs/2.6.1/identityAsserts.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.6.1/ignore.html
+++ b/docs/2.6.1/ignore.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.6.1/ignore.html
+++ b/docs/2.6.1/ignore.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.6.1/ignore.html
+++ b/docs/2.6.1/ignore.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.6.1/ignore.html
+++ b/docs/2.6.1/ignore.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.6.1/installation.html
+++ b/docs/2.6.1/installation.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.6.1/installation.html
+++ b/docs/2.6.1/installation.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.6.1/installation.html
+++ b/docs/2.6.1/installation.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.6.1/installation.html
+++ b/docs/2.6.1/installation.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.6.1/license.html
+++ b/docs/2.6.1/license.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.6.1/license.html
+++ b/docs/2.6.1/license.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.6.1/license.html
+++ b/docs/2.6.1/license.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.6.1/license.html
+++ b/docs/2.6.1/license.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.6.1/listMapper.html
+++ b/docs/2.6.1/listMapper.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.6.1/listMapper.html
+++ b/docs/2.6.1/listMapper.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.6.1/listMapper.html
+++ b/docs/2.6.1/listMapper.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.6.1/listMapper.html
+++ b/docs/2.6.1/listMapper.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.6.1/mainMenu.html
+++ b/docs/2.6.1/mainMenu.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.6.1/mainMenu.html
+++ b/docs/2.6.1/mainMenu.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.6.1/mainMenu.html
+++ b/docs/2.6.1/mainMenu.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.6.1/mainMenu.html
+++ b/docs/2.6.1/mainMenu.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.6.1/maxtime.html
+++ b/docs/2.6.1/maxtime.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.6.1/maxtime.html
+++ b/docs/2.6.1/maxtime.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.6.1/maxtime.html
+++ b/docs/2.6.1/maxtime.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.6.1/maxtime.html
+++ b/docs/2.6.1/maxtime.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.6.1/multiAssembly.html
+++ b/docs/2.6.1/multiAssembly.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.6.1/multiAssembly.html
+++ b/docs/2.6.1/multiAssembly.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.6.1/multiAssembly.html
+++ b/docs/2.6.1/multiAssembly.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.6.1/multiAssembly.html
+++ b/docs/2.6.1/multiAssembly.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.6.1/nunit-agent.html
+++ b/docs/2.6.1/nunit-agent.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.6.1/nunit-agent.html
+++ b/docs/2.6.1/nunit-agent.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.6.1/nunit-agent.html
+++ b/docs/2.6.1/nunit-agent.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.6.1/nunit-agent.html
+++ b/docs/2.6.1/nunit-agent.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.6.1/nunit-console.html
+++ b/docs/2.6.1/nunit-console.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.6.1/nunit-console.html
+++ b/docs/2.6.1/nunit-console.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.6.1/nunit-console.html
+++ b/docs/2.6.1/nunit-console.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.6.1/nunit-console.html
+++ b/docs/2.6.1/nunit-console.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.6.1/nunit-gui.html
+++ b/docs/2.6.1/nunit-gui.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.6.1/nunit-gui.html
+++ b/docs/2.6.1/nunit-gui.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.6.1/nunit-gui.html
+++ b/docs/2.6.1/nunit-gui.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.6.1/nunit-gui.html
+++ b/docs/2.6.1/nunit-gui.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.6.1/nunitAddins.html
+++ b/docs/2.6.1/nunitAddins.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.6.1/nunitAddins.html
+++ b/docs/2.6.1/nunitAddins.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.6.1/nunitAddins.html
+++ b/docs/2.6.1/nunitAddins.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.6.1/nunitAddins.html
+++ b/docs/2.6.1/nunitAddins.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.6.1/pairwise.html
+++ b/docs/2.6.1/pairwise.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.6.1/pairwise.html
+++ b/docs/2.6.1/pairwise.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.6.1/pairwise.html
+++ b/docs/2.6.1/pairwise.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.6.1/pairwise.html
+++ b/docs/2.6.1/pairwise.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.6.1/parameterizedTests.html
+++ b/docs/2.6.1/parameterizedTests.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.6.1/parameterizedTests.html
+++ b/docs/2.6.1/parameterizedTests.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.6.1/parameterizedTests.html
+++ b/docs/2.6.1/parameterizedTests.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.6.1/parameterizedTests.html
+++ b/docs/2.6.1/parameterizedTests.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.6.1/pathConstraints.html
+++ b/docs/2.6.1/pathConstraints.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.6.1/pathConstraints.html
+++ b/docs/2.6.1/pathConstraints.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.6.1/pathConstraints.html
+++ b/docs/2.6.1/pathConstraints.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.6.1/pathConstraints.html
+++ b/docs/2.6.1/pathConstraints.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.6.1/platform.html
+++ b/docs/2.6.1/platform.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.6.1/platform.html
+++ b/docs/2.6.1/platform.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.6.1/platform.html
+++ b/docs/2.6.1/platform.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.6.1/platform.html
+++ b/docs/2.6.1/platform.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.6.1/pnunit.html
+++ b/docs/2.6.1/pnunit.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.6.1/pnunit.html
+++ b/docs/2.6.1/pnunit.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.6.1/pnunit.html
+++ b/docs/2.6.1/pnunit.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.6.1/pnunit.html
+++ b/docs/2.6.1/pnunit.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.6.1/projectEditor.html
+++ b/docs/2.6.1/projectEditor.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.6.1/projectEditor.html
+++ b/docs/2.6.1/projectEditor.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.6.1/projectEditor.html
+++ b/docs/2.6.1/projectEditor.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.6.1/projectEditor.html
+++ b/docs/2.6.1/projectEditor.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.6.1/property.html
+++ b/docs/2.6.1/property.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.6.1/property.html
+++ b/docs/2.6.1/property.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.6.1/property.html
+++ b/docs/2.6.1/property.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.6.1/property.html
+++ b/docs/2.6.1/property.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.6.1/propertyConstraint.html
+++ b/docs/2.6.1/propertyConstraint.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.6.1/propertyConstraint.html
+++ b/docs/2.6.1/propertyConstraint.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.6.1/propertyConstraint.html
+++ b/docs/2.6.1/propertyConstraint.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.6.1/propertyConstraint.html
+++ b/docs/2.6.1/propertyConstraint.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.6.1/quickStart.html
+++ b/docs/2.6.1/quickStart.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.6.1/quickStart.html
+++ b/docs/2.6.1/quickStart.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.6.1/quickStart.html
+++ b/docs/2.6.1/quickStart.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.6.1/quickStart.html
+++ b/docs/2.6.1/quickStart.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.6.1/quickStartSource.html
+++ b/docs/2.6.1/quickStartSource.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.6.1/quickStartSource.html
+++ b/docs/2.6.1/quickStartSource.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.6.1/quickStartSource.html
+++ b/docs/2.6.1/quickStartSource.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.6.1/quickStartSource.html
+++ b/docs/2.6.1/quickStartSource.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.6.1/random.html
+++ b/docs/2.6.1/random.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.6.1/random.html
+++ b/docs/2.6.1/random.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.6.1/random.html
+++ b/docs/2.6.1/random.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.6.1/random.html
+++ b/docs/2.6.1/random.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.6.1/range.html
+++ b/docs/2.6.1/range.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.6.1/range.html
+++ b/docs/2.6.1/range.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.6.1/range.html
+++ b/docs/2.6.1/range.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.6.1/range.html
+++ b/docs/2.6.1/range.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.6.1/releaseBreakdown.html
+++ b/docs/2.6.1/releaseBreakdown.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.6.1/releaseBreakdown.html
+++ b/docs/2.6.1/releaseBreakdown.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.6.1/releaseBreakdown.html
+++ b/docs/2.6.1/releaseBreakdown.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.6.1/releaseBreakdown.html
+++ b/docs/2.6.1/releaseBreakdown.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.6.1/releaseNotes.html
+++ b/docs/2.6.1/releaseNotes.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.6.1/releaseNotes.html
+++ b/docs/2.6.1/releaseNotes.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.6.1/releaseNotes.html
+++ b/docs/2.6.1/releaseNotes.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.6.1/releaseNotes.html
+++ b/docs/2.6.1/releaseNotes.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.6.1/repeat.html
+++ b/docs/2.6.1/repeat.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.6.1/repeat.html
+++ b/docs/2.6.1/repeat.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.6.1/repeat.html
+++ b/docs/2.6.1/repeat.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.6.1/repeat.html
+++ b/docs/2.6.1/repeat.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.6.1/requiredAddin.html
+++ b/docs/2.6.1/requiredAddin.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.6.1/requiredAddin.html
+++ b/docs/2.6.1/requiredAddin.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.6.1/requiredAddin.html
+++ b/docs/2.6.1/requiredAddin.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.6.1/requiredAddin.html
+++ b/docs/2.6.1/requiredAddin.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.6.1/requiresMTA.html
+++ b/docs/2.6.1/requiresMTA.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.6.1/requiresMTA.html
+++ b/docs/2.6.1/requiresMTA.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.6.1/requiresMTA.html
+++ b/docs/2.6.1/requiresMTA.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.6.1/requiresMTA.html
+++ b/docs/2.6.1/requiresMTA.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.6.1/requiresSTA.html
+++ b/docs/2.6.1/requiresSTA.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.6.1/requiresSTA.html
+++ b/docs/2.6.1/requiresSTA.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.6.1/requiresSTA.html
+++ b/docs/2.6.1/requiresSTA.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.6.1/requiresSTA.html
+++ b/docs/2.6.1/requiresSTA.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.6.1/requiresThread.html
+++ b/docs/2.6.1/requiresThread.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.6.1/requiresThread.html
+++ b/docs/2.6.1/requiresThread.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.6.1/requiresThread.html
+++ b/docs/2.6.1/requiresThread.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.6.1/requiresThread.html
+++ b/docs/2.6.1/requiresThread.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.6.1/reusableConstraint.html
+++ b/docs/2.6.1/reusableConstraint.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.6.1/reusableConstraint.html
+++ b/docs/2.6.1/reusableConstraint.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.6.1/reusableConstraint.html
+++ b/docs/2.6.1/reusableConstraint.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.6.1/reusableConstraint.html
+++ b/docs/2.6.1/reusableConstraint.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.6.1/runningTests.html
+++ b/docs/2.6.1/runningTests.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.6.1/runningTests.html
+++ b/docs/2.6.1/runningTests.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.6.1/runningTests.html
+++ b/docs/2.6.1/runningTests.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.6.1/runningTests.html
+++ b/docs/2.6.1/runningTests.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.6.1/runtimeSelection.html
+++ b/docs/2.6.1/runtimeSelection.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.6.1/runtimeSelection.html
+++ b/docs/2.6.1/runtimeSelection.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.6.1/runtimeSelection.html
+++ b/docs/2.6.1/runtimeSelection.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.6.1/runtimeSelection.html
+++ b/docs/2.6.1/runtimeSelection.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.6.1/sameasConstraint.html
+++ b/docs/2.6.1/sameasConstraint.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.6.1/sameasConstraint.html
+++ b/docs/2.6.1/sameasConstraint.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.6.1/sameasConstraint.html
+++ b/docs/2.6.1/sameasConstraint.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.6.1/sameasConstraint.html
+++ b/docs/2.6.1/sameasConstraint.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.6.1/samples.html
+++ b/docs/2.6.1/samples.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.6.1/samples.html
+++ b/docs/2.6.1/samples.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.6.1/samples.html
+++ b/docs/2.6.1/samples.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.6.1/samples.html
+++ b/docs/2.6.1/samples.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.6.1/sequential.html
+++ b/docs/2.6.1/sequential.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.6.1/sequential.html
+++ b/docs/2.6.1/sequential.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.6.1/sequential.html
+++ b/docs/2.6.1/sequential.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.6.1/sequential.html
+++ b/docs/2.6.1/sequential.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.6.1/setCulture.html
+++ b/docs/2.6.1/setCulture.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.6.1/setCulture.html
+++ b/docs/2.6.1/setCulture.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.6.1/setCulture.html
+++ b/docs/2.6.1/setCulture.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.6.1/setCulture.html
+++ b/docs/2.6.1/setCulture.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.6.1/setUICulture.html
+++ b/docs/2.6.1/setUICulture.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.6.1/setUICulture.html
+++ b/docs/2.6.1/setUICulture.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.6.1/setUICulture.html
+++ b/docs/2.6.1/setUICulture.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.6.1/setUICulture.html
+++ b/docs/2.6.1/setUICulture.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.6.1/settingsDialog.html
+++ b/docs/2.6.1/settingsDialog.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.6.1/settingsDialog.html
+++ b/docs/2.6.1/settingsDialog.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.6.1/settingsDialog.html
+++ b/docs/2.6.1/settingsDialog.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.6.1/settingsDialog.html
+++ b/docs/2.6.1/settingsDialog.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.6.1/setup.html
+++ b/docs/2.6.1/setup.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.6.1/setup.html
+++ b/docs/2.6.1/setup.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.6.1/setup.html
+++ b/docs/2.6.1/setup.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.6.1/setup.html
+++ b/docs/2.6.1/setup.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.6.1/setupFixture.html
+++ b/docs/2.6.1/setupFixture.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.6.1/setupFixture.html
+++ b/docs/2.6.1/setupFixture.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.6.1/setupFixture.html
+++ b/docs/2.6.1/setupFixture.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.6.1/setupFixture.html
+++ b/docs/2.6.1/setupFixture.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.6.1/stringAssert.html
+++ b/docs/2.6.1/stringAssert.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.6.1/stringAssert.html
+++ b/docs/2.6.1/stringAssert.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.6.1/stringAssert.html
+++ b/docs/2.6.1/stringAssert.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.6.1/stringAssert.html
+++ b/docs/2.6.1/stringAssert.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.6.1/stringConstraints.html
+++ b/docs/2.6.1/stringConstraints.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.6.1/stringConstraints.html
+++ b/docs/2.6.1/stringConstraints.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.6.1/stringConstraints.html
+++ b/docs/2.6.1/stringConstraints.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.6.1/stringConstraints.html
+++ b/docs/2.6.1/stringConstraints.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.6.1/suite.html
+++ b/docs/2.6.1/suite.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.6.1/suite.html
+++ b/docs/2.6.1/suite.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.6.1/suite.html
+++ b/docs/2.6.1/suite.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.6.1/suite.html
+++ b/docs/2.6.1/suite.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.6.1/suiteBuilders.html
+++ b/docs/2.6.1/suiteBuilders.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.6.1/suiteBuilders.html
+++ b/docs/2.6.1/suiteBuilders.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.6.1/suiteBuilders.html
+++ b/docs/2.6.1/suiteBuilders.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.6.1/suiteBuilders.html
+++ b/docs/2.6.1/suiteBuilders.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.6.1/teardown.html
+++ b/docs/2.6.1/teardown.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.6.1/teardown.html
+++ b/docs/2.6.1/teardown.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.6.1/teardown.html
+++ b/docs/2.6.1/teardown.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.6.1/teardown.html
+++ b/docs/2.6.1/teardown.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.6.1/test.html
+++ b/docs/2.6.1/test.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.6.1/test.html
+++ b/docs/2.6.1/test.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.6.1/test.html
+++ b/docs/2.6.1/test.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.6.1/test.html
+++ b/docs/2.6.1/test.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.6.1/testCase.html
+++ b/docs/2.6.1/testCase.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.6.1/testCase.html
+++ b/docs/2.6.1/testCase.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.6.1/testCase.html
+++ b/docs/2.6.1/testCase.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.6.1/testCase.html
+++ b/docs/2.6.1/testCase.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.6.1/testCaseSource.html
+++ b/docs/2.6.1/testCaseSource.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.6.1/testCaseSource.html
+++ b/docs/2.6.1/testCaseSource.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.6.1/testCaseSource.html
+++ b/docs/2.6.1/testCaseSource.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.6.1/testCaseSource.html
+++ b/docs/2.6.1/testCaseSource.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.6.1/testContext.html
+++ b/docs/2.6.1/testContext.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.6.1/testContext.html
+++ b/docs/2.6.1/testContext.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.6.1/testContext.html
+++ b/docs/2.6.1/testContext.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.6.1/testContext.html
+++ b/docs/2.6.1/testContext.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.6.1/testDecorators.html
+++ b/docs/2.6.1/testDecorators.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.6.1/testDecorators.html
+++ b/docs/2.6.1/testDecorators.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.6.1/testDecorators.html
+++ b/docs/2.6.1/testDecorators.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.6.1/testDecorators.html
+++ b/docs/2.6.1/testDecorators.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.6.1/testFixture.html
+++ b/docs/2.6.1/testFixture.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.6.1/testFixture.html
+++ b/docs/2.6.1/testFixture.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.6.1/testFixture.html
+++ b/docs/2.6.1/testFixture.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.6.1/testFixture.html
+++ b/docs/2.6.1/testFixture.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.6.1/testProperties.html
+++ b/docs/2.6.1/testProperties.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.6.1/testProperties.html
+++ b/docs/2.6.1/testProperties.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.6.1/testProperties.html
+++ b/docs/2.6.1/testProperties.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.6.1/testProperties.html
+++ b/docs/2.6.1/testProperties.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.6.1/testcaseBuilders.html
+++ b/docs/2.6.1/testcaseBuilders.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.6.1/testcaseBuilders.html
+++ b/docs/2.6.1/testcaseBuilders.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.6.1/testcaseBuilders.html
+++ b/docs/2.6.1/testcaseBuilders.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.6.1/testcaseBuilders.html
+++ b/docs/2.6.1/testcaseBuilders.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.6.1/testcaseProviders.html
+++ b/docs/2.6.1/testcaseProviders.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.6.1/testcaseProviders.html
+++ b/docs/2.6.1/testcaseProviders.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.6.1/testcaseProviders.html
+++ b/docs/2.6.1/testcaseProviders.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.6.1/testcaseProviders.html
+++ b/docs/2.6.1/testcaseProviders.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.6.1/theory.html
+++ b/docs/2.6.1/theory.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.6.1/theory.html
+++ b/docs/2.6.1/theory.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.6.1/theory.html
+++ b/docs/2.6.1/theory.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.6.1/theory.html
+++ b/docs/2.6.1/theory.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.6.1/throwsConstraint.html
+++ b/docs/2.6.1/throwsConstraint.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.6.1/throwsConstraint.html
+++ b/docs/2.6.1/throwsConstraint.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.6.1/throwsConstraint.html
+++ b/docs/2.6.1/throwsConstraint.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.6.1/throwsConstraint.html
+++ b/docs/2.6.1/throwsConstraint.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.6.1/timeout.html
+++ b/docs/2.6.1/timeout.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.6.1/timeout.html
+++ b/docs/2.6.1/timeout.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.6.1/timeout.html
+++ b/docs/2.6.1/timeout.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.6.1/timeout.html
+++ b/docs/2.6.1/timeout.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.6.1/typeAsserts.html
+++ b/docs/2.6.1/typeAsserts.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.6.1/typeAsserts.html
+++ b/docs/2.6.1/typeAsserts.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.6.1/typeAsserts.html
+++ b/docs/2.6.1/typeAsserts.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.6.1/typeAsserts.html
+++ b/docs/2.6.1/typeAsserts.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.6.1/typeConstraints.html
+++ b/docs/2.6.1/typeConstraints.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.6.1/typeConstraints.html
+++ b/docs/2.6.1/typeConstraints.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.6.1/typeConstraints.html
+++ b/docs/2.6.1/typeConstraints.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.6.1/typeConstraints.html
+++ b/docs/2.6.1/typeConstraints.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.6.1/upgrade.html
+++ b/docs/2.6.1/upgrade.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.6.1/upgrade.html
+++ b/docs/2.6.1/upgrade.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.6.1/upgrade.html
+++ b/docs/2.6.1/upgrade.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.6.1/upgrade.html
+++ b/docs/2.6.1/upgrade.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.6.1/utilityAsserts.html
+++ b/docs/2.6.1/utilityAsserts.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.6.1/utilityAsserts.html
+++ b/docs/2.6.1/utilityAsserts.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.6.1/utilityAsserts.html
+++ b/docs/2.6.1/utilityAsserts.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.6.1/utilityAsserts.html
+++ b/docs/2.6.1/utilityAsserts.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.6.1/valueSource.html
+++ b/docs/2.6.1/valueSource.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.6.1/valueSource.html
+++ b/docs/2.6.1/valueSource.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.6.1/valueSource.html
+++ b/docs/2.6.1/valueSource.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.6.1/valueSource.html
+++ b/docs/2.6.1/valueSource.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.6.1/values.html
+++ b/docs/2.6.1/values.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.6.1/values.html
+++ b/docs/2.6.1/values.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.6.1/values.html
+++ b/docs/2.6.1/values.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.6.1/values.html
+++ b/docs/2.6.1/values.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.6.1/vsSupport.html
+++ b/docs/2.6.1/vsSupport.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.6.1/vsSupport.html
+++ b/docs/2.6.1/vsSupport.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.6.1/vsSupport.html
+++ b/docs/2.6.1/vsSupport.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.6.1/vsSupport.html
+++ b/docs/2.6.1/vsSupport.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.6.1/writingTests.html
+++ b/docs/2.6.1/writingTests.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.6.1/writingTests.html
+++ b/docs/2.6.1/writingTests.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.6.1/writingTests.html
+++ b/docs/2.6.1/writingTests.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.6.1/writingTests.html
+++ b/docs/2.6.1/writingTests.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.6.2/actionAttributes.html
+++ b/docs/2.6.2/actionAttributes.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.6.2/actionAttributes.html
+++ b/docs/2.6.2/actionAttributes.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.6.2/actionAttributes.html
+++ b/docs/2.6.2/actionAttributes.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.6.2/actionAttributes.html
+++ b/docs/2.6.2/actionAttributes.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.6.2/addinsDialog.html
+++ b/docs/2.6.2/addinsDialog.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.6.2/addinsDialog.html
+++ b/docs/2.6.2/addinsDialog.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.6.2/addinsDialog.html
+++ b/docs/2.6.2/addinsDialog.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.6.2/addinsDialog.html
+++ b/docs/2.6.2/addinsDialog.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.6.2/assemblyIsolation.html
+++ b/docs/2.6.2/assemblyIsolation.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.6.2/assemblyIsolation.html
+++ b/docs/2.6.2/assemblyIsolation.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.6.2/assemblyIsolation.html
+++ b/docs/2.6.2/assemblyIsolation.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.6.2/assemblyIsolation.html
+++ b/docs/2.6.2/assemblyIsolation.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.6.2/assertions.html
+++ b/docs/2.6.2/assertions.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.6.2/assertions.html
+++ b/docs/2.6.2/assertions.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.6.2/assertions.html
+++ b/docs/2.6.2/assertions.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.6.2/assertions.html
+++ b/docs/2.6.2/assertions.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.6.2/attributes.html
+++ b/docs/2.6.2/attributes.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.6.2/attributes.html
+++ b/docs/2.6.2/attributes.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.6.2/attributes.html
+++ b/docs/2.6.2/attributes.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.6.2/attributes.html
+++ b/docs/2.6.2/attributes.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.6.2/category.html
+++ b/docs/2.6.2/category.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.6.2/category.html
+++ b/docs/2.6.2/category.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.6.2/category.html
+++ b/docs/2.6.2/category.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.6.2/category.html
+++ b/docs/2.6.2/category.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.6.2/classicModel.html
+++ b/docs/2.6.2/classicModel.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.6.2/classicModel.html
+++ b/docs/2.6.2/classicModel.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.6.2/classicModel.html
+++ b/docs/2.6.2/classicModel.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.6.2/classicModel.html
+++ b/docs/2.6.2/classicModel.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.6.2/collectionAssert.html
+++ b/docs/2.6.2/collectionAssert.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.6.2/collectionAssert.html
+++ b/docs/2.6.2/collectionAssert.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.6.2/collectionAssert.html
+++ b/docs/2.6.2/collectionAssert.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.6.2/collectionAssert.html
+++ b/docs/2.6.2/collectionAssert.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.6.2/collectionConstraints.html
+++ b/docs/2.6.2/collectionConstraints.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.6.2/collectionConstraints.html
+++ b/docs/2.6.2/collectionConstraints.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.6.2/collectionConstraints.html
+++ b/docs/2.6.2/collectionConstraints.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.6.2/collectionConstraints.html
+++ b/docs/2.6.2/collectionConstraints.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.6.2/combinatorial.html
+++ b/docs/2.6.2/combinatorial.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.6.2/combinatorial.html
+++ b/docs/2.6.2/combinatorial.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.6.2/combinatorial.html
+++ b/docs/2.6.2/combinatorial.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.6.2/combinatorial.html
+++ b/docs/2.6.2/combinatorial.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.6.2/comparisonAsserts.html
+++ b/docs/2.6.2/comparisonAsserts.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.6.2/comparisonAsserts.html
+++ b/docs/2.6.2/comparisonAsserts.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.6.2/comparisonAsserts.html
+++ b/docs/2.6.2/comparisonAsserts.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.6.2/comparisonAsserts.html
+++ b/docs/2.6.2/comparisonAsserts.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.6.2/comparisonConstraints.html
+++ b/docs/2.6.2/comparisonConstraints.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.6.2/comparisonConstraints.html
+++ b/docs/2.6.2/comparisonConstraints.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.6.2/comparisonConstraints.html
+++ b/docs/2.6.2/comparisonConstraints.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.6.2/comparisonConstraints.html
+++ b/docs/2.6.2/comparisonConstraints.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.6.2/compoundConstraints.html
+++ b/docs/2.6.2/compoundConstraints.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.6.2/compoundConstraints.html
+++ b/docs/2.6.2/compoundConstraints.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.6.2/compoundConstraints.html
+++ b/docs/2.6.2/compoundConstraints.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.6.2/compoundConstraints.html
+++ b/docs/2.6.2/compoundConstraints.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.6.2/conditionAsserts.html
+++ b/docs/2.6.2/conditionAsserts.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.6.2/conditionAsserts.html
+++ b/docs/2.6.2/conditionAsserts.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.6.2/conditionAsserts.html
+++ b/docs/2.6.2/conditionAsserts.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.6.2/conditionAsserts.html
+++ b/docs/2.6.2/conditionAsserts.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.6.2/conditionConstraints.html
+++ b/docs/2.6.2/conditionConstraints.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.6.2/conditionConstraints.html
+++ b/docs/2.6.2/conditionConstraints.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.6.2/conditionConstraints.html
+++ b/docs/2.6.2/conditionConstraints.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.6.2/conditionConstraints.html
+++ b/docs/2.6.2/conditionConstraints.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.6.2/configEditor.html
+++ b/docs/2.6.2/configEditor.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.6.2/configEditor.html
+++ b/docs/2.6.2/configEditor.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.6.2/configEditor.html
+++ b/docs/2.6.2/configEditor.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.6.2/configEditor.html
+++ b/docs/2.6.2/configEditor.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.6.2/configFiles.html
+++ b/docs/2.6.2/configFiles.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.6.2/configFiles.html
+++ b/docs/2.6.2/configFiles.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.6.2/configFiles.html
+++ b/docs/2.6.2/configFiles.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.6.2/configFiles.html
+++ b/docs/2.6.2/configFiles.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.6.2/consoleCommandLine.html
+++ b/docs/2.6.2/consoleCommandLine.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.6.2/consoleCommandLine.html
+++ b/docs/2.6.2/consoleCommandLine.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.6.2/consoleCommandLine.html
+++ b/docs/2.6.2/consoleCommandLine.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.6.2/consoleCommandLine.html
+++ b/docs/2.6.2/consoleCommandLine.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.6.2/constraintModel.html
+++ b/docs/2.6.2/constraintModel.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.6.2/constraintModel.html
+++ b/docs/2.6.2/constraintModel.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.6.2/constraintModel.html
+++ b/docs/2.6.2/constraintModel.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.6.2/constraintModel.html
+++ b/docs/2.6.2/constraintModel.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.6.2/contextMenu.html
+++ b/docs/2.6.2/contextMenu.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.6.2/contextMenu.html
+++ b/docs/2.6.2/contextMenu.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.6.2/contextMenu.html
+++ b/docs/2.6.2/contextMenu.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.6.2/contextMenu.html
+++ b/docs/2.6.2/contextMenu.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.6.2/culture.html
+++ b/docs/2.6.2/culture.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.6.2/culture.html
+++ b/docs/2.6.2/culture.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.6.2/culture.html
+++ b/docs/2.6.2/culture.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.6.2/culture.html
+++ b/docs/2.6.2/culture.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.6.2/customConstraints.html
+++ b/docs/2.6.2/customConstraints.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.6.2/customConstraints.html
+++ b/docs/2.6.2/customConstraints.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.6.2/customConstraints.html
+++ b/docs/2.6.2/customConstraints.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.6.2/customConstraints.html
+++ b/docs/2.6.2/customConstraints.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.6.2/datapoint.html
+++ b/docs/2.6.2/datapoint.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.6.2/datapoint.html
+++ b/docs/2.6.2/datapoint.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.6.2/datapoint.html
+++ b/docs/2.6.2/datapoint.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.6.2/datapoint.html
+++ b/docs/2.6.2/datapoint.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.6.2/datapointProviders.html
+++ b/docs/2.6.2/datapointProviders.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.6.2/datapointProviders.html
+++ b/docs/2.6.2/datapointProviders.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.6.2/datapointProviders.html
+++ b/docs/2.6.2/datapointProviders.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.6.2/datapointProviders.html
+++ b/docs/2.6.2/datapointProviders.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.6.2/delayedConstraint.html
+++ b/docs/2.6.2/delayedConstraint.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.6.2/delayedConstraint.html
+++ b/docs/2.6.2/delayedConstraint.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.6.2/delayedConstraint.html
+++ b/docs/2.6.2/delayedConstraint.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.6.2/delayedConstraint.html
+++ b/docs/2.6.2/delayedConstraint.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.6.2/description.html
+++ b/docs/2.6.2/description.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.6.2/description.html
+++ b/docs/2.6.2/description.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.6.2/description.html
+++ b/docs/2.6.2/description.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.6.2/description.html
+++ b/docs/2.6.2/description.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.6.2/directoryAssert.html
+++ b/docs/2.6.2/directoryAssert.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.6.2/directoryAssert.html
+++ b/docs/2.6.2/directoryAssert.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.6.2/directoryAssert.html
+++ b/docs/2.6.2/directoryAssert.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.6.2/directoryAssert.html
+++ b/docs/2.6.2/directoryAssert.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.6.2/docHome.html
+++ b/docs/2.6.2/docHome.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.6.2/docHome.html
+++ b/docs/2.6.2/docHome.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.6.2/docHome.html
+++ b/docs/2.6.2/docHome.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.6.2/docHome.html
+++ b/docs/2.6.2/docHome.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.6.2/equalConstraint.html
+++ b/docs/2.6.2/equalConstraint.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.6.2/equalConstraint.html
+++ b/docs/2.6.2/equalConstraint.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.6.2/equalConstraint.html
+++ b/docs/2.6.2/equalConstraint.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.6.2/equalConstraint.html
+++ b/docs/2.6.2/equalConstraint.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.6.2/equalityAsserts.html
+++ b/docs/2.6.2/equalityAsserts.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.6.2/equalityAsserts.html
+++ b/docs/2.6.2/equalityAsserts.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.6.2/equalityAsserts.html
+++ b/docs/2.6.2/equalityAsserts.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.6.2/equalityAsserts.html
+++ b/docs/2.6.2/equalityAsserts.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.6.2/eventListeners.html
+++ b/docs/2.6.2/eventListeners.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.6.2/eventListeners.html
+++ b/docs/2.6.2/eventListeners.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.6.2/eventListeners.html
+++ b/docs/2.6.2/eventListeners.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.6.2/eventListeners.html
+++ b/docs/2.6.2/eventListeners.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.6.2/exception.html
+++ b/docs/2.6.2/exception.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.6.2/exception.html
+++ b/docs/2.6.2/exception.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.6.2/exception.html
+++ b/docs/2.6.2/exception.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.6.2/exception.html
+++ b/docs/2.6.2/exception.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.6.2/exceptionAsserts.html
+++ b/docs/2.6.2/exceptionAsserts.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.6.2/exceptionAsserts.html
+++ b/docs/2.6.2/exceptionAsserts.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.6.2/exceptionAsserts.html
+++ b/docs/2.6.2/exceptionAsserts.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.6.2/exceptionAsserts.html
+++ b/docs/2.6.2/exceptionAsserts.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.6.2/explicit.html
+++ b/docs/2.6.2/explicit.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.6.2/explicit.html
+++ b/docs/2.6.2/explicit.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.6.2/explicit.html
+++ b/docs/2.6.2/explicit.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.6.2/explicit.html
+++ b/docs/2.6.2/explicit.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.6.2/extensibility.html
+++ b/docs/2.6.2/extensibility.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.6.2/extensibility.html
+++ b/docs/2.6.2/extensibility.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.6.2/extensibility.html
+++ b/docs/2.6.2/extensibility.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.6.2/extensibility.html
+++ b/docs/2.6.2/extensibility.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.6.2/extensionTips.html
+++ b/docs/2.6.2/extensionTips.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.6.2/extensionTips.html
+++ b/docs/2.6.2/extensionTips.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.6.2/extensionTips.html
+++ b/docs/2.6.2/extensionTips.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.6.2/extensionTips.html
+++ b/docs/2.6.2/extensionTips.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.6.2/fileAssert.html
+++ b/docs/2.6.2/fileAssert.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.6.2/fileAssert.html
+++ b/docs/2.6.2/fileAssert.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.6.2/fileAssert.html
+++ b/docs/2.6.2/fileAssert.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.6.2/fileAssert.html
+++ b/docs/2.6.2/fileAssert.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.6.2/fixtureSetup.html
+++ b/docs/2.6.2/fixtureSetup.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.6.2/fixtureSetup.html
+++ b/docs/2.6.2/fixtureSetup.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.6.2/fixtureSetup.html
+++ b/docs/2.6.2/fixtureSetup.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.6.2/fixtureSetup.html
+++ b/docs/2.6.2/fixtureSetup.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.6.2/fixtureTeardown.html
+++ b/docs/2.6.2/fixtureTeardown.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.6.2/fixtureTeardown.html
+++ b/docs/2.6.2/fixtureTeardown.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.6.2/fixtureTeardown.html
+++ b/docs/2.6.2/fixtureTeardown.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.6.2/fixtureTeardown.html
+++ b/docs/2.6.2/fixtureTeardown.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.6.2/getStarted.html
+++ b/docs/2.6.2/getStarted.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.6.2/getStarted.html
+++ b/docs/2.6.2/getStarted.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.6.2/getStarted.html
+++ b/docs/2.6.2/getStarted.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.6.2/getStarted.html
+++ b/docs/2.6.2/getStarted.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.6.2/guiCommandLine.html
+++ b/docs/2.6.2/guiCommandLine.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.6.2/guiCommandLine.html
+++ b/docs/2.6.2/guiCommandLine.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.6.2/guiCommandLine.html
+++ b/docs/2.6.2/guiCommandLine.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.6.2/guiCommandLine.html
+++ b/docs/2.6.2/guiCommandLine.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.6.2/identityAsserts.html
+++ b/docs/2.6.2/identityAsserts.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.6.2/identityAsserts.html
+++ b/docs/2.6.2/identityAsserts.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.6.2/identityAsserts.html
+++ b/docs/2.6.2/identityAsserts.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.6.2/identityAsserts.html
+++ b/docs/2.6.2/identityAsserts.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.6.2/ignore.html
+++ b/docs/2.6.2/ignore.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.6.2/ignore.html
+++ b/docs/2.6.2/ignore.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.6.2/ignore.html
+++ b/docs/2.6.2/ignore.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.6.2/ignore.html
+++ b/docs/2.6.2/ignore.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.6.2/installation.html
+++ b/docs/2.6.2/installation.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.6.2/installation.html
+++ b/docs/2.6.2/installation.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.6.2/installation.html
+++ b/docs/2.6.2/installation.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.6.2/installation.html
+++ b/docs/2.6.2/installation.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.6.2/license.html
+++ b/docs/2.6.2/license.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.6.2/license.html
+++ b/docs/2.6.2/license.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.6.2/license.html
+++ b/docs/2.6.2/license.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.6.2/license.html
+++ b/docs/2.6.2/license.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.6.2/listMapper.html
+++ b/docs/2.6.2/listMapper.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.6.2/listMapper.html
+++ b/docs/2.6.2/listMapper.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.6.2/listMapper.html
+++ b/docs/2.6.2/listMapper.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.6.2/listMapper.html
+++ b/docs/2.6.2/listMapper.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.6.2/mainMenu.html
+++ b/docs/2.6.2/mainMenu.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.6.2/mainMenu.html
+++ b/docs/2.6.2/mainMenu.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.6.2/mainMenu.html
+++ b/docs/2.6.2/mainMenu.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.6.2/mainMenu.html
+++ b/docs/2.6.2/mainMenu.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.6.2/maxtime.html
+++ b/docs/2.6.2/maxtime.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.6.2/maxtime.html
+++ b/docs/2.6.2/maxtime.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.6.2/maxtime.html
+++ b/docs/2.6.2/maxtime.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.6.2/maxtime.html
+++ b/docs/2.6.2/maxtime.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.6.2/multiAssembly.html
+++ b/docs/2.6.2/multiAssembly.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.6.2/multiAssembly.html
+++ b/docs/2.6.2/multiAssembly.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.6.2/multiAssembly.html
+++ b/docs/2.6.2/multiAssembly.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.6.2/multiAssembly.html
+++ b/docs/2.6.2/multiAssembly.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.6.2/nunit-agent.html
+++ b/docs/2.6.2/nunit-agent.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.6.2/nunit-agent.html
+++ b/docs/2.6.2/nunit-agent.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.6.2/nunit-agent.html
+++ b/docs/2.6.2/nunit-agent.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.6.2/nunit-agent.html
+++ b/docs/2.6.2/nunit-agent.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.6.2/nunit-console.html
+++ b/docs/2.6.2/nunit-console.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.6.2/nunit-console.html
+++ b/docs/2.6.2/nunit-console.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.6.2/nunit-console.html
+++ b/docs/2.6.2/nunit-console.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.6.2/nunit-console.html
+++ b/docs/2.6.2/nunit-console.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.6.2/nunit-gui.html
+++ b/docs/2.6.2/nunit-gui.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.6.2/nunit-gui.html
+++ b/docs/2.6.2/nunit-gui.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.6.2/nunit-gui.html
+++ b/docs/2.6.2/nunit-gui.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.6.2/nunit-gui.html
+++ b/docs/2.6.2/nunit-gui.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.6.2/nunitAddins.html
+++ b/docs/2.6.2/nunitAddins.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.6.2/nunitAddins.html
+++ b/docs/2.6.2/nunitAddins.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.6.2/nunitAddins.html
+++ b/docs/2.6.2/nunitAddins.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.6.2/nunitAddins.html
+++ b/docs/2.6.2/nunitAddins.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.6.2/pairwise.html
+++ b/docs/2.6.2/pairwise.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.6.2/pairwise.html
+++ b/docs/2.6.2/pairwise.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.6.2/pairwise.html
+++ b/docs/2.6.2/pairwise.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.6.2/pairwise.html
+++ b/docs/2.6.2/pairwise.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.6.2/parameterizedTests.html
+++ b/docs/2.6.2/parameterizedTests.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.6.2/parameterizedTests.html
+++ b/docs/2.6.2/parameterizedTests.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.6.2/parameterizedTests.html
+++ b/docs/2.6.2/parameterizedTests.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.6.2/parameterizedTests.html
+++ b/docs/2.6.2/parameterizedTests.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.6.2/pathConstraints.html
+++ b/docs/2.6.2/pathConstraints.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.6.2/pathConstraints.html
+++ b/docs/2.6.2/pathConstraints.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.6.2/pathConstraints.html
+++ b/docs/2.6.2/pathConstraints.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.6.2/pathConstraints.html
+++ b/docs/2.6.2/pathConstraints.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.6.2/platform.html
+++ b/docs/2.6.2/platform.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.6.2/platform.html
+++ b/docs/2.6.2/platform.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.6.2/platform.html
+++ b/docs/2.6.2/platform.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.6.2/platform.html
+++ b/docs/2.6.2/platform.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.6.2/pnunit.html
+++ b/docs/2.6.2/pnunit.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.6.2/pnunit.html
+++ b/docs/2.6.2/pnunit.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.6.2/pnunit.html
+++ b/docs/2.6.2/pnunit.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.6.2/pnunit.html
+++ b/docs/2.6.2/pnunit.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.6.2/projectEditor.html
+++ b/docs/2.6.2/projectEditor.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.6.2/projectEditor.html
+++ b/docs/2.6.2/projectEditor.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.6.2/projectEditor.html
+++ b/docs/2.6.2/projectEditor.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.6.2/projectEditor.html
+++ b/docs/2.6.2/projectEditor.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.6.2/property.html
+++ b/docs/2.6.2/property.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.6.2/property.html
+++ b/docs/2.6.2/property.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.6.2/property.html
+++ b/docs/2.6.2/property.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.6.2/property.html
+++ b/docs/2.6.2/property.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.6.2/propertyConstraint.html
+++ b/docs/2.6.2/propertyConstraint.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.6.2/propertyConstraint.html
+++ b/docs/2.6.2/propertyConstraint.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.6.2/propertyConstraint.html
+++ b/docs/2.6.2/propertyConstraint.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.6.2/propertyConstraint.html
+++ b/docs/2.6.2/propertyConstraint.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.6.2/quickStart.html
+++ b/docs/2.6.2/quickStart.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.6.2/quickStart.html
+++ b/docs/2.6.2/quickStart.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.6.2/quickStart.html
+++ b/docs/2.6.2/quickStart.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.6.2/quickStart.html
+++ b/docs/2.6.2/quickStart.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.6.2/quickStartSource.html
+++ b/docs/2.6.2/quickStartSource.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.6.2/quickStartSource.html
+++ b/docs/2.6.2/quickStartSource.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.6.2/quickStartSource.html
+++ b/docs/2.6.2/quickStartSource.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.6.2/quickStartSource.html
+++ b/docs/2.6.2/quickStartSource.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.6.2/random.html
+++ b/docs/2.6.2/random.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.6.2/random.html
+++ b/docs/2.6.2/random.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.6.2/random.html
+++ b/docs/2.6.2/random.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.6.2/random.html
+++ b/docs/2.6.2/random.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.6.2/range.html
+++ b/docs/2.6.2/range.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.6.2/range.html
+++ b/docs/2.6.2/range.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.6.2/range.html
+++ b/docs/2.6.2/range.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.6.2/range.html
+++ b/docs/2.6.2/range.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.6.2/releaseBreakdown.html
+++ b/docs/2.6.2/releaseBreakdown.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.6.2/releaseBreakdown.html
+++ b/docs/2.6.2/releaseBreakdown.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.6.2/releaseBreakdown.html
+++ b/docs/2.6.2/releaseBreakdown.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.6.2/releaseBreakdown.html
+++ b/docs/2.6.2/releaseBreakdown.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.6.2/releaseNotes.html
+++ b/docs/2.6.2/releaseNotes.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.6.2/releaseNotes.html
+++ b/docs/2.6.2/releaseNotes.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.6.2/releaseNotes.html
+++ b/docs/2.6.2/releaseNotes.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.6.2/releaseNotes.html
+++ b/docs/2.6.2/releaseNotes.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.6.2/repeat.html
+++ b/docs/2.6.2/repeat.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.6.2/repeat.html
+++ b/docs/2.6.2/repeat.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.6.2/repeat.html
+++ b/docs/2.6.2/repeat.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.6.2/repeat.html
+++ b/docs/2.6.2/repeat.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.6.2/requiredAddin.html
+++ b/docs/2.6.2/requiredAddin.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.6.2/requiredAddin.html
+++ b/docs/2.6.2/requiredAddin.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.6.2/requiredAddin.html
+++ b/docs/2.6.2/requiredAddin.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.6.2/requiredAddin.html
+++ b/docs/2.6.2/requiredAddin.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.6.2/requiresMTA.html
+++ b/docs/2.6.2/requiresMTA.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.6.2/requiresMTA.html
+++ b/docs/2.6.2/requiresMTA.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.6.2/requiresMTA.html
+++ b/docs/2.6.2/requiresMTA.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.6.2/requiresMTA.html
+++ b/docs/2.6.2/requiresMTA.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.6.2/requiresSTA.html
+++ b/docs/2.6.2/requiresSTA.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.6.2/requiresSTA.html
+++ b/docs/2.6.2/requiresSTA.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.6.2/requiresSTA.html
+++ b/docs/2.6.2/requiresSTA.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.6.2/requiresSTA.html
+++ b/docs/2.6.2/requiresSTA.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.6.2/requiresThread.html
+++ b/docs/2.6.2/requiresThread.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.6.2/requiresThread.html
+++ b/docs/2.6.2/requiresThread.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.6.2/requiresThread.html
+++ b/docs/2.6.2/requiresThread.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.6.2/requiresThread.html
+++ b/docs/2.6.2/requiresThread.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.6.2/reusableConstraint.html
+++ b/docs/2.6.2/reusableConstraint.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.6.2/reusableConstraint.html
+++ b/docs/2.6.2/reusableConstraint.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.6.2/reusableConstraint.html
+++ b/docs/2.6.2/reusableConstraint.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.6.2/reusableConstraint.html
+++ b/docs/2.6.2/reusableConstraint.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.6.2/runningTests.html
+++ b/docs/2.6.2/runningTests.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.6.2/runningTests.html
+++ b/docs/2.6.2/runningTests.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.6.2/runningTests.html
+++ b/docs/2.6.2/runningTests.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.6.2/runningTests.html
+++ b/docs/2.6.2/runningTests.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.6.2/runtimeSelection.html
+++ b/docs/2.6.2/runtimeSelection.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.6.2/runtimeSelection.html
+++ b/docs/2.6.2/runtimeSelection.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.6.2/runtimeSelection.html
+++ b/docs/2.6.2/runtimeSelection.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.6.2/runtimeSelection.html
+++ b/docs/2.6.2/runtimeSelection.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.6.2/sameasConstraint.html
+++ b/docs/2.6.2/sameasConstraint.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.6.2/sameasConstraint.html
+++ b/docs/2.6.2/sameasConstraint.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.6.2/sameasConstraint.html
+++ b/docs/2.6.2/sameasConstraint.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.6.2/sameasConstraint.html
+++ b/docs/2.6.2/sameasConstraint.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.6.2/samples.html
+++ b/docs/2.6.2/samples.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.6.2/samples.html
+++ b/docs/2.6.2/samples.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.6.2/samples.html
+++ b/docs/2.6.2/samples.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.6.2/samples.html
+++ b/docs/2.6.2/samples.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.6.2/sequential.html
+++ b/docs/2.6.2/sequential.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.6.2/sequential.html
+++ b/docs/2.6.2/sequential.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.6.2/sequential.html
+++ b/docs/2.6.2/sequential.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.6.2/sequential.html
+++ b/docs/2.6.2/sequential.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.6.2/setCulture.html
+++ b/docs/2.6.2/setCulture.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.6.2/setCulture.html
+++ b/docs/2.6.2/setCulture.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.6.2/setCulture.html
+++ b/docs/2.6.2/setCulture.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.6.2/setCulture.html
+++ b/docs/2.6.2/setCulture.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.6.2/setUICulture.html
+++ b/docs/2.6.2/setUICulture.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.6.2/setUICulture.html
+++ b/docs/2.6.2/setUICulture.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.6.2/setUICulture.html
+++ b/docs/2.6.2/setUICulture.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.6.2/setUICulture.html
+++ b/docs/2.6.2/setUICulture.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.6.2/settingsDialog.html
+++ b/docs/2.6.2/settingsDialog.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.6.2/settingsDialog.html
+++ b/docs/2.6.2/settingsDialog.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.6.2/settingsDialog.html
+++ b/docs/2.6.2/settingsDialog.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.6.2/settingsDialog.html
+++ b/docs/2.6.2/settingsDialog.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.6.2/setup.html
+++ b/docs/2.6.2/setup.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.6.2/setup.html
+++ b/docs/2.6.2/setup.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.6.2/setup.html
+++ b/docs/2.6.2/setup.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.6.2/setup.html
+++ b/docs/2.6.2/setup.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.6.2/setupFixture.html
+++ b/docs/2.6.2/setupFixture.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.6.2/setupFixture.html
+++ b/docs/2.6.2/setupFixture.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.6.2/setupFixture.html
+++ b/docs/2.6.2/setupFixture.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.6.2/setupFixture.html
+++ b/docs/2.6.2/setupFixture.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.6.2/stringAssert.html
+++ b/docs/2.6.2/stringAssert.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.6.2/stringAssert.html
+++ b/docs/2.6.2/stringAssert.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.6.2/stringAssert.html
+++ b/docs/2.6.2/stringAssert.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.6.2/stringAssert.html
+++ b/docs/2.6.2/stringAssert.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.6.2/stringConstraints.html
+++ b/docs/2.6.2/stringConstraints.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.6.2/stringConstraints.html
+++ b/docs/2.6.2/stringConstraints.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.6.2/stringConstraints.html
+++ b/docs/2.6.2/stringConstraints.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.6.2/stringConstraints.html
+++ b/docs/2.6.2/stringConstraints.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.6.2/suite.html
+++ b/docs/2.6.2/suite.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.6.2/suite.html
+++ b/docs/2.6.2/suite.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.6.2/suite.html
+++ b/docs/2.6.2/suite.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.6.2/suite.html
+++ b/docs/2.6.2/suite.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.6.2/suiteBuilders.html
+++ b/docs/2.6.2/suiteBuilders.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.6.2/suiteBuilders.html
+++ b/docs/2.6.2/suiteBuilders.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.6.2/suiteBuilders.html
+++ b/docs/2.6.2/suiteBuilders.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.6.2/suiteBuilders.html
+++ b/docs/2.6.2/suiteBuilders.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.6.2/teardown.html
+++ b/docs/2.6.2/teardown.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.6.2/teardown.html
+++ b/docs/2.6.2/teardown.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.6.2/teardown.html
+++ b/docs/2.6.2/teardown.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.6.2/teardown.html
+++ b/docs/2.6.2/teardown.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.6.2/test.html
+++ b/docs/2.6.2/test.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.6.2/test.html
+++ b/docs/2.6.2/test.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.6.2/test.html
+++ b/docs/2.6.2/test.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.6.2/test.html
+++ b/docs/2.6.2/test.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.6.2/testCase.html
+++ b/docs/2.6.2/testCase.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.6.2/testCase.html
+++ b/docs/2.6.2/testCase.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.6.2/testCase.html
+++ b/docs/2.6.2/testCase.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.6.2/testCase.html
+++ b/docs/2.6.2/testCase.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.6.2/testCaseSource.html
+++ b/docs/2.6.2/testCaseSource.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.6.2/testCaseSource.html
+++ b/docs/2.6.2/testCaseSource.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.6.2/testCaseSource.html
+++ b/docs/2.6.2/testCaseSource.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.6.2/testCaseSource.html
+++ b/docs/2.6.2/testCaseSource.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.6.2/testContext.html
+++ b/docs/2.6.2/testContext.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.6.2/testContext.html
+++ b/docs/2.6.2/testContext.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.6.2/testContext.html
+++ b/docs/2.6.2/testContext.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.6.2/testContext.html
+++ b/docs/2.6.2/testContext.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.6.2/testDecorators.html
+++ b/docs/2.6.2/testDecorators.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.6.2/testDecorators.html
+++ b/docs/2.6.2/testDecorators.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.6.2/testDecorators.html
+++ b/docs/2.6.2/testDecorators.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.6.2/testDecorators.html
+++ b/docs/2.6.2/testDecorators.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.6.2/testFixture.html
+++ b/docs/2.6.2/testFixture.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.6.2/testFixture.html
+++ b/docs/2.6.2/testFixture.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.6.2/testFixture.html
+++ b/docs/2.6.2/testFixture.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.6.2/testFixture.html
+++ b/docs/2.6.2/testFixture.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.6.2/testProperties.html
+++ b/docs/2.6.2/testProperties.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.6.2/testProperties.html
+++ b/docs/2.6.2/testProperties.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.6.2/testProperties.html
+++ b/docs/2.6.2/testProperties.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.6.2/testProperties.html
+++ b/docs/2.6.2/testProperties.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.6.2/testcaseBuilders.html
+++ b/docs/2.6.2/testcaseBuilders.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.6.2/testcaseBuilders.html
+++ b/docs/2.6.2/testcaseBuilders.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.6.2/testcaseBuilders.html
+++ b/docs/2.6.2/testcaseBuilders.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.6.2/testcaseBuilders.html
+++ b/docs/2.6.2/testcaseBuilders.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.6.2/testcaseProviders.html
+++ b/docs/2.6.2/testcaseProviders.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.6.2/testcaseProviders.html
+++ b/docs/2.6.2/testcaseProviders.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.6.2/testcaseProviders.html
+++ b/docs/2.6.2/testcaseProviders.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.6.2/testcaseProviders.html
+++ b/docs/2.6.2/testcaseProviders.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.6.2/theory.html
+++ b/docs/2.6.2/theory.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.6.2/theory.html
+++ b/docs/2.6.2/theory.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.6.2/theory.html
+++ b/docs/2.6.2/theory.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.6.2/theory.html
+++ b/docs/2.6.2/theory.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.6.2/throwsConstraint.html
+++ b/docs/2.6.2/throwsConstraint.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.6.2/throwsConstraint.html
+++ b/docs/2.6.2/throwsConstraint.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.6.2/throwsConstraint.html
+++ b/docs/2.6.2/throwsConstraint.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.6.2/throwsConstraint.html
+++ b/docs/2.6.2/throwsConstraint.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.6.2/timeout.html
+++ b/docs/2.6.2/timeout.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.6.2/timeout.html
+++ b/docs/2.6.2/timeout.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.6.2/timeout.html
+++ b/docs/2.6.2/timeout.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.6.2/timeout.html
+++ b/docs/2.6.2/timeout.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.6.2/typeAsserts.html
+++ b/docs/2.6.2/typeAsserts.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.6.2/typeAsserts.html
+++ b/docs/2.6.2/typeAsserts.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.6.2/typeAsserts.html
+++ b/docs/2.6.2/typeAsserts.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.6.2/typeAsserts.html
+++ b/docs/2.6.2/typeAsserts.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.6.2/typeConstraints.html
+++ b/docs/2.6.2/typeConstraints.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.6.2/typeConstraints.html
+++ b/docs/2.6.2/typeConstraints.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.6.2/typeConstraints.html
+++ b/docs/2.6.2/typeConstraints.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.6.2/typeConstraints.html
+++ b/docs/2.6.2/typeConstraints.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.6.2/upgrade.html
+++ b/docs/2.6.2/upgrade.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.6.2/upgrade.html
+++ b/docs/2.6.2/upgrade.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.6.2/upgrade.html
+++ b/docs/2.6.2/upgrade.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.6.2/upgrade.html
+++ b/docs/2.6.2/upgrade.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.6.2/utilityAsserts.html
+++ b/docs/2.6.2/utilityAsserts.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.6.2/utilityAsserts.html
+++ b/docs/2.6.2/utilityAsserts.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.6.2/utilityAsserts.html
+++ b/docs/2.6.2/utilityAsserts.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.6.2/utilityAsserts.html
+++ b/docs/2.6.2/utilityAsserts.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.6.2/valueSource.html
+++ b/docs/2.6.2/valueSource.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.6.2/valueSource.html
+++ b/docs/2.6.2/valueSource.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.6.2/valueSource.html
+++ b/docs/2.6.2/valueSource.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.6.2/valueSource.html
+++ b/docs/2.6.2/valueSource.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.6.2/values.html
+++ b/docs/2.6.2/values.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.6.2/values.html
+++ b/docs/2.6.2/values.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.6.2/values.html
+++ b/docs/2.6.2/values.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.6.2/values.html
+++ b/docs/2.6.2/values.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.6.2/vsSupport.html
+++ b/docs/2.6.2/vsSupport.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.6.2/vsSupport.html
+++ b/docs/2.6.2/vsSupport.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.6.2/vsSupport.html
+++ b/docs/2.6.2/vsSupport.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.6.2/vsSupport.html
+++ b/docs/2.6.2/vsSupport.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.6.2/writingTests.html
+++ b/docs/2.6.2/writingTests.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.6.2/writingTests.html
+++ b/docs/2.6.2/writingTests.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.6.2/writingTests.html
+++ b/docs/2.6.2/writingTests.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.6.2/writingTests.html
+++ b/docs/2.6.2/writingTests.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.6.3/actionAttributes.html
+++ b/docs/2.6.3/actionAttributes.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.6.3/actionAttributes.html
+++ b/docs/2.6.3/actionAttributes.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.6.3/actionAttributes.html
+++ b/docs/2.6.3/actionAttributes.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.6.3/actionAttributes.html
+++ b/docs/2.6.3/actionAttributes.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.6.3/addinsDialog.html
+++ b/docs/2.6.3/addinsDialog.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.6.3/addinsDialog.html
+++ b/docs/2.6.3/addinsDialog.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.6.3/addinsDialog.html
+++ b/docs/2.6.3/addinsDialog.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.6.3/addinsDialog.html
+++ b/docs/2.6.3/addinsDialog.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.6.3/assemblyIsolation.html
+++ b/docs/2.6.3/assemblyIsolation.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.6.3/assemblyIsolation.html
+++ b/docs/2.6.3/assemblyIsolation.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.6.3/assemblyIsolation.html
+++ b/docs/2.6.3/assemblyIsolation.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.6.3/assemblyIsolation.html
+++ b/docs/2.6.3/assemblyIsolation.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.6.3/assertions.html
+++ b/docs/2.6.3/assertions.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.6.3/assertions.html
+++ b/docs/2.6.3/assertions.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.6.3/assertions.html
+++ b/docs/2.6.3/assertions.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.6.3/assertions.html
+++ b/docs/2.6.3/assertions.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.6.3/attributes.html
+++ b/docs/2.6.3/attributes.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.6.3/attributes.html
+++ b/docs/2.6.3/attributes.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.6.3/attributes.html
+++ b/docs/2.6.3/attributes.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.6.3/attributes.html
+++ b/docs/2.6.3/attributes.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.6.3/category.html
+++ b/docs/2.6.3/category.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.6.3/category.html
+++ b/docs/2.6.3/category.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.6.3/category.html
+++ b/docs/2.6.3/category.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.6.3/category.html
+++ b/docs/2.6.3/category.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.6.3/classicModel.html
+++ b/docs/2.6.3/classicModel.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.6.3/classicModel.html
+++ b/docs/2.6.3/classicModel.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.6.3/classicModel.html
+++ b/docs/2.6.3/classicModel.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.6.3/classicModel.html
+++ b/docs/2.6.3/classicModel.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.6.3/collectionAssert.html
+++ b/docs/2.6.3/collectionAssert.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.6.3/collectionAssert.html
+++ b/docs/2.6.3/collectionAssert.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.6.3/collectionAssert.html
+++ b/docs/2.6.3/collectionAssert.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.6.3/collectionAssert.html
+++ b/docs/2.6.3/collectionAssert.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.6.3/collectionConstraints.html
+++ b/docs/2.6.3/collectionConstraints.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.6.3/collectionConstraints.html
+++ b/docs/2.6.3/collectionConstraints.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.6.3/collectionConstraints.html
+++ b/docs/2.6.3/collectionConstraints.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.6.3/collectionConstraints.html
+++ b/docs/2.6.3/collectionConstraints.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.6.3/combinatorial.html
+++ b/docs/2.6.3/combinatorial.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.6.3/combinatorial.html
+++ b/docs/2.6.3/combinatorial.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.6.3/combinatorial.html
+++ b/docs/2.6.3/combinatorial.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.6.3/combinatorial.html
+++ b/docs/2.6.3/combinatorial.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.6.3/comparisonAsserts.html
+++ b/docs/2.6.3/comparisonAsserts.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.6.3/comparisonAsserts.html
+++ b/docs/2.6.3/comparisonAsserts.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.6.3/comparisonAsserts.html
+++ b/docs/2.6.3/comparisonAsserts.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.6.3/comparisonAsserts.html
+++ b/docs/2.6.3/comparisonAsserts.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.6.3/comparisonConstraints.html
+++ b/docs/2.6.3/comparisonConstraints.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.6.3/comparisonConstraints.html
+++ b/docs/2.6.3/comparisonConstraints.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.6.3/comparisonConstraints.html
+++ b/docs/2.6.3/comparisonConstraints.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.6.3/comparisonConstraints.html
+++ b/docs/2.6.3/comparisonConstraints.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.6.3/compoundConstraints.html
+++ b/docs/2.6.3/compoundConstraints.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.6.3/compoundConstraints.html
+++ b/docs/2.6.3/compoundConstraints.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.6.3/compoundConstraints.html
+++ b/docs/2.6.3/compoundConstraints.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.6.3/compoundConstraints.html
+++ b/docs/2.6.3/compoundConstraints.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.6.3/conditionAsserts.html
+++ b/docs/2.6.3/conditionAsserts.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.6.3/conditionAsserts.html
+++ b/docs/2.6.3/conditionAsserts.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.6.3/conditionAsserts.html
+++ b/docs/2.6.3/conditionAsserts.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.6.3/conditionAsserts.html
+++ b/docs/2.6.3/conditionAsserts.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.6.3/conditionConstraints.html
+++ b/docs/2.6.3/conditionConstraints.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.6.3/conditionConstraints.html
+++ b/docs/2.6.3/conditionConstraints.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.6.3/conditionConstraints.html
+++ b/docs/2.6.3/conditionConstraints.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.6.3/conditionConstraints.html
+++ b/docs/2.6.3/conditionConstraints.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.6.3/configEditor.html
+++ b/docs/2.6.3/configEditor.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.6.3/configEditor.html
+++ b/docs/2.6.3/configEditor.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.6.3/configEditor.html
+++ b/docs/2.6.3/configEditor.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.6.3/configEditor.html
+++ b/docs/2.6.3/configEditor.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.6.3/configFiles.html
+++ b/docs/2.6.3/configFiles.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.6.3/configFiles.html
+++ b/docs/2.6.3/configFiles.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.6.3/configFiles.html
+++ b/docs/2.6.3/configFiles.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.6.3/configFiles.html
+++ b/docs/2.6.3/configFiles.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.6.3/consoleCommandLine.html
+++ b/docs/2.6.3/consoleCommandLine.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.6.3/consoleCommandLine.html
+++ b/docs/2.6.3/consoleCommandLine.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.6.3/consoleCommandLine.html
+++ b/docs/2.6.3/consoleCommandLine.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.6.3/consoleCommandLine.html
+++ b/docs/2.6.3/consoleCommandLine.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.6.3/constraintModel.html
+++ b/docs/2.6.3/constraintModel.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.6.3/constraintModel.html
+++ b/docs/2.6.3/constraintModel.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.6.3/constraintModel.html
+++ b/docs/2.6.3/constraintModel.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.6.3/constraintModel.html
+++ b/docs/2.6.3/constraintModel.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.6.3/contextMenu.html
+++ b/docs/2.6.3/contextMenu.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.6.3/contextMenu.html
+++ b/docs/2.6.3/contextMenu.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.6.3/contextMenu.html
+++ b/docs/2.6.3/contextMenu.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.6.3/contextMenu.html
+++ b/docs/2.6.3/contextMenu.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.6.3/culture.html
+++ b/docs/2.6.3/culture.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.6.3/culture.html
+++ b/docs/2.6.3/culture.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.6.3/culture.html
+++ b/docs/2.6.3/culture.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.6.3/culture.html
+++ b/docs/2.6.3/culture.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.6.3/customConstraints.html
+++ b/docs/2.6.3/customConstraints.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.6.3/customConstraints.html
+++ b/docs/2.6.3/customConstraints.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.6.3/customConstraints.html
+++ b/docs/2.6.3/customConstraints.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.6.3/customConstraints.html
+++ b/docs/2.6.3/customConstraints.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.6.3/datapoint.html
+++ b/docs/2.6.3/datapoint.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.6.3/datapoint.html
+++ b/docs/2.6.3/datapoint.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.6.3/datapoint.html
+++ b/docs/2.6.3/datapoint.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.6.3/datapoint.html
+++ b/docs/2.6.3/datapoint.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.6.3/datapointProviders.html
+++ b/docs/2.6.3/datapointProviders.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.6.3/datapointProviders.html
+++ b/docs/2.6.3/datapointProviders.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.6.3/datapointProviders.html
+++ b/docs/2.6.3/datapointProviders.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.6.3/datapointProviders.html
+++ b/docs/2.6.3/datapointProviders.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.6.3/delayedConstraint.html
+++ b/docs/2.6.3/delayedConstraint.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.6.3/delayedConstraint.html
+++ b/docs/2.6.3/delayedConstraint.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.6.3/delayedConstraint.html
+++ b/docs/2.6.3/delayedConstraint.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.6.3/delayedConstraint.html
+++ b/docs/2.6.3/delayedConstraint.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.6.3/description.html
+++ b/docs/2.6.3/description.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.6.3/description.html
+++ b/docs/2.6.3/description.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.6.3/description.html
+++ b/docs/2.6.3/description.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.6.3/description.html
+++ b/docs/2.6.3/description.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.6.3/directoryAssert.html
+++ b/docs/2.6.3/directoryAssert.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.6.3/directoryAssert.html
+++ b/docs/2.6.3/directoryAssert.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.6.3/directoryAssert.html
+++ b/docs/2.6.3/directoryAssert.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.6.3/directoryAssert.html
+++ b/docs/2.6.3/directoryAssert.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.6.3/docHome.html
+++ b/docs/2.6.3/docHome.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.6.3/docHome.html
+++ b/docs/2.6.3/docHome.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.6.3/docHome.html
+++ b/docs/2.6.3/docHome.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.6.3/docHome.html
+++ b/docs/2.6.3/docHome.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.6.3/equalConstraint.html
+++ b/docs/2.6.3/equalConstraint.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.6.3/equalConstraint.html
+++ b/docs/2.6.3/equalConstraint.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.6.3/equalConstraint.html
+++ b/docs/2.6.3/equalConstraint.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.6.3/equalConstraint.html
+++ b/docs/2.6.3/equalConstraint.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.6.3/equalityAsserts.html
+++ b/docs/2.6.3/equalityAsserts.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.6.3/equalityAsserts.html
+++ b/docs/2.6.3/equalityAsserts.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.6.3/equalityAsserts.html
+++ b/docs/2.6.3/equalityAsserts.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.6.3/equalityAsserts.html
+++ b/docs/2.6.3/equalityAsserts.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.6.3/eventListeners.html
+++ b/docs/2.6.3/eventListeners.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.6.3/eventListeners.html
+++ b/docs/2.6.3/eventListeners.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.6.3/eventListeners.html
+++ b/docs/2.6.3/eventListeners.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.6.3/eventListeners.html
+++ b/docs/2.6.3/eventListeners.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.6.3/exception.html
+++ b/docs/2.6.3/exception.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.6.3/exception.html
+++ b/docs/2.6.3/exception.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.6.3/exception.html
+++ b/docs/2.6.3/exception.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.6.3/exception.html
+++ b/docs/2.6.3/exception.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.6.3/exceptionAsserts.html
+++ b/docs/2.6.3/exceptionAsserts.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.6.3/exceptionAsserts.html
+++ b/docs/2.6.3/exceptionAsserts.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.6.3/exceptionAsserts.html
+++ b/docs/2.6.3/exceptionAsserts.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.6.3/exceptionAsserts.html
+++ b/docs/2.6.3/exceptionAsserts.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.6.3/explicit.html
+++ b/docs/2.6.3/explicit.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.6.3/explicit.html
+++ b/docs/2.6.3/explicit.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.6.3/explicit.html
+++ b/docs/2.6.3/explicit.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.6.3/explicit.html
+++ b/docs/2.6.3/explicit.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.6.3/extensibility.html
+++ b/docs/2.6.3/extensibility.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.6.3/extensibility.html
+++ b/docs/2.6.3/extensibility.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.6.3/extensibility.html
+++ b/docs/2.6.3/extensibility.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.6.3/extensibility.html
+++ b/docs/2.6.3/extensibility.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.6.3/extensionTips.html
+++ b/docs/2.6.3/extensionTips.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.6.3/extensionTips.html
+++ b/docs/2.6.3/extensionTips.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.6.3/extensionTips.html
+++ b/docs/2.6.3/extensionTips.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.6.3/extensionTips.html
+++ b/docs/2.6.3/extensionTips.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.6.3/fileAssert.html
+++ b/docs/2.6.3/fileAssert.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.6.3/fileAssert.html
+++ b/docs/2.6.3/fileAssert.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.6.3/fileAssert.html
+++ b/docs/2.6.3/fileAssert.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.6.3/fileAssert.html
+++ b/docs/2.6.3/fileAssert.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.6.3/fixtureSetup.html
+++ b/docs/2.6.3/fixtureSetup.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.6.3/fixtureSetup.html
+++ b/docs/2.6.3/fixtureSetup.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.6.3/fixtureSetup.html
+++ b/docs/2.6.3/fixtureSetup.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.6.3/fixtureSetup.html
+++ b/docs/2.6.3/fixtureSetup.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.6.3/fixtureTeardown.html
+++ b/docs/2.6.3/fixtureTeardown.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.6.3/fixtureTeardown.html
+++ b/docs/2.6.3/fixtureTeardown.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.6.3/fixtureTeardown.html
+++ b/docs/2.6.3/fixtureTeardown.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.6.3/fixtureTeardown.html
+++ b/docs/2.6.3/fixtureTeardown.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.6.3/getStarted.html
+++ b/docs/2.6.3/getStarted.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.6.3/getStarted.html
+++ b/docs/2.6.3/getStarted.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.6.3/getStarted.html
+++ b/docs/2.6.3/getStarted.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.6.3/getStarted.html
+++ b/docs/2.6.3/getStarted.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.6.3/guiCommandLine.html
+++ b/docs/2.6.3/guiCommandLine.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.6.3/guiCommandLine.html
+++ b/docs/2.6.3/guiCommandLine.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.6.3/guiCommandLine.html
+++ b/docs/2.6.3/guiCommandLine.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.6.3/guiCommandLine.html
+++ b/docs/2.6.3/guiCommandLine.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.6.3/identityAsserts.html
+++ b/docs/2.6.3/identityAsserts.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.6.3/identityAsserts.html
+++ b/docs/2.6.3/identityAsserts.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.6.3/identityAsserts.html
+++ b/docs/2.6.3/identityAsserts.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.6.3/identityAsserts.html
+++ b/docs/2.6.3/identityAsserts.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.6.3/ignore.html
+++ b/docs/2.6.3/ignore.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.6.3/ignore.html
+++ b/docs/2.6.3/ignore.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.6.3/ignore.html
+++ b/docs/2.6.3/ignore.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.6.3/ignore.html
+++ b/docs/2.6.3/ignore.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.6.3/installation.html
+++ b/docs/2.6.3/installation.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.6.3/installation.html
+++ b/docs/2.6.3/installation.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.6.3/installation.html
+++ b/docs/2.6.3/installation.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.6.3/installation.html
+++ b/docs/2.6.3/installation.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.6.3/license.html
+++ b/docs/2.6.3/license.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.6.3/license.html
+++ b/docs/2.6.3/license.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.6.3/license.html
+++ b/docs/2.6.3/license.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.6.3/license.html
+++ b/docs/2.6.3/license.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.6.3/listMapper.html
+++ b/docs/2.6.3/listMapper.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.6.3/listMapper.html
+++ b/docs/2.6.3/listMapper.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.6.3/listMapper.html
+++ b/docs/2.6.3/listMapper.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.6.3/listMapper.html
+++ b/docs/2.6.3/listMapper.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.6.3/mainMenu.html
+++ b/docs/2.6.3/mainMenu.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.6.3/mainMenu.html
+++ b/docs/2.6.3/mainMenu.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.6.3/mainMenu.html
+++ b/docs/2.6.3/mainMenu.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.6.3/mainMenu.html
+++ b/docs/2.6.3/mainMenu.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.6.3/maxtime.html
+++ b/docs/2.6.3/maxtime.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.6.3/maxtime.html
+++ b/docs/2.6.3/maxtime.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.6.3/maxtime.html
+++ b/docs/2.6.3/maxtime.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.6.3/maxtime.html
+++ b/docs/2.6.3/maxtime.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.6.3/multiAssembly.html
+++ b/docs/2.6.3/multiAssembly.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.6.3/multiAssembly.html
+++ b/docs/2.6.3/multiAssembly.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.6.3/multiAssembly.html
+++ b/docs/2.6.3/multiAssembly.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.6.3/multiAssembly.html
+++ b/docs/2.6.3/multiAssembly.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.6.3/nunit-agent.html
+++ b/docs/2.6.3/nunit-agent.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.6.3/nunit-agent.html
+++ b/docs/2.6.3/nunit-agent.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.6.3/nunit-agent.html
+++ b/docs/2.6.3/nunit-agent.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.6.3/nunit-agent.html
+++ b/docs/2.6.3/nunit-agent.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.6.3/nunit-console.html
+++ b/docs/2.6.3/nunit-console.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.6.3/nunit-console.html
+++ b/docs/2.6.3/nunit-console.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.6.3/nunit-console.html
+++ b/docs/2.6.3/nunit-console.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.6.3/nunit-console.html
+++ b/docs/2.6.3/nunit-console.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.6.3/nunit-gui.html
+++ b/docs/2.6.3/nunit-gui.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.6.3/nunit-gui.html
+++ b/docs/2.6.3/nunit-gui.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.6.3/nunit-gui.html
+++ b/docs/2.6.3/nunit-gui.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.6.3/nunit-gui.html
+++ b/docs/2.6.3/nunit-gui.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.6.3/nunitAddins.html
+++ b/docs/2.6.3/nunitAddins.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.6.3/nunitAddins.html
+++ b/docs/2.6.3/nunitAddins.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.6.3/nunitAddins.html
+++ b/docs/2.6.3/nunitAddins.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.6.3/nunitAddins.html
+++ b/docs/2.6.3/nunitAddins.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.6.3/pairwise.html
+++ b/docs/2.6.3/pairwise.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.6.3/pairwise.html
+++ b/docs/2.6.3/pairwise.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.6.3/pairwise.html
+++ b/docs/2.6.3/pairwise.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.6.3/pairwise.html
+++ b/docs/2.6.3/pairwise.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.6.3/parameterizedTests.html
+++ b/docs/2.6.3/parameterizedTests.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.6.3/parameterizedTests.html
+++ b/docs/2.6.3/parameterizedTests.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.6.3/parameterizedTests.html
+++ b/docs/2.6.3/parameterizedTests.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.6.3/parameterizedTests.html
+++ b/docs/2.6.3/parameterizedTests.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.6.3/pathConstraints.html
+++ b/docs/2.6.3/pathConstraints.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.6.3/pathConstraints.html
+++ b/docs/2.6.3/pathConstraints.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.6.3/pathConstraints.html
+++ b/docs/2.6.3/pathConstraints.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.6.3/pathConstraints.html
+++ b/docs/2.6.3/pathConstraints.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.6.3/platform.html
+++ b/docs/2.6.3/platform.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.6.3/platform.html
+++ b/docs/2.6.3/platform.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.6.3/platform.html
+++ b/docs/2.6.3/platform.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.6.3/platform.html
+++ b/docs/2.6.3/platform.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.6.3/pnunit.html
+++ b/docs/2.6.3/pnunit.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.6.3/pnunit.html
+++ b/docs/2.6.3/pnunit.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.6.3/pnunit.html
+++ b/docs/2.6.3/pnunit.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.6.3/pnunit.html
+++ b/docs/2.6.3/pnunit.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.6.3/projectEditor.html
+++ b/docs/2.6.3/projectEditor.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.6.3/projectEditor.html
+++ b/docs/2.6.3/projectEditor.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.6.3/projectEditor.html
+++ b/docs/2.6.3/projectEditor.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.6.3/projectEditor.html
+++ b/docs/2.6.3/projectEditor.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.6.3/property.html
+++ b/docs/2.6.3/property.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.6.3/property.html
+++ b/docs/2.6.3/property.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.6.3/property.html
+++ b/docs/2.6.3/property.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.6.3/property.html
+++ b/docs/2.6.3/property.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.6.3/propertyConstraint.html
+++ b/docs/2.6.3/propertyConstraint.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.6.3/propertyConstraint.html
+++ b/docs/2.6.3/propertyConstraint.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.6.3/propertyConstraint.html
+++ b/docs/2.6.3/propertyConstraint.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.6.3/propertyConstraint.html
+++ b/docs/2.6.3/propertyConstraint.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.6.3/quickStart.html
+++ b/docs/2.6.3/quickStart.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.6.3/quickStart.html
+++ b/docs/2.6.3/quickStart.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.6.3/quickStart.html
+++ b/docs/2.6.3/quickStart.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.6.3/quickStart.html
+++ b/docs/2.6.3/quickStart.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.6.3/quickStartSource.html
+++ b/docs/2.6.3/quickStartSource.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.6.3/quickStartSource.html
+++ b/docs/2.6.3/quickStartSource.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.6.3/quickStartSource.html
+++ b/docs/2.6.3/quickStartSource.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.6.3/quickStartSource.html
+++ b/docs/2.6.3/quickStartSource.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.6.3/random.html
+++ b/docs/2.6.3/random.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.6.3/random.html
+++ b/docs/2.6.3/random.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.6.3/random.html
+++ b/docs/2.6.3/random.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.6.3/random.html
+++ b/docs/2.6.3/random.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.6.3/range.html
+++ b/docs/2.6.3/range.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.6.3/range.html
+++ b/docs/2.6.3/range.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.6.3/range.html
+++ b/docs/2.6.3/range.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.6.3/range.html
+++ b/docs/2.6.3/range.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.6.3/releaseBreakdown.html
+++ b/docs/2.6.3/releaseBreakdown.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.6.3/releaseBreakdown.html
+++ b/docs/2.6.3/releaseBreakdown.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.6.3/releaseBreakdown.html
+++ b/docs/2.6.3/releaseBreakdown.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.6.3/releaseBreakdown.html
+++ b/docs/2.6.3/releaseBreakdown.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.6.3/releaseNotes.html
+++ b/docs/2.6.3/releaseNotes.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.6.3/releaseNotes.html
+++ b/docs/2.6.3/releaseNotes.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.6.3/releaseNotes.html
+++ b/docs/2.6.3/releaseNotes.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.6.3/releaseNotes.html
+++ b/docs/2.6.3/releaseNotes.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.6.3/repeat.html
+++ b/docs/2.6.3/repeat.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.6.3/repeat.html
+++ b/docs/2.6.3/repeat.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.6.3/repeat.html
+++ b/docs/2.6.3/repeat.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.6.3/repeat.html
+++ b/docs/2.6.3/repeat.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.6.3/requiredAddin.html
+++ b/docs/2.6.3/requiredAddin.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.6.3/requiredAddin.html
+++ b/docs/2.6.3/requiredAddin.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.6.3/requiredAddin.html
+++ b/docs/2.6.3/requiredAddin.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.6.3/requiredAddin.html
+++ b/docs/2.6.3/requiredAddin.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.6.3/requiresMTA.html
+++ b/docs/2.6.3/requiresMTA.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.6.3/requiresMTA.html
+++ b/docs/2.6.3/requiresMTA.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.6.3/requiresMTA.html
+++ b/docs/2.6.3/requiresMTA.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.6.3/requiresMTA.html
+++ b/docs/2.6.3/requiresMTA.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.6.3/requiresSTA.html
+++ b/docs/2.6.3/requiresSTA.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.6.3/requiresSTA.html
+++ b/docs/2.6.3/requiresSTA.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.6.3/requiresSTA.html
+++ b/docs/2.6.3/requiresSTA.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.6.3/requiresSTA.html
+++ b/docs/2.6.3/requiresSTA.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.6.3/requiresThread.html
+++ b/docs/2.6.3/requiresThread.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.6.3/requiresThread.html
+++ b/docs/2.6.3/requiresThread.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.6.3/requiresThread.html
+++ b/docs/2.6.3/requiresThread.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.6.3/requiresThread.html
+++ b/docs/2.6.3/requiresThread.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.6.3/reusableConstraint.html
+++ b/docs/2.6.3/reusableConstraint.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.6.3/reusableConstraint.html
+++ b/docs/2.6.3/reusableConstraint.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.6.3/reusableConstraint.html
+++ b/docs/2.6.3/reusableConstraint.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.6.3/reusableConstraint.html
+++ b/docs/2.6.3/reusableConstraint.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.6.3/runningTests.html
+++ b/docs/2.6.3/runningTests.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.6.3/runningTests.html
+++ b/docs/2.6.3/runningTests.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.6.3/runningTests.html
+++ b/docs/2.6.3/runningTests.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.6.3/runningTests.html
+++ b/docs/2.6.3/runningTests.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.6.3/runtimeSelection.html
+++ b/docs/2.6.3/runtimeSelection.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.6.3/runtimeSelection.html
+++ b/docs/2.6.3/runtimeSelection.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.6.3/runtimeSelection.html
+++ b/docs/2.6.3/runtimeSelection.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.6.3/runtimeSelection.html
+++ b/docs/2.6.3/runtimeSelection.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.6.3/sameasConstraint.html
+++ b/docs/2.6.3/sameasConstraint.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.6.3/sameasConstraint.html
+++ b/docs/2.6.3/sameasConstraint.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.6.3/sameasConstraint.html
+++ b/docs/2.6.3/sameasConstraint.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.6.3/sameasConstraint.html
+++ b/docs/2.6.3/sameasConstraint.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.6.3/samples.html
+++ b/docs/2.6.3/samples.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.6.3/samples.html
+++ b/docs/2.6.3/samples.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.6.3/samples.html
+++ b/docs/2.6.3/samples.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.6.3/samples.html
+++ b/docs/2.6.3/samples.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.6.3/sequential.html
+++ b/docs/2.6.3/sequential.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.6.3/sequential.html
+++ b/docs/2.6.3/sequential.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.6.3/sequential.html
+++ b/docs/2.6.3/sequential.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.6.3/sequential.html
+++ b/docs/2.6.3/sequential.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.6.3/setCulture.html
+++ b/docs/2.6.3/setCulture.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.6.3/setCulture.html
+++ b/docs/2.6.3/setCulture.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.6.3/setCulture.html
+++ b/docs/2.6.3/setCulture.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.6.3/setCulture.html
+++ b/docs/2.6.3/setCulture.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.6.3/setUICulture.html
+++ b/docs/2.6.3/setUICulture.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.6.3/setUICulture.html
+++ b/docs/2.6.3/setUICulture.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.6.3/setUICulture.html
+++ b/docs/2.6.3/setUICulture.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.6.3/setUICulture.html
+++ b/docs/2.6.3/setUICulture.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.6.3/settingsDialog.html
+++ b/docs/2.6.3/settingsDialog.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.6.3/settingsDialog.html
+++ b/docs/2.6.3/settingsDialog.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.6.3/settingsDialog.html
+++ b/docs/2.6.3/settingsDialog.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.6.3/settingsDialog.html
+++ b/docs/2.6.3/settingsDialog.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.6.3/setup.html
+++ b/docs/2.6.3/setup.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.6.3/setup.html
+++ b/docs/2.6.3/setup.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.6.3/setup.html
+++ b/docs/2.6.3/setup.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.6.3/setup.html
+++ b/docs/2.6.3/setup.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.6.3/setupFixture.html
+++ b/docs/2.6.3/setupFixture.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.6.3/setupFixture.html
+++ b/docs/2.6.3/setupFixture.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.6.3/setupFixture.html
+++ b/docs/2.6.3/setupFixture.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.6.3/setupFixture.html
+++ b/docs/2.6.3/setupFixture.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.6.3/stringAssert.html
+++ b/docs/2.6.3/stringAssert.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.6.3/stringAssert.html
+++ b/docs/2.6.3/stringAssert.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.6.3/stringAssert.html
+++ b/docs/2.6.3/stringAssert.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.6.3/stringAssert.html
+++ b/docs/2.6.3/stringAssert.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.6.3/stringConstraints.html
+++ b/docs/2.6.3/stringConstraints.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.6.3/stringConstraints.html
+++ b/docs/2.6.3/stringConstraints.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.6.3/stringConstraints.html
+++ b/docs/2.6.3/stringConstraints.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.6.3/stringConstraints.html
+++ b/docs/2.6.3/stringConstraints.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.6.3/suite.html
+++ b/docs/2.6.3/suite.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.6.3/suite.html
+++ b/docs/2.6.3/suite.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.6.3/suite.html
+++ b/docs/2.6.3/suite.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.6.3/suite.html
+++ b/docs/2.6.3/suite.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.6.3/suiteBuilders.html
+++ b/docs/2.6.3/suiteBuilders.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.6.3/suiteBuilders.html
+++ b/docs/2.6.3/suiteBuilders.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.6.3/suiteBuilders.html
+++ b/docs/2.6.3/suiteBuilders.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.6.3/suiteBuilders.html
+++ b/docs/2.6.3/suiteBuilders.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.6.3/teardown.html
+++ b/docs/2.6.3/teardown.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.6.3/teardown.html
+++ b/docs/2.6.3/teardown.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.6.3/teardown.html
+++ b/docs/2.6.3/teardown.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.6.3/teardown.html
+++ b/docs/2.6.3/teardown.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.6.3/test.html
+++ b/docs/2.6.3/test.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.6.3/test.html
+++ b/docs/2.6.3/test.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.6.3/test.html
+++ b/docs/2.6.3/test.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.6.3/test.html
+++ b/docs/2.6.3/test.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.6.3/testCase.html
+++ b/docs/2.6.3/testCase.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.6.3/testCase.html
+++ b/docs/2.6.3/testCase.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.6.3/testCase.html
+++ b/docs/2.6.3/testCase.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.6.3/testCase.html
+++ b/docs/2.6.3/testCase.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.6.3/testCaseSource.html
+++ b/docs/2.6.3/testCaseSource.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.6.3/testCaseSource.html
+++ b/docs/2.6.3/testCaseSource.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.6.3/testCaseSource.html
+++ b/docs/2.6.3/testCaseSource.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.6.3/testCaseSource.html
+++ b/docs/2.6.3/testCaseSource.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.6.3/testContext.html
+++ b/docs/2.6.3/testContext.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.6.3/testContext.html
+++ b/docs/2.6.3/testContext.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.6.3/testContext.html
+++ b/docs/2.6.3/testContext.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.6.3/testContext.html
+++ b/docs/2.6.3/testContext.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.6.3/testDecorators.html
+++ b/docs/2.6.3/testDecorators.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.6.3/testDecorators.html
+++ b/docs/2.6.3/testDecorators.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.6.3/testDecorators.html
+++ b/docs/2.6.3/testDecorators.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.6.3/testDecorators.html
+++ b/docs/2.6.3/testDecorators.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.6.3/testFixture.html
+++ b/docs/2.6.3/testFixture.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.6.3/testFixture.html
+++ b/docs/2.6.3/testFixture.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.6.3/testFixture.html
+++ b/docs/2.6.3/testFixture.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.6.3/testFixture.html
+++ b/docs/2.6.3/testFixture.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.6.3/testProperties.html
+++ b/docs/2.6.3/testProperties.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.6.3/testProperties.html
+++ b/docs/2.6.3/testProperties.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.6.3/testProperties.html
+++ b/docs/2.6.3/testProperties.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.6.3/testProperties.html
+++ b/docs/2.6.3/testProperties.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.6.3/testcaseBuilders.html
+++ b/docs/2.6.3/testcaseBuilders.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.6.3/testcaseBuilders.html
+++ b/docs/2.6.3/testcaseBuilders.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.6.3/testcaseBuilders.html
+++ b/docs/2.6.3/testcaseBuilders.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.6.3/testcaseBuilders.html
+++ b/docs/2.6.3/testcaseBuilders.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.6.3/testcaseProviders.html
+++ b/docs/2.6.3/testcaseProviders.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.6.3/testcaseProviders.html
+++ b/docs/2.6.3/testcaseProviders.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.6.3/testcaseProviders.html
+++ b/docs/2.6.3/testcaseProviders.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.6.3/testcaseProviders.html
+++ b/docs/2.6.3/testcaseProviders.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.6.3/theory.html
+++ b/docs/2.6.3/theory.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.6.3/theory.html
+++ b/docs/2.6.3/theory.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.6.3/theory.html
+++ b/docs/2.6.3/theory.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.6.3/theory.html
+++ b/docs/2.6.3/theory.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.6.3/throwsConstraint.html
+++ b/docs/2.6.3/throwsConstraint.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.6.3/throwsConstraint.html
+++ b/docs/2.6.3/throwsConstraint.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.6.3/throwsConstraint.html
+++ b/docs/2.6.3/throwsConstraint.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.6.3/throwsConstraint.html
+++ b/docs/2.6.3/throwsConstraint.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.6.3/timeout.html
+++ b/docs/2.6.3/timeout.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.6.3/timeout.html
+++ b/docs/2.6.3/timeout.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.6.3/timeout.html
+++ b/docs/2.6.3/timeout.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.6.3/timeout.html
+++ b/docs/2.6.3/timeout.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.6.3/typeAsserts.html
+++ b/docs/2.6.3/typeAsserts.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.6.3/typeAsserts.html
+++ b/docs/2.6.3/typeAsserts.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.6.3/typeAsserts.html
+++ b/docs/2.6.3/typeAsserts.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.6.3/typeAsserts.html
+++ b/docs/2.6.3/typeAsserts.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.6.3/typeConstraints.html
+++ b/docs/2.6.3/typeConstraints.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.6.3/typeConstraints.html
+++ b/docs/2.6.3/typeConstraints.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.6.3/typeConstraints.html
+++ b/docs/2.6.3/typeConstraints.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.6.3/typeConstraints.html
+++ b/docs/2.6.3/typeConstraints.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.6.3/upgrade.html
+++ b/docs/2.6.3/upgrade.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.6.3/upgrade.html
+++ b/docs/2.6.3/upgrade.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.6.3/upgrade.html
+++ b/docs/2.6.3/upgrade.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.6.3/upgrade.html
+++ b/docs/2.6.3/upgrade.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.6.3/utilityAsserts.html
+++ b/docs/2.6.3/utilityAsserts.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.6.3/utilityAsserts.html
+++ b/docs/2.6.3/utilityAsserts.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.6.3/utilityAsserts.html
+++ b/docs/2.6.3/utilityAsserts.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.6.3/utilityAsserts.html
+++ b/docs/2.6.3/utilityAsserts.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.6.3/valueSource.html
+++ b/docs/2.6.3/valueSource.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.6.3/valueSource.html
+++ b/docs/2.6.3/valueSource.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.6.3/valueSource.html
+++ b/docs/2.6.3/valueSource.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.6.3/valueSource.html
+++ b/docs/2.6.3/valueSource.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.6.3/values.html
+++ b/docs/2.6.3/values.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.6.3/values.html
+++ b/docs/2.6.3/values.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.6.3/values.html
+++ b/docs/2.6.3/values.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.6.3/values.html
+++ b/docs/2.6.3/values.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.6.3/vsSupport.html
+++ b/docs/2.6.3/vsSupport.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.6.3/vsSupport.html
+++ b/docs/2.6.3/vsSupport.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.6.3/vsSupport.html
+++ b/docs/2.6.3/vsSupport.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.6.3/vsSupport.html
+++ b/docs/2.6.3/vsSupport.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.6.3/writingTests.html
+++ b/docs/2.6.3/writingTests.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.6.3/writingTests.html
+++ b/docs/2.6.3/writingTests.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.6.3/writingTests.html
+++ b/docs/2.6.3/writingTests.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.6.3/writingTests.html
+++ b/docs/2.6.3/writingTests.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.6.4/actionAttributes.html
+++ b/docs/2.6.4/actionAttributes.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.6.4/actionAttributes.html
+++ b/docs/2.6.4/actionAttributes.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.6.4/actionAttributes.html
+++ b/docs/2.6.4/actionAttributes.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.6.4/actionAttributes.html
+++ b/docs/2.6.4/actionAttributes.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.6.4/addinsDialog.html
+++ b/docs/2.6.4/addinsDialog.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.6.4/addinsDialog.html
+++ b/docs/2.6.4/addinsDialog.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.6.4/addinsDialog.html
+++ b/docs/2.6.4/addinsDialog.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.6.4/addinsDialog.html
+++ b/docs/2.6.4/addinsDialog.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.6.4/assemblyIsolation.html
+++ b/docs/2.6.4/assemblyIsolation.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.6.4/assemblyIsolation.html
+++ b/docs/2.6.4/assemblyIsolation.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.6.4/assemblyIsolation.html
+++ b/docs/2.6.4/assemblyIsolation.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.6.4/assemblyIsolation.html
+++ b/docs/2.6.4/assemblyIsolation.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.6.4/assertions.html
+++ b/docs/2.6.4/assertions.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.6.4/assertions.html
+++ b/docs/2.6.4/assertions.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.6.4/assertions.html
+++ b/docs/2.6.4/assertions.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.6.4/assertions.html
+++ b/docs/2.6.4/assertions.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.6.4/attributes.html
+++ b/docs/2.6.4/attributes.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.6.4/attributes.html
+++ b/docs/2.6.4/attributes.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.6.4/attributes.html
+++ b/docs/2.6.4/attributes.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.6.4/attributes.html
+++ b/docs/2.6.4/attributes.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.6.4/category.html
+++ b/docs/2.6.4/category.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.6.4/category.html
+++ b/docs/2.6.4/category.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.6.4/category.html
+++ b/docs/2.6.4/category.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.6.4/category.html
+++ b/docs/2.6.4/category.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.6.4/classicModel.html
+++ b/docs/2.6.4/classicModel.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.6.4/classicModel.html
+++ b/docs/2.6.4/classicModel.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.6.4/classicModel.html
+++ b/docs/2.6.4/classicModel.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.6.4/classicModel.html
+++ b/docs/2.6.4/classicModel.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.6.4/collectionAssert.html
+++ b/docs/2.6.4/collectionAssert.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.6.4/collectionAssert.html
+++ b/docs/2.6.4/collectionAssert.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.6.4/collectionAssert.html
+++ b/docs/2.6.4/collectionAssert.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.6.4/collectionAssert.html
+++ b/docs/2.6.4/collectionAssert.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.6.4/collectionConstraints.html
+++ b/docs/2.6.4/collectionConstraints.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.6.4/collectionConstraints.html
+++ b/docs/2.6.4/collectionConstraints.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.6.4/collectionConstraints.html
+++ b/docs/2.6.4/collectionConstraints.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.6.4/collectionConstraints.html
+++ b/docs/2.6.4/collectionConstraints.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.6.4/combinatorial.html
+++ b/docs/2.6.4/combinatorial.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.6.4/combinatorial.html
+++ b/docs/2.6.4/combinatorial.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.6.4/combinatorial.html
+++ b/docs/2.6.4/combinatorial.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.6.4/combinatorial.html
+++ b/docs/2.6.4/combinatorial.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.6.4/comparisonAsserts.html
+++ b/docs/2.6.4/comparisonAsserts.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.6.4/comparisonAsserts.html
+++ b/docs/2.6.4/comparisonAsserts.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.6.4/comparisonAsserts.html
+++ b/docs/2.6.4/comparisonAsserts.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.6.4/comparisonAsserts.html
+++ b/docs/2.6.4/comparisonAsserts.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.6.4/comparisonConstraints.html
+++ b/docs/2.6.4/comparisonConstraints.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.6.4/comparisonConstraints.html
+++ b/docs/2.6.4/comparisonConstraints.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.6.4/comparisonConstraints.html
+++ b/docs/2.6.4/comparisonConstraints.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.6.4/comparisonConstraints.html
+++ b/docs/2.6.4/comparisonConstraints.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.6.4/compoundConstraints.html
+++ b/docs/2.6.4/compoundConstraints.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.6.4/compoundConstraints.html
+++ b/docs/2.6.4/compoundConstraints.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.6.4/compoundConstraints.html
+++ b/docs/2.6.4/compoundConstraints.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.6.4/compoundConstraints.html
+++ b/docs/2.6.4/compoundConstraints.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.6.4/conditionAsserts.html
+++ b/docs/2.6.4/conditionAsserts.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.6.4/conditionAsserts.html
+++ b/docs/2.6.4/conditionAsserts.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.6.4/conditionAsserts.html
+++ b/docs/2.6.4/conditionAsserts.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.6.4/conditionAsserts.html
+++ b/docs/2.6.4/conditionAsserts.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.6.4/conditionConstraints.html
+++ b/docs/2.6.4/conditionConstraints.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.6.4/conditionConstraints.html
+++ b/docs/2.6.4/conditionConstraints.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.6.4/conditionConstraints.html
+++ b/docs/2.6.4/conditionConstraints.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.6.4/conditionConstraints.html
+++ b/docs/2.6.4/conditionConstraints.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.6.4/configEditor.html
+++ b/docs/2.6.4/configEditor.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.6.4/configEditor.html
+++ b/docs/2.6.4/configEditor.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.6.4/configEditor.html
+++ b/docs/2.6.4/configEditor.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.6.4/configEditor.html
+++ b/docs/2.6.4/configEditor.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.6.4/configFiles.html
+++ b/docs/2.6.4/configFiles.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.6.4/configFiles.html
+++ b/docs/2.6.4/configFiles.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.6.4/configFiles.html
+++ b/docs/2.6.4/configFiles.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.6.4/configFiles.html
+++ b/docs/2.6.4/configFiles.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.6.4/consoleCommandLine.html
+++ b/docs/2.6.4/consoleCommandLine.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.6.4/consoleCommandLine.html
+++ b/docs/2.6.4/consoleCommandLine.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.6.4/consoleCommandLine.html
+++ b/docs/2.6.4/consoleCommandLine.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.6.4/consoleCommandLine.html
+++ b/docs/2.6.4/consoleCommandLine.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.6.4/constraintModel.html
+++ b/docs/2.6.4/constraintModel.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.6.4/constraintModel.html
+++ b/docs/2.6.4/constraintModel.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.6.4/constraintModel.html
+++ b/docs/2.6.4/constraintModel.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.6.4/constraintModel.html
+++ b/docs/2.6.4/constraintModel.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.6.4/contextMenu.html
+++ b/docs/2.6.4/contextMenu.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.6.4/contextMenu.html
+++ b/docs/2.6.4/contextMenu.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.6.4/contextMenu.html
+++ b/docs/2.6.4/contextMenu.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.6.4/contextMenu.html
+++ b/docs/2.6.4/contextMenu.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.6.4/culture.html
+++ b/docs/2.6.4/culture.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.6.4/culture.html
+++ b/docs/2.6.4/culture.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.6.4/culture.html
+++ b/docs/2.6.4/culture.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.6.4/culture.html
+++ b/docs/2.6.4/culture.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.6.4/customConstraints.html
+++ b/docs/2.6.4/customConstraints.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.6.4/customConstraints.html
+++ b/docs/2.6.4/customConstraints.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.6.4/customConstraints.html
+++ b/docs/2.6.4/customConstraints.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.6.4/customConstraints.html
+++ b/docs/2.6.4/customConstraints.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.6.4/datapoint.html
+++ b/docs/2.6.4/datapoint.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.6.4/datapoint.html
+++ b/docs/2.6.4/datapoint.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.6.4/datapoint.html
+++ b/docs/2.6.4/datapoint.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.6.4/datapoint.html
+++ b/docs/2.6.4/datapoint.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.6.4/datapointProviders.html
+++ b/docs/2.6.4/datapointProviders.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.6.4/datapointProviders.html
+++ b/docs/2.6.4/datapointProviders.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.6.4/datapointProviders.html
+++ b/docs/2.6.4/datapointProviders.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.6.4/datapointProviders.html
+++ b/docs/2.6.4/datapointProviders.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.6.4/delayedConstraint.html
+++ b/docs/2.6.4/delayedConstraint.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.6.4/delayedConstraint.html
+++ b/docs/2.6.4/delayedConstraint.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.6.4/delayedConstraint.html
+++ b/docs/2.6.4/delayedConstraint.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.6.4/delayedConstraint.html
+++ b/docs/2.6.4/delayedConstraint.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.6.4/description.html
+++ b/docs/2.6.4/description.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.6.4/description.html
+++ b/docs/2.6.4/description.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.6.4/description.html
+++ b/docs/2.6.4/description.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.6.4/description.html
+++ b/docs/2.6.4/description.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.6.4/directoryAssert.html
+++ b/docs/2.6.4/directoryAssert.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.6.4/directoryAssert.html
+++ b/docs/2.6.4/directoryAssert.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.6.4/directoryAssert.html
+++ b/docs/2.6.4/directoryAssert.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.6.4/directoryAssert.html
+++ b/docs/2.6.4/directoryAssert.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.6.4/docHome.html
+++ b/docs/2.6.4/docHome.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.6.4/docHome.html
+++ b/docs/2.6.4/docHome.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.6.4/docHome.html
+++ b/docs/2.6.4/docHome.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.6.4/docHome.html
+++ b/docs/2.6.4/docHome.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.6.4/equalConstraint.html
+++ b/docs/2.6.4/equalConstraint.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.6.4/equalConstraint.html
+++ b/docs/2.6.4/equalConstraint.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.6.4/equalConstraint.html
+++ b/docs/2.6.4/equalConstraint.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.6.4/equalConstraint.html
+++ b/docs/2.6.4/equalConstraint.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.6.4/equalityAsserts.html
+++ b/docs/2.6.4/equalityAsserts.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.6.4/equalityAsserts.html
+++ b/docs/2.6.4/equalityAsserts.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.6.4/equalityAsserts.html
+++ b/docs/2.6.4/equalityAsserts.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.6.4/equalityAsserts.html
+++ b/docs/2.6.4/equalityAsserts.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.6.4/eventListeners.html
+++ b/docs/2.6.4/eventListeners.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.6.4/eventListeners.html
+++ b/docs/2.6.4/eventListeners.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.6.4/eventListeners.html
+++ b/docs/2.6.4/eventListeners.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.6.4/eventListeners.html
+++ b/docs/2.6.4/eventListeners.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.6.4/exception.html
+++ b/docs/2.6.4/exception.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.6.4/exception.html
+++ b/docs/2.6.4/exception.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.6.4/exception.html
+++ b/docs/2.6.4/exception.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.6.4/exception.html
+++ b/docs/2.6.4/exception.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.6.4/exceptionAsserts.html
+++ b/docs/2.6.4/exceptionAsserts.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.6.4/exceptionAsserts.html
+++ b/docs/2.6.4/exceptionAsserts.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.6.4/exceptionAsserts.html
+++ b/docs/2.6.4/exceptionAsserts.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.6.4/exceptionAsserts.html
+++ b/docs/2.6.4/exceptionAsserts.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.6.4/explicit.html
+++ b/docs/2.6.4/explicit.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.6.4/explicit.html
+++ b/docs/2.6.4/explicit.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.6.4/explicit.html
+++ b/docs/2.6.4/explicit.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.6.4/explicit.html
+++ b/docs/2.6.4/explicit.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.6.4/extensibility.html
+++ b/docs/2.6.4/extensibility.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.6.4/extensibility.html
+++ b/docs/2.6.4/extensibility.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.6.4/extensibility.html
+++ b/docs/2.6.4/extensibility.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.6.4/extensibility.html
+++ b/docs/2.6.4/extensibility.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.6.4/extensionTips.html
+++ b/docs/2.6.4/extensionTips.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.6.4/extensionTips.html
+++ b/docs/2.6.4/extensionTips.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.6.4/extensionTips.html
+++ b/docs/2.6.4/extensionTips.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.6.4/extensionTips.html
+++ b/docs/2.6.4/extensionTips.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.6.4/fileAssert.html
+++ b/docs/2.6.4/fileAssert.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.6.4/fileAssert.html
+++ b/docs/2.6.4/fileAssert.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.6.4/fileAssert.html
+++ b/docs/2.6.4/fileAssert.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.6.4/fileAssert.html
+++ b/docs/2.6.4/fileAssert.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.6.4/fixtureSetup.html
+++ b/docs/2.6.4/fixtureSetup.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.6.4/fixtureSetup.html
+++ b/docs/2.6.4/fixtureSetup.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.6.4/fixtureSetup.html
+++ b/docs/2.6.4/fixtureSetup.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.6.4/fixtureSetup.html
+++ b/docs/2.6.4/fixtureSetup.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.6.4/fixtureTeardown.html
+++ b/docs/2.6.4/fixtureTeardown.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.6.4/fixtureTeardown.html
+++ b/docs/2.6.4/fixtureTeardown.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.6.4/fixtureTeardown.html
+++ b/docs/2.6.4/fixtureTeardown.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.6.4/fixtureTeardown.html
+++ b/docs/2.6.4/fixtureTeardown.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.6.4/getStarted.html
+++ b/docs/2.6.4/getStarted.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.6.4/getStarted.html
+++ b/docs/2.6.4/getStarted.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.6.4/getStarted.html
+++ b/docs/2.6.4/getStarted.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.6.4/getStarted.html
+++ b/docs/2.6.4/getStarted.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.6.4/guiCommandLine.html
+++ b/docs/2.6.4/guiCommandLine.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.6.4/guiCommandLine.html
+++ b/docs/2.6.4/guiCommandLine.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.6.4/guiCommandLine.html
+++ b/docs/2.6.4/guiCommandLine.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.6.4/guiCommandLine.html
+++ b/docs/2.6.4/guiCommandLine.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.6.4/identityAsserts.html
+++ b/docs/2.6.4/identityAsserts.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.6.4/identityAsserts.html
+++ b/docs/2.6.4/identityAsserts.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.6.4/identityAsserts.html
+++ b/docs/2.6.4/identityAsserts.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.6.4/identityAsserts.html
+++ b/docs/2.6.4/identityAsserts.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.6.4/ignore.html
+++ b/docs/2.6.4/ignore.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.6.4/ignore.html
+++ b/docs/2.6.4/ignore.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.6.4/ignore.html
+++ b/docs/2.6.4/ignore.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.6.4/ignore.html
+++ b/docs/2.6.4/ignore.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.6.4/installation.html
+++ b/docs/2.6.4/installation.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.6.4/installation.html
+++ b/docs/2.6.4/installation.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.6.4/installation.html
+++ b/docs/2.6.4/installation.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.6.4/installation.html
+++ b/docs/2.6.4/installation.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.6.4/license.html
+++ b/docs/2.6.4/license.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.6.4/license.html
+++ b/docs/2.6.4/license.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.6.4/license.html
+++ b/docs/2.6.4/license.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.6.4/license.html
+++ b/docs/2.6.4/license.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.6.4/listMapper.html
+++ b/docs/2.6.4/listMapper.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.6.4/listMapper.html
+++ b/docs/2.6.4/listMapper.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.6.4/listMapper.html
+++ b/docs/2.6.4/listMapper.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.6.4/listMapper.html
+++ b/docs/2.6.4/listMapper.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.6.4/mainMenu.html
+++ b/docs/2.6.4/mainMenu.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.6.4/mainMenu.html
+++ b/docs/2.6.4/mainMenu.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.6.4/mainMenu.html
+++ b/docs/2.6.4/mainMenu.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.6.4/mainMenu.html
+++ b/docs/2.6.4/mainMenu.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.6.4/maxtime.html
+++ b/docs/2.6.4/maxtime.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.6.4/maxtime.html
+++ b/docs/2.6.4/maxtime.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.6.4/maxtime.html
+++ b/docs/2.6.4/maxtime.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.6.4/maxtime.html
+++ b/docs/2.6.4/maxtime.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.6.4/multiAssembly.html
+++ b/docs/2.6.4/multiAssembly.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.6.4/multiAssembly.html
+++ b/docs/2.6.4/multiAssembly.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.6.4/multiAssembly.html
+++ b/docs/2.6.4/multiAssembly.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.6.4/multiAssembly.html
+++ b/docs/2.6.4/multiAssembly.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.6.4/nunit-agent.html
+++ b/docs/2.6.4/nunit-agent.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.6.4/nunit-agent.html
+++ b/docs/2.6.4/nunit-agent.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.6.4/nunit-agent.html
+++ b/docs/2.6.4/nunit-agent.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.6.4/nunit-agent.html
+++ b/docs/2.6.4/nunit-agent.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.6.4/nunit-console.html
+++ b/docs/2.6.4/nunit-console.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.6.4/nunit-console.html
+++ b/docs/2.6.4/nunit-console.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.6.4/nunit-console.html
+++ b/docs/2.6.4/nunit-console.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.6.4/nunit-console.html
+++ b/docs/2.6.4/nunit-console.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.6.4/nunit-gui.html
+++ b/docs/2.6.4/nunit-gui.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.6.4/nunit-gui.html
+++ b/docs/2.6.4/nunit-gui.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.6.4/nunit-gui.html
+++ b/docs/2.6.4/nunit-gui.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.6.4/nunit-gui.html
+++ b/docs/2.6.4/nunit-gui.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.6.4/nunitAddins.html
+++ b/docs/2.6.4/nunitAddins.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.6.4/nunitAddins.html
+++ b/docs/2.6.4/nunitAddins.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.6.4/nunitAddins.html
+++ b/docs/2.6.4/nunitAddins.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.6.4/nunitAddins.html
+++ b/docs/2.6.4/nunitAddins.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.6.4/pairwise.html
+++ b/docs/2.6.4/pairwise.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.6.4/pairwise.html
+++ b/docs/2.6.4/pairwise.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.6.4/pairwise.html
+++ b/docs/2.6.4/pairwise.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.6.4/pairwise.html
+++ b/docs/2.6.4/pairwise.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.6.4/parameterizedTests.html
+++ b/docs/2.6.4/parameterizedTests.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.6.4/parameterizedTests.html
+++ b/docs/2.6.4/parameterizedTests.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.6.4/parameterizedTests.html
+++ b/docs/2.6.4/parameterizedTests.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.6.4/parameterizedTests.html
+++ b/docs/2.6.4/parameterizedTests.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.6.4/pathConstraints.html
+++ b/docs/2.6.4/pathConstraints.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.6.4/pathConstraints.html
+++ b/docs/2.6.4/pathConstraints.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.6.4/pathConstraints.html
+++ b/docs/2.6.4/pathConstraints.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.6.4/pathConstraints.html
+++ b/docs/2.6.4/pathConstraints.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.6.4/platform.html
+++ b/docs/2.6.4/platform.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.6.4/platform.html
+++ b/docs/2.6.4/platform.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.6.4/platform.html
+++ b/docs/2.6.4/platform.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.6.4/platform.html
+++ b/docs/2.6.4/platform.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.6.4/pnunit.html
+++ b/docs/2.6.4/pnunit.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.6.4/pnunit.html
+++ b/docs/2.6.4/pnunit.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.6.4/pnunit.html
+++ b/docs/2.6.4/pnunit.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.6.4/pnunit.html
+++ b/docs/2.6.4/pnunit.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.6.4/projectEditor.html
+++ b/docs/2.6.4/projectEditor.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.6.4/projectEditor.html
+++ b/docs/2.6.4/projectEditor.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.6.4/projectEditor.html
+++ b/docs/2.6.4/projectEditor.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.6.4/projectEditor.html
+++ b/docs/2.6.4/projectEditor.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.6.4/property.html
+++ b/docs/2.6.4/property.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.6.4/property.html
+++ b/docs/2.6.4/property.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.6.4/property.html
+++ b/docs/2.6.4/property.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.6.4/property.html
+++ b/docs/2.6.4/property.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.6.4/propertyConstraint.html
+++ b/docs/2.6.4/propertyConstraint.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.6.4/propertyConstraint.html
+++ b/docs/2.6.4/propertyConstraint.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.6.4/propertyConstraint.html
+++ b/docs/2.6.4/propertyConstraint.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.6.4/propertyConstraint.html
+++ b/docs/2.6.4/propertyConstraint.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.6.4/quickStart.html
+++ b/docs/2.6.4/quickStart.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.6.4/quickStart.html
+++ b/docs/2.6.4/quickStart.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.6.4/quickStart.html
+++ b/docs/2.6.4/quickStart.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.6.4/quickStart.html
+++ b/docs/2.6.4/quickStart.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.6.4/quickStartSource.html
+++ b/docs/2.6.4/quickStartSource.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.6.4/quickStartSource.html
+++ b/docs/2.6.4/quickStartSource.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.6.4/quickStartSource.html
+++ b/docs/2.6.4/quickStartSource.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.6.4/quickStartSource.html
+++ b/docs/2.6.4/quickStartSource.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.6.4/random.html
+++ b/docs/2.6.4/random.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.6.4/random.html
+++ b/docs/2.6.4/random.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.6.4/random.html
+++ b/docs/2.6.4/random.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.6.4/random.html
+++ b/docs/2.6.4/random.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.6.4/range.html
+++ b/docs/2.6.4/range.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.6.4/range.html
+++ b/docs/2.6.4/range.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.6.4/range.html
+++ b/docs/2.6.4/range.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.6.4/range.html
+++ b/docs/2.6.4/range.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.6.4/releaseBreakdown.html
+++ b/docs/2.6.4/releaseBreakdown.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.6.4/releaseBreakdown.html
+++ b/docs/2.6.4/releaseBreakdown.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.6.4/releaseBreakdown.html
+++ b/docs/2.6.4/releaseBreakdown.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.6.4/releaseBreakdown.html
+++ b/docs/2.6.4/releaseBreakdown.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.6.4/releaseNotes.html
+++ b/docs/2.6.4/releaseNotes.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.6.4/releaseNotes.html
+++ b/docs/2.6.4/releaseNotes.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.6.4/releaseNotes.html
+++ b/docs/2.6.4/releaseNotes.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.6.4/releaseNotes.html
+++ b/docs/2.6.4/releaseNotes.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.6.4/repeat.html
+++ b/docs/2.6.4/repeat.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.6.4/repeat.html
+++ b/docs/2.6.4/repeat.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.6.4/repeat.html
+++ b/docs/2.6.4/repeat.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.6.4/repeat.html
+++ b/docs/2.6.4/repeat.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.6.4/requiredAddin.html
+++ b/docs/2.6.4/requiredAddin.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.6.4/requiredAddin.html
+++ b/docs/2.6.4/requiredAddin.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.6.4/requiredAddin.html
+++ b/docs/2.6.4/requiredAddin.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.6.4/requiredAddin.html
+++ b/docs/2.6.4/requiredAddin.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.6.4/requiresMTA.html
+++ b/docs/2.6.4/requiresMTA.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.6.4/requiresMTA.html
+++ b/docs/2.6.4/requiresMTA.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.6.4/requiresMTA.html
+++ b/docs/2.6.4/requiresMTA.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.6.4/requiresMTA.html
+++ b/docs/2.6.4/requiresMTA.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.6.4/requiresSTA.html
+++ b/docs/2.6.4/requiresSTA.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.6.4/requiresSTA.html
+++ b/docs/2.6.4/requiresSTA.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.6.4/requiresSTA.html
+++ b/docs/2.6.4/requiresSTA.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.6.4/requiresSTA.html
+++ b/docs/2.6.4/requiresSTA.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.6.4/requiresThread.html
+++ b/docs/2.6.4/requiresThread.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.6.4/requiresThread.html
+++ b/docs/2.6.4/requiresThread.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.6.4/requiresThread.html
+++ b/docs/2.6.4/requiresThread.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.6.4/requiresThread.html
+++ b/docs/2.6.4/requiresThread.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.6.4/reusableConstraint.html
+++ b/docs/2.6.4/reusableConstraint.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.6.4/reusableConstraint.html
+++ b/docs/2.6.4/reusableConstraint.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.6.4/reusableConstraint.html
+++ b/docs/2.6.4/reusableConstraint.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.6.4/reusableConstraint.html
+++ b/docs/2.6.4/reusableConstraint.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.6.4/runningTests.html
+++ b/docs/2.6.4/runningTests.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.6.4/runningTests.html
+++ b/docs/2.6.4/runningTests.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.6.4/runningTests.html
+++ b/docs/2.6.4/runningTests.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.6.4/runningTests.html
+++ b/docs/2.6.4/runningTests.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.6.4/runtimeSelection.html
+++ b/docs/2.6.4/runtimeSelection.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.6.4/runtimeSelection.html
+++ b/docs/2.6.4/runtimeSelection.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.6.4/runtimeSelection.html
+++ b/docs/2.6.4/runtimeSelection.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.6.4/runtimeSelection.html
+++ b/docs/2.6.4/runtimeSelection.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.6.4/sameasConstraint.html
+++ b/docs/2.6.4/sameasConstraint.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.6.4/sameasConstraint.html
+++ b/docs/2.6.4/sameasConstraint.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.6.4/sameasConstraint.html
+++ b/docs/2.6.4/sameasConstraint.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.6.4/sameasConstraint.html
+++ b/docs/2.6.4/sameasConstraint.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.6.4/samples.html
+++ b/docs/2.6.4/samples.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.6.4/samples.html
+++ b/docs/2.6.4/samples.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.6.4/samples.html
+++ b/docs/2.6.4/samples.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.6.4/samples.html
+++ b/docs/2.6.4/samples.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.6.4/sequential.html
+++ b/docs/2.6.4/sequential.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.6.4/sequential.html
+++ b/docs/2.6.4/sequential.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.6.4/sequential.html
+++ b/docs/2.6.4/sequential.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.6.4/sequential.html
+++ b/docs/2.6.4/sequential.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.6.4/setCulture.html
+++ b/docs/2.6.4/setCulture.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.6.4/setCulture.html
+++ b/docs/2.6.4/setCulture.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.6.4/setCulture.html
+++ b/docs/2.6.4/setCulture.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.6.4/setCulture.html
+++ b/docs/2.6.4/setCulture.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.6.4/setUICulture.html
+++ b/docs/2.6.4/setUICulture.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.6.4/setUICulture.html
+++ b/docs/2.6.4/setUICulture.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.6.4/setUICulture.html
+++ b/docs/2.6.4/setUICulture.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.6.4/setUICulture.html
+++ b/docs/2.6.4/setUICulture.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.6.4/settingsDialog.html
+++ b/docs/2.6.4/settingsDialog.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.6.4/settingsDialog.html
+++ b/docs/2.6.4/settingsDialog.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.6.4/settingsDialog.html
+++ b/docs/2.6.4/settingsDialog.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.6.4/settingsDialog.html
+++ b/docs/2.6.4/settingsDialog.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.6.4/setup.html
+++ b/docs/2.6.4/setup.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.6.4/setup.html
+++ b/docs/2.6.4/setup.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.6.4/setup.html
+++ b/docs/2.6.4/setup.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.6.4/setup.html
+++ b/docs/2.6.4/setup.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.6.4/setupFixture.html
+++ b/docs/2.6.4/setupFixture.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.6.4/setupFixture.html
+++ b/docs/2.6.4/setupFixture.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.6.4/setupFixture.html
+++ b/docs/2.6.4/setupFixture.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.6.4/setupFixture.html
+++ b/docs/2.6.4/setupFixture.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.6.4/stringAssert.html
+++ b/docs/2.6.4/stringAssert.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.6.4/stringAssert.html
+++ b/docs/2.6.4/stringAssert.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.6.4/stringAssert.html
+++ b/docs/2.6.4/stringAssert.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.6.4/stringAssert.html
+++ b/docs/2.6.4/stringAssert.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.6.4/stringConstraints.html
+++ b/docs/2.6.4/stringConstraints.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.6.4/stringConstraints.html
+++ b/docs/2.6.4/stringConstraints.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.6.4/stringConstraints.html
+++ b/docs/2.6.4/stringConstraints.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.6.4/stringConstraints.html
+++ b/docs/2.6.4/stringConstraints.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.6.4/suite.html
+++ b/docs/2.6.4/suite.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.6.4/suite.html
+++ b/docs/2.6.4/suite.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.6.4/suite.html
+++ b/docs/2.6.4/suite.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.6.4/suite.html
+++ b/docs/2.6.4/suite.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.6.4/suiteBuilders.html
+++ b/docs/2.6.4/suiteBuilders.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.6.4/suiteBuilders.html
+++ b/docs/2.6.4/suiteBuilders.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.6.4/suiteBuilders.html
+++ b/docs/2.6.4/suiteBuilders.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.6.4/suiteBuilders.html
+++ b/docs/2.6.4/suiteBuilders.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.6.4/teardown.html
+++ b/docs/2.6.4/teardown.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.6.4/teardown.html
+++ b/docs/2.6.4/teardown.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.6.4/teardown.html
+++ b/docs/2.6.4/teardown.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.6.4/teardown.html
+++ b/docs/2.6.4/teardown.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.6.4/test.html
+++ b/docs/2.6.4/test.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.6.4/test.html
+++ b/docs/2.6.4/test.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.6.4/test.html
+++ b/docs/2.6.4/test.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.6.4/test.html
+++ b/docs/2.6.4/test.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.6.4/testCase.html
+++ b/docs/2.6.4/testCase.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.6.4/testCase.html
+++ b/docs/2.6.4/testCase.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.6.4/testCase.html
+++ b/docs/2.6.4/testCase.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.6.4/testCase.html
+++ b/docs/2.6.4/testCase.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.6.4/testCaseSource.html
+++ b/docs/2.6.4/testCaseSource.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.6.4/testCaseSource.html
+++ b/docs/2.6.4/testCaseSource.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.6.4/testCaseSource.html
+++ b/docs/2.6.4/testCaseSource.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.6.4/testCaseSource.html
+++ b/docs/2.6.4/testCaseSource.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.6.4/testContext.html
+++ b/docs/2.6.4/testContext.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.6.4/testContext.html
+++ b/docs/2.6.4/testContext.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.6.4/testContext.html
+++ b/docs/2.6.4/testContext.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.6.4/testContext.html
+++ b/docs/2.6.4/testContext.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.6.4/testDecorators.html
+++ b/docs/2.6.4/testDecorators.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.6.4/testDecorators.html
+++ b/docs/2.6.4/testDecorators.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.6.4/testDecorators.html
+++ b/docs/2.6.4/testDecorators.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.6.4/testDecorators.html
+++ b/docs/2.6.4/testDecorators.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.6.4/testFixture.html
+++ b/docs/2.6.4/testFixture.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.6.4/testFixture.html
+++ b/docs/2.6.4/testFixture.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.6.4/testFixture.html
+++ b/docs/2.6.4/testFixture.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.6.4/testFixture.html
+++ b/docs/2.6.4/testFixture.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.6.4/testProperties.html
+++ b/docs/2.6.4/testProperties.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.6.4/testProperties.html
+++ b/docs/2.6.4/testProperties.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.6.4/testProperties.html
+++ b/docs/2.6.4/testProperties.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.6.4/testProperties.html
+++ b/docs/2.6.4/testProperties.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.6.4/testcaseBuilders.html
+++ b/docs/2.6.4/testcaseBuilders.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.6.4/testcaseBuilders.html
+++ b/docs/2.6.4/testcaseBuilders.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.6.4/testcaseBuilders.html
+++ b/docs/2.6.4/testcaseBuilders.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.6.4/testcaseBuilders.html
+++ b/docs/2.6.4/testcaseBuilders.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.6.4/testcaseProviders.html
+++ b/docs/2.6.4/testcaseProviders.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.6.4/testcaseProviders.html
+++ b/docs/2.6.4/testcaseProviders.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.6.4/testcaseProviders.html
+++ b/docs/2.6.4/testcaseProviders.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.6.4/testcaseProviders.html
+++ b/docs/2.6.4/testcaseProviders.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.6.4/theory.html
+++ b/docs/2.6.4/theory.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.6.4/theory.html
+++ b/docs/2.6.4/theory.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.6.4/theory.html
+++ b/docs/2.6.4/theory.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.6.4/theory.html
+++ b/docs/2.6.4/theory.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.6.4/throwsConstraint.html
+++ b/docs/2.6.4/throwsConstraint.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.6.4/throwsConstraint.html
+++ b/docs/2.6.4/throwsConstraint.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.6.4/throwsConstraint.html
+++ b/docs/2.6.4/throwsConstraint.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.6.4/throwsConstraint.html
+++ b/docs/2.6.4/throwsConstraint.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.6.4/timeout.html
+++ b/docs/2.6.4/timeout.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.6.4/timeout.html
+++ b/docs/2.6.4/timeout.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.6.4/timeout.html
+++ b/docs/2.6.4/timeout.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.6.4/timeout.html
+++ b/docs/2.6.4/timeout.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.6.4/typeAsserts.html
+++ b/docs/2.6.4/typeAsserts.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.6.4/typeAsserts.html
+++ b/docs/2.6.4/typeAsserts.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.6.4/typeAsserts.html
+++ b/docs/2.6.4/typeAsserts.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.6.4/typeAsserts.html
+++ b/docs/2.6.4/typeAsserts.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.6.4/typeConstraints.html
+++ b/docs/2.6.4/typeConstraints.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.6.4/typeConstraints.html
+++ b/docs/2.6.4/typeConstraints.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.6.4/typeConstraints.html
+++ b/docs/2.6.4/typeConstraints.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.6.4/typeConstraints.html
+++ b/docs/2.6.4/typeConstraints.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.6.4/upgrade.html
+++ b/docs/2.6.4/upgrade.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.6.4/upgrade.html
+++ b/docs/2.6.4/upgrade.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.6.4/upgrade.html
+++ b/docs/2.6.4/upgrade.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.6.4/upgrade.html
+++ b/docs/2.6.4/upgrade.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.6.4/utilityAsserts.html
+++ b/docs/2.6.4/utilityAsserts.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.6.4/utilityAsserts.html
+++ b/docs/2.6.4/utilityAsserts.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.6.4/utilityAsserts.html
+++ b/docs/2.6.4/utilityAsserts.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.6.4/utilityAsserts.html
+++ b/docs/2.6.4/utilityAsserts.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.6.4/valueSource.html
+++ b/docs/2.6.4/valueSource.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.6.4/valueSource.html
+++ b/docs/2.6.4/valueSource.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.6.4/valueSource.html
+++ b/docs/2.6.4/valueSource.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.6.4/valueSource.html
+++ b/docs/2.6.4/valueSource.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.6.4/values.html
+++ b/docs/2.6.4/values.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.6.4/values.html
+++ b/docs/2.6.4/values.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.6.4/values.html
+++ b/docs/2.6.4/values.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.6.4/values.html
+++ b/docs/2.6.4/values.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.6.4/vsSupport.html
+++ b/docs/2.6.4/vsSupport.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.6.4/vsSupport.html
+++ b/docs/2.6.4/vsSupport.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.6.4/vsSupport.html
+++ b/docs/2.6.4/vsSupport.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.6.4/vsSupport.html
+++ b/docs/2.6.4/vsSupport.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.6.4/writingTests.html
+++ b/docs/2.6.4/writingTests.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.6.4/writingTests.html
+++ b/docs/2.6.4/writingTests.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.6.4/writingTests.html
+++ b/docs/2.6.4/writingTests.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.6.4/writingTests.html
+++ b/docs/2.6.4/writingTests.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.6/actionAttributes.html
+++ b/docs/2.6/actionAttributes.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.6/actionAttributes.html
+++ b/docs/2.6/actionAttributes.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.6/actionAttributes.html
+++ b/docs/2.6/actionAttributes.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.6/actionAttributes.html
+++ b/docs/2.6/actionAttributes.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.6/addinsDialog.html
+++ b/docs/2.6/addinsDialog.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.6/addinsDialog.html
+++ b/docs/2.6/addinsDialog.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.6/addinsDialog.html
+++ b/docs/2.6/addinsDialog.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.6/addinsDialog.html
+++ b/docs/2.6/addinsDialog.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.6/assemblyIsolation.html
+++ b/docs/2.6/assemblyIsolation.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.6/assemblyIsolation.html
+++ b/docs/2.6/assemblyIsolation.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.6/assemblyIsolation.html
+++ b/docs/2.6/assemblyIsolation.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.6/assemblyIsolation.html
+++ b/docs/2.6/assemblyIsolation.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.6/assertions.html
+++ b/docs/2.6/assertions.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.6/assertions.html
+++ b/docs/2.6/assertions.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.6/assertions.html
+++ b/docs/2.6/assertions.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.6/assertions.html
+++ b/docs/2.6/assertions.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.6/attributes.html
+++ b/docs/2.6/attributes.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.6/attributes.html
+++ b/docs/2.6/attributes.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.6/attributes.html
+++ b/docs/2.6/attributes.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.6/attributes.html
+++ b/docs/2.6/attributes.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.6/category.html
+++ b/docs/2.6/category.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.6/category.html
+++ b/docs/2.6/category.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.6/category.html
+++ b/docs/2.6/category.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.6/category.html
+++ b/docs/2.6/category.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.6/collectionAssert.html
+++ b/docs/2.6/collectionAssert.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.6/collectionAssert.html
+++ b/docs/2.6/collectionAssert.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.6/collectionAssert.html
+++ b/docs/2.6/collectionAssert.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.6/collectionAssert.html
+++ b/docs/2.6/collectionAssert.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.6/collectionConstraints.html
+++ b/docs/2.6/collectionConstraints.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.6/collectionConstraints.html
+++ b/docs/2.6/collectionConstraints.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.6/collectionConstraints.html
+++ b/docs/2.6/collectionConstraints.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.6/collectionConstraints.html
+++ b/docs/2.6/collectionConstraints.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.6/combinatorial.html
+++ b/docs/2.6/combinatorial.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.6/combinatorial.html
+++ b/docs/2.6/combinatorial.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.6/combinatorial.html
+++ b/docs/2.6/combinatorial.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.6/combinatorial.html
+++ b/docs/2.6/combinatorial.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.6/comparisonAsserts.html
+++ b/docs/2.6/comparisonAsserts.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.6/comparisonAsserts.html
+++ b/docs/2.6/comparisonAsserts.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.6/comparisonAsserts.html
+++ b/docs/2.6/comparisonAsserts.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.6/comparisonAsserts.html
+++ b/docs/2.6/comparisonAsserts.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.6/comparisonConstraints.html
+++ b/docs/2.6/comparisonConstraints.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.6/comparisonConstraints.html
+++ b/docs/2.6/comparisonConstraints.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.6/comparisonConstraints.html
+++ b/docs/2.6/comparisonConstraints.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.6/comparisonConstraints.html
+++ b/docs/2.6/comparisonConstraints.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.6/compoundConstraints.html
+++ b/docs/2.6/compoundConstraints.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.6/compoundConstraints.html
+++ b/docs/2.6/compoundConstraints.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.6/compoundConstraints.html
+++ b/docs/2.6/compoundConstraints.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.6/compoundConstraints.html
+++ b/docs/2.6/compoundConstraints.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.6/conditionAsserts.html
+++ b/docs/2.6/conditionAsserts.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.6/conditionAsserts.html
+++ b/docs/2.6/conditionAsserts.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.6/conditionAsserts.html
+++ b/docs/2.6/conditionAsserts.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.6/conditionAsserts.html
+++ b/docs/2.6/conditionAsserts.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.6/conditionConstraints.html
+++ b/docs/2.6/conditionConstraints.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.6/conditionConstraints.html
+++ b/docs/2.6/conditionConstraints.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.6/conditionConstraints.html
+++ b/docs/2.6/conditionConstraints.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.6/conditionConstraints.html
+++ b/docs/2.6/conditionConstraints.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.6/configEditor.html
+++ b/docs/2.6/configEditor.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.6/configEditor.html
+++ b/docs/2.6/configEditor.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.6/configEditor.html
+++ b/docs/2.6/configEditor.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.6/configEditor.html
+++ b/docs/2.6/configEditor.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.6/configFiles.html
+++ b/docs/2.6/configFiles.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.6/configFiles.html
+++ b/docs/2.6/configFiles.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.6/configFiles.html
+++ b/docs/2.6/configFiles.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.6/configFiles.html
+++ b/docs/2.6/configFiles.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.6/consoleCommandLine.html
+++ b/docs/2.6/consoleCommandLine.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.6/consoleCommandLine.html
+++ b/docs/2.6/consoleCommandLine.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.6/consoleCommandLine.html
+++ b/docs/2.6/consoleCommandLine.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.6/consoleCommandLine.html
+++ b/docs/2.6/consoleCommandLine.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.6/constraintModel.html
+++ b/docs/2.6/constraintModel.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.6/constraintModel.html
+++ b/docs/2.6/constraintModel.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.6/constraintModel.html
+++ b/docs/2.6/constraintModel.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.6/constraintModel.html
+++ b/docs/2.6/constraintModel.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.6/contextMenu.html
+++ b/docs/2.6/contextMenu.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.6/contextMenu.html
+++ b/docs/2.6/contextMenu.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.6/contextMenu.html
+++ b/docs/2.6/contextMenu.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.6/contextMenu.html
+++ b/docs/2.6/contextMenu.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.6/culture.html
+++ b/docs/2.6/culture.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.6/culture.html
+++ b/docs/2.6/culture.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.6/culture.html
+++ b/docs/2.6/culture.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.6/culture.html
+++ b/docs/2.6/culture.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.6/customConstraints.html
+++ b/docs/2.6/customConstraints.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.6/customConstraints.html
+++ b/docs/2.6/customConstraints.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.6/customConstraints.html
+++ b/docs/2.6/customConstraints.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.6/customConstraints.html
+++ b/docs/2.6/customConstraints.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.6/datapoint.html
+++ b/docs/2.6/datapoint.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.6/datapoint.html
+++ b/docs/2.6/datapoint.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.6/datapoint.html
+++ b/docs/2.6/datapoint.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.6/datapoint.html
+++ b/docs/2.6/datapoint.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.6/datapointProviders.html
+++ b/docs/2.6/datapointProviders.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.6/datapointProviders.html
+++ b/docs/2.6/datapointProviders.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.6/datapointProviders.html
+++ b/docs/2.6/datapointProviders.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.6/datapointProviders.html
+++ b/docs/2.6/datapointProviders.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.6/delayedConstraint.html
+++ b/docs/2.6/delayedConstraint.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.6/delayedConstraint.html
+++ b/docs/2.6/delayedConstraint.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.6/delayedConstraint.html
+++ b/docs/2.6/delayedConstraint.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.6/delayedConstraint.html
+++ b/docs/2.6/delayedConstraint.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.6/description.html
+++ b/docs/2.6/description.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.6/description.html
+++ b/docs/2.6/description.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.6/description.html
+++ b/docs/2.6/description.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.6/description.html
+++ b/docs/2.6/description.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.6/directoryAssert.html
+++ b/docs/2.6/directoryAssert.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.6/directoryAssert.html
+++ b/docs/2.6/directoryAssert.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.6/directoryAssert.html
+++ b/docs/2.6/directoryAssert.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.6/directoryAssert.html
+++ b/docs/2.6/directoryAssert.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.6/docHome.html
+++ b/docs/2.6/docHome.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.6/docHome.html
+++ b/docs/2.6/docHome.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.6/docHome.html
+++ b/docs/2.6/docHome.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.6/docHome.html
+++ b/docs/2.6/docHome.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.6/equalConstraint.html
+++ b/docs/2.6/equalConstraint.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.6/equalConstraint.html
+++ b/docs/2.6/equalConstraint.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.6/equalConstraint.html
+++ b/docs/2.6/equalConstraint.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.6/equalConstraint.html
+++ b/docs/2.6/equalConstraint.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.6/equalityAsserts.html
+++ b/docs/2.6/equalityAsserts.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.6/equalityAsserts.html
+++ b/docs/2.6/equalityAsserts.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.6/equalityAsserts.html
+++ b/docs/2.6/equalityAsserts.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.6/equalityAsserts.html
+++ b/docs/2.6/equalityAsserts.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.6/eventListeners.html
+++ b/docs/2.6/eventListeners.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.6/eventListeners.html
+++ b/docs/2.6/eventListeners.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.6/eventListeners.html
+++ b/docs/2.6/eventListeners.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.6/eventListeners.html
+++ b/docs/2.6/eventListeners.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.6/exception.html
+++ b/docs/2.6/exception.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.6/exception.html
+++ b/docs/2.6/exception.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.6/exception.html
+++ b/docs/2.6/exception.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.6/exception.html
+++ b/docs/2.6/exception.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.6/exceptionAsserts.html
+++ b/docs/2.6/exceptionAsserts.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.6/exceptionAsserts.html
+++ b/docs/2.6/exceptionAsserts.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.6/exceptionAsserts.html
+++ b/docs/2.6/exceptionAsserts.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.6/exceptionAsserts.html
+++ b/docs/2.6/exceptionAsserts.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.6/explicit.html
+++ b/docs/2.6/explicit.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.6/explicit.html
+++ b/docs/2.6/explicit.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.6/explicit.html
+++ b/docs/2.6/explicit.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.6/explicit.html
+++ b/docs/2.6/explicit.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.6/extensibility.html
+++ b/docs/2.6/extensibility.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.6/extensibility.html
+++ b/docs/2.6/extensibility.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.6/extensibility.html
+++ b/docs/2.6/extensibility.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.6/extensibility.html
+++ b/docs/2.6/extensibility.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.6/extensionTips.html
+++ b/docs/2.6/extensionTips.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.6/extensionTips.html
+++ b/docs/2.6/extensionTips.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.6/extensionTips.html
+++ b/docs/2.6/extensionTips.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.6/extensionTips.html
+++ b/docs/2.6/extensionTips.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.6/fileAssert.html
+++ b/docs/2.6/fileAssert.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.6/fileAssert.html
+++ b/docs/2.6/fileAssert.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.6/fileAssert.html
+++ b/docs/2.6/fileAssert.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.6/fileAssert.html
+++ b/docs/2.6/fileAssert.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.6/fixtureSetup.html
+++ b/docs/2.6/fixtureSetup.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.6/fixtureSetup.html
+++ b/docs/2.6/fixtureSetup.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.6/fixtureSetup.html
+++ b/docs/2.6/fixtureSetup.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.6/fixtureSetup.html
+++ b/docs/2.6/fixtureSetup.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.6/fixtureTeardown.html
+++ b/docs/2.6/fixtureTeardown.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.6/fixtureTeardown.html
+++ b/docs/2.6/fixtureTeardown.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.6/fixtureTeardown.html
+++ b/docs/2.6/fixtureTeardown.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.6/fixtureTeardown.html
+++ b/docs/2.6/fixtureTeardown.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.6/getStarted.html
+++ b/docs/2.6/getStarted.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.6/getStarted.html
+++ b/docs/2.6/getStarted.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.6/getStarted.html
+++ b/docs/2.6/getStarted.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.6/getStarted.html
+++ b/docs/2.6/getStarted.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.6/guiCommandLine.html
+++ b/docs/2.6/guiCommandLine.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.6/guiCommandLine.html
+++ b/docs/2.6/guiCommandLine.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.6/guiCommandLine.html
+++ b/docs/2.6/guiCommandLine.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.6/guiCommandLine.html
+++ b/docs/2.6/guiCommandLine.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.6/identityAsserts.html
+++ b/docs/2.6/identityAsserts.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.6/identityAsserts.html
+++ b/docs/2.6/identityAsserts.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.6/identityAsserts.html
+++ b/docs/2.6/identityAsserts.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.6/identityAsserts.html
+++ b/docs/2.6/identityAsserts.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.6/ignore.html
+++ b/docs/2.6/ignore.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.6/ignore.html
+++ b/docs/2.6/ignore.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.6/ignore.html
+++ b/docs/2.6/ignore.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.6/ignore.html
+++ b/docs/2.6/ignore.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.6/installation.html
+++ b/docs/2.6/installation.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.6/installation.html
+++ b/docs/2.6/installation.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.6/installation.html
+++ b/docs/2.6/installation.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.6/installation.html
+++ b/docs/2.6/installation.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.6/license.html
+++ b/docs/2.6/license.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.6/license.html
+++ b/docs/2.6/license.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.6/license.html
+++ b/docs/2.6/license.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.6/license.html
+++ b/docs/2.6/license.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.6/listMapper.html
+++ b/docs/2.6/listMapper.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.6/listMapper.html
+++ b/docs/2.6/listMapper.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.6/listMapper.html
+++ b/docs/2.6/listMapper.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.6/listMapper.html
+++ b/docs/2.6/listMapper.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.6/mainMenu.html
+++ b/docs/2.6/mainMenu.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.6/mainMenu.html
+++ b/docs/2.6/mainMenu.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.6/mainMenu.html
+++ b/docs/2.6/mainMenu.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.6/mainMenu.html
+++ b/docs/2.6/mainMenu.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.6/maxtime.html
+++ b/docs/2.6/maxtime.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.6/maxtime.html
+++ b/docs/2.6/maxtime.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.6/maxtime.html
+++ b/docs/2.6/maxtime.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.6/maxtime.html
+++ b/docs/2.6/maxtime.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.6/multiAssembly.html
+++ b/docs/2.6/multiAssembly.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.6/multiAssembly.html
+++ b/docs/2.6/multiAssembly.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.6/multiAssembly.html
+++ b/docs/2.6/multiAssembly.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.6/multiAssembly.html
+++ b/docs/2.6/multiAssembly.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.6/nunit-agent.html
+++ b/docs/2.6/nunit-agent.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.6/nunit-agent.html
+++ b/docs/2.6/nunit-agent.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.6/nunit-agent.html
+++ b/docs/2.6/nunit-agent.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.6/nunit-agent.html
+++ b/docs/2.6/nunit-agent.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.6/nunit-console.html
+++ b/docs/2.6/nunit-console.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.6/nunit-console.html
+++ b/docs/2.6/nunit-console.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.6/nunit-console.html
+++ b/docs/2.6/nunit-console.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.6/nunit-console.html
+++ b/docs/2.6/nunit-console.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.6/nunit-gui.html
+++ b/docs/2.6/nunit-gui.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.6/nunit-gui.html
+++ b/docs/2.6/nunit-gui.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.6/nunit-gui.html
+++ b/docs/2.6/nunit-gui.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.6/nunit-gui.html
+++ b/docs/2.6/nunit-gui.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.6/nunitAddins.html
+++ b/docs/2.6/nunitAddins.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.6/nunitAddins.html
+++ b/docs/2.6/nunitAddins.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.6/nunitAddins.html
+++ b/docs/2.6/nunitAddins.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.6/nunitAddins.html
+++ b/docs/2.6/nunitAddins.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.6/pairwise.html
+++ b/docs/2.6/pairwise.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.6/pairwise.html
+++ b/docs/2.6/pairwise.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.6/pairwise.html
+++ b/docs/2.6/pairwise.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.6/pairwise.html
+++ b/docs/2.6/pairwise.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.6/parameterizedTests.html
+++ b/docs/2.6/parameterizedTests.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.6/parameterizedTests.html
+++ b/docs/2.6/parameterizedTests.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.6/parameterizedTests.html
+++ b/docs/2.6/parameterizedTests.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.6/parameterizedTests.html
+++ b/docs/2.6/parameterizedTests.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.6/pathConstraints.html
+++ b/docs/2.6/pathConstraints.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.6/pathConstraints.html
+++ b/docs/2.6/pathConstraints.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.6/pathConstraints.html
+++ b/docs/2.6/pathConstraints.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.6/pathConstraints.html
+++ b/docs/2.6/pathConstraints.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.6/platform.html
+++ b/docs/2.6/platform.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.6/platform.html
+++ b/docs/2.6/platform.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.6/platform.html
+++ b/docs/2.6/platform.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.6/platform.html
+++ b/docs/2.6/platform.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.6/pnunit.html
+++ b/docs/2.6/pnunit.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.6/pnunit.html
+++ b/docs/2.6/pnunit.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.6/pnunit.html
+++ b/docs/2.6/pnunit.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.6/pnunit.html
+++ b/docs/2.6/pnunit.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.6/projectEditor.html
+++ b/docs/2.6/projectEditor.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.6/projectEditor.html
+++ b/docs/2.6/projectEditor.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.6/projectEditor.html
+++ b/docs/2.6/projectEditor.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.6/projectEditor.html
+++ b/docs/2.6/projectEditor.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.6/property.html
+++ b/docs/2.6/property.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.6/property.html
+++ b/docs/2.6/property.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.6/property.html
+++ b/docs/2.6/property.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.6/property.html
+++ b/docs/2.6/property.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.6/propertyConstraint.html
+++ b/docs/2.6/propertyConstraint.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.6/propertyConstraint.html
+++ b/docs/2.6/propertyConstraint.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.6/propertyConstraint.html
+++ b/docs/2.6/propertyConstraint.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.6/propertyConstraint.html
+++ b/docs/2.6/propertyConstraint.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.6/quickStart.html
+++ b/docs/2.6/quickStart.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.6/quickStart.html
+++ b/docs/2.6/quickStart.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.6/quickStart.html
+++ b/docs/2.6/quickStart.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.6/quickStart.html
+++ b/docs/2.6/quickStart.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.6/quickStartSource.html
+++ b/docs/2.6/quickStartSource.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.6/quickStartSource.html
+++ b/docs/2.6/quickStartSource.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.6/quickStartSource.html
+++ b/docs/2.6/quickStartSource.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.6/quickStartSource.html
+++ b/docs/2.6/quickStartSource.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.6/random.html
+++ b/docs/2.6/random.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.6/random.html
+++ b/docs/2.6/random.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.6/random.html
+++ b/docs/2.6/random.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.6/random.html
+++ b/docs/2.6/random.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.6/range.html
+++ b/docs/2.6/range.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.6/range.html
+++ b/docs/2.6/range.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.6/range.html
+++ b/docs/2.6/range.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.6/range.html
+++ b/docs/2.6/range.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.6/releaseBreakdown.html
+++ b/docs/2.6/releaseBreakdown.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.6/releaseBreakdown.html
+++ b/docs/2.6/releaseBreakdown.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.6/releaseBreakdown.html
+++ b/docs/2.6/releaseBreakdown.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.6/releaseBreakdown.html
+++ b/docs/2.6/releaseBreakdown.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.6/releaseNotes.html
+++ b/docs/2.6/releaseNotes.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.6/releaseNotes.html
+++ b/docs/2.6/releaseNotes.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.6/releaseNotes.html
+++ b/docs/2.6/releaseNotes.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.6/releaseNotes.html
+++ b/docs/2.6/releaseNotes.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.6/repeat.html
+++ b/docs/2.6/repeat.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.6/repeat.html
+++ b/docs/2.6/repeat.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.6/repeat.html
+++ b/docs/2.6/repeat.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.6/repeat.html
+++ b/docs/2.6/repeat.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.6/requiredAddin.html
+++ b/docs/2.6/requiredAddin.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.6/requiredAddin.html
+++ b/docs/2.6/requiredAddin.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.6/requiredAddin.html
+++ b/docs/2.6/requiredAddin.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.6/requiredAddin.html
+++ b/docs/2.6/requiredAddin.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.6/requiresMTA.html
+++ b/docs/2.6/requiresMTA.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.6/requiresMTA.html
+++ b/docs/2.6/requiresMTA.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.6/requiresMTA.html
+++ b/docs/2.6/requiresMTA.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.6/requiresMTA.html
+++ b/docs/2.6/requiresMTA.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.6/requiresSTA.html
+++ b/docs/2.6/requiresSTA.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.6/requiresSTA.html
+++ b/docs/2.6/requiresSTA.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.6/requiresSTA.html
+++ b/docs/2.6/requiresSTA.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.6/requiresSTA.html
+++ b/docs/2.6/requiresSTA.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.6/requiresThread.html
+++ b/docs/2.6/requiresThread.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.6/requiresThread.html
+++ b/docs/2.6/requiresThread.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.6/requiresThread.html
+++ b/docs/2.6/requiresThread.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.6/requiresThread.html
+++ b/docs/2.6/requiresThread.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.6/reusableConstraint.html
+++ b/docs/2.6/reusableConstraint.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.6/reusableConstraint.html
+++ b/docs/2.6/reusableConstraint.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.6/reusableConstraint.html
+++ b/docs/2.6/reusableConstraint.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.6/reusableConstraint.html
+++ b/docs/2.6/reusableConstraint.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.6/runningTests.html
+++ b/docs/2.6/runningTests.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.6/runningTests.html
+++ b/docs/2.6/runningTests.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.6/runningTests.html
+++ b/docs/2.6/runningTests.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.6/runningTests.html
+++ b/docs/2.6/runningTests.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.6/runtimeSelection.html
+++ b/docs/2.6/runtimeSelection.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.6/runtimeSelection.html
+++ b/docs/2.6/runtimeSelection.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.6/runtimeSelection.html
+++ b/docs/2.6/runtimeSelection.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.6/runtimeSelection.html
+++ b/docs/2.6/runtimeSelection.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.6/sameasConstraint.html
+++ b/docs/2.6/sameasConstraint.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.6/sameasConstraint.html
+++ b/docs/2.6/sameasConstraint.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.6/sameasConstraint.html
+++ b/docs/2.6/sameasConstraint.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.6/sameasConstraint.html
+++ b/docs/2.6/sameasConstraint.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.6/samples.html
+++ b/docs/2.6/samples.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.6/samples.html
+++ b/docs/2.6/samples.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.6/samples.html
+++ b/docs/2.6/samples.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.6/samples.html
+++ b/docs/2.6/samples.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.6/sequential.html
+++ b/docs/2.6/sequential.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.6/sequential.html
+++ b/docs/2.6/sequential.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.6/sequential.html
+++ b/docs/2.6/sequential.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.6/sequential.html
+++ b/docs/2.6/sequential.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.6/setCulture.html
+++ b/docs/2.6/setCulture.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.6/setCulture.html
+++ b/docs/2.6/setCulture.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.6/setCulture.html
+++ b/docs/2.6/setCulture.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.6/setCulture.html
+++ b/docs/2.6/setCulture.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.6/setUICulture.html
+++ b/docs/2.6/setUICulture.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.6/setUICulture.html
+++ b/docs/2.6/setUICulture.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.6/setUICulture.html
+++ b/docs/2.6/setUICulture.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.6/setUICulture.html
+++ b/docs/2.6/setUICulture.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.6/settingsDialog.html
+++ b/docs/2.6/settingsDialog.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.6/settingsDialog.html
+++ b/docs/2.6/settingsDialog.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.6/settingsDialog.html
+++ b/docs/2.6/settingsDialog.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.6/settingsDialog.html
+++ b/docs/2.6/settingsDialog.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.6/setup.html
+++ b/docs/2.6/setup.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.6/setup.html
+++ b/docs/2.6/setup.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.6/setup.html
+++ b/docs/2.6/setup.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.6/setup.html
+++ b/docs/2.6/setup.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.6/setupFixture.html
+++ b/docs/2.6/setupFixture.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.6/setupFixture.html
+++ b/docs/2.6/setupFixture.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.6/setupFixture.html
+++ b/docs/2.6/setupFixture.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.6/setupFixture.html
+++ b/docs/2.6/setupFixture.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.6/stringAssert.html
+++ b/docs/2.6/stringAssert.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.6/stringAssert.html
+++ b/docs/2.6/stringAssert.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.6/stringAssert.html
+++ b/docs/2.6/stringAssert.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.6/stringAssert.html
+++ b/docs/2.6/stringAssert.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.6/stringConstraints.html
+++ b/docs/2.6/stringConstraints.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.6/stringConstraints.html
+++ b/docs/2.6/stringConstraints.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.6/stringConstraints.html
+++ b/docs/2.6/stringConstraints.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.6/stringConstraints.html
+++ b/docs/2.6/stringConstraints.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.6/suite.html
+++ b/docs/2.6/suite.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.6/suite.html
+++ b/docs/2.6/suite.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.6/suite.html
+++ b/docs/2.6/suite.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.6/suite.html
+++ b/docs/2.6/suite.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.6/suiteBuilders.html
+++ b/docs/2.6/suiteBuilders.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.6/suiteBuilders.html
+++ b/docs/2.6/suiteBuilders.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.6/suiteBuilders.html
+++ b/docs/2.6/suiteBuilders.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.6/suiteBuilders.html
+++ b/docs/2.6/suiteBuilders.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.6/teardown.html
+++ b/docs/2.6/teardown.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.6/teardown.html
+++ b/docs/2.6/teardown.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.6/teardown.html
+++ b/docs/2.6/teardown.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.6/teardown.html
+++ b/docs/2.6/teardown.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.6/test.html
+++ b/docs/2.6/test.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.6/test.html
+++ b/docs/2.6/test.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.6/test.html
+++ b/docs/2.6/test.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.6/test.html
+++ b/docs/2.6/test.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.6/testCase.html
+++ b/docs/2.6/testCase.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.6/testCase.html
+++ b/docs/2.6/testCase.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.6/testCase.html
+++ b/docs/2.6/testCase.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.6/testCase.html
+++ b/docs/2.6/testCase.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.6/testCaseSource.html
+++ b/docs/2.6/testCaseSource.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.6/testCaseSource.html
+++ b/docs/2.6/testCaseSource.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.6/testCaseSource.html
+++ b/docs/2.6/testCaseSource.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.6/testCaseSource.html
+++ b/docs/2.6/testCaseSource.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.6/testContext.html
+++ b/docs/2.6/testContext.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.6/testContext.html
+++ b/docs/2.6/testContext.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.6/testContext.html
+++ b/docs/2.6/testContext.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.6/testContext.html
+++ b/docs/2.6/testContext.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.6/testDecorators.html
+++ b/docs/2.6/testDecorators.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.6/testDecorators.html
+++ b/docs/2.6/testDecorators.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.6/testDecorators.html
+++ b/docs/2.6/testDecorators.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.6/testDecorators.html
+++ b/docs/2.6/testDecorators.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.6/testFixture.html
+++ b/docs/2.6/testFixture.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.6/testFixture.html
+++ b/docs/2.6/testFixture.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.6/testFixture.html
+++ b/docs/2.6/testFixture.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.6/testFixture.html
+++ b/docs/2.6/testFixture.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.6/testProperties.html
+++ b/docs/2.6/testProperties.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.6/testProperties.html
+++ b/docs/2.6/testProperties.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.6/testProperties.html
+++ b/docs/2.6/testProperties.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.6/testProperties.html
+++ b/docs/2.6/testProperties.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.6/testcaseBuilders.html
+++ b/docs/2.6/testcaseBuilders.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.6/testcaseBuilders.html
+++ b/docs/2.6/testcaseBuilders.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.6/testcaseBuilders.html
+++ b/docs/2.6/testcaseBuilders.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.6/testcaseBuilders.html
+++ b/docs/2.6/testcaseBuilders.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.6/testcaseProviders.html
+++ b/docs/2.6/testcaseProviders.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.6/testcaseProviders.html
+++ b/docs/2.6/testcaseProviders.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.6/testcaseProviders.html
+++ b/docs/2.6/testcaseProviders.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.6/testcaseProviders.html
+++ b/docs/2.6/testcaseProviders.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.6/theory.html
+++ b/docs/2.6/theory.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.6/theory.html
+++ b/docs/2.6/theory.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.6/theory.html
+++ b/docs/2.6/theory.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.6/theory.html
+++ b/docs/2.6/theory.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.6/throwsConstraint.html
+++ b/docs/2.6/throwsConstraint.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.6/throwsConstraint.html
+++ b/docs/2.6/throwsConstraint.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.6/throwsConstraint.html
+++ b/docs/2.6/throwsConstraint.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.6/throwsConstraint.html
+++ b/docs/2.6/throwsConstraint.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.6/timeout.html
+++ b/docs/2.6/timeout.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.6/timeout.html
+++ b/docs/2.6/timeout.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.6/timeout.html
+++ b/docs/2.6/timeout.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.6/timeout.html
+++ b/docs/2.6/timeout.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.6/typeAsserts.html
+++ b/docs/2.6/typeAsserts.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.6/typeAsserts.html
+++ b/docs/2.6/typeAsserts.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.6/typeAsserts.html
+++ b/docs/2.6/typeAsserts.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.6/typeAsserts.html
+++ b/docs/2.6/typeAsserts.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.6/typeConstraints.html
+++ b/docs/2.6/typeConstraints.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.6/typeConstraints.html
+++ b/docs/2.6/typeConstraints.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.6/typeConstraints.html
+++ b/docs/2.6/typeConstraints.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.6/typeConstraints.html
+++ b/docs/2.6/typeConstraints.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.6/upgrade.html
+++ b/docs/2.6/upgrade.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.6/upgrade.html
+++ b/docs/2.6/upgrade.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.6/upgrade.html
+++ b/docs/2.6/upgrade.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.6/upgrade.html
+++ b/docs/2.6/upgrade.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.6/utilityAsserts.html
+++ b/docs/2.6/utilityAsserts.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.6/utilityAsserts.html
+++ b/docs/2.6/utilityAsserts.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.6/utilityAsserts.html
+++ b/docs/2.6/utilityAsserts.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.6/utilityAsserts.html
+++ b/docs/2.6/utilityAsserts.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.6/valueSource.html
+++ b/docs/2.6/valueSource.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.6/valueSource.html
+++ b/docs/2.6/valueSource.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.6/valueSource.html
+++ b/docs/2.6/valueSource.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.6/valueSource.html
+++ b/docs/2.6/valueSource.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.6/values.html
+++ b/docs/2.6/values.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.6/values.html
+++ b/docs/2.6/values.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.6/values.html
+++ b/docs/2.6/values.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.6/values.html
+++ b/docs/2.6/values.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.6/vsSupport.html
+++ b/docs/2.6/vsSupport.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.6/vsSupport.html
+++ b/docs/2.6/vsSupport.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.6/vsSupport.html
+++ b/docs/2.6/vsSupport.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.6/vsSupport.html
+++ b/docs/2.6/vsSupport.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>

--- a/docs/2.6/writingTests.html
+++ b/docs/2.6/writingTests.html
@@ -43,7 +43,7 @@
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
-            <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
+            <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>

--- a/docs/2.6/writingTests.html
+++ b/docs/2.6/writingTests.html
@@ -42,7 +42,7 @@
     </div>
     <div id="navbar" class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-            <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
+            <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>

--- a/docs/2.6/writingTests.html
+++ b/docs/2.6/writingTests.html
@@ -45,7 +45,7 @@
             <li><a href="https://nunit.org/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="https://nunit.org/download/"><i class="fa fa-download"></i> Download</a></li>
             <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
-            <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://nunit.org/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>
             <li><a href="https://github.com/nunit" target="_blank"><i class="fa fa-github"></i> GitHub</a></li>

--- a/docs/2.6/writingTests.html
+++ b/docs/2.6/writingTests.html
@@ -44,7 +44,7 @@
         <ul class="nav navbar-nav">
             <li><a href="/news/"><i class="fa fa-commenting-o"></i> News</a></li>
             <li><a href="/download/"><i class="fa fa-download"></i> Download</a></li>
-            <li><a href="/documentation/"><i class="fa fa-book"></i> Documentation</a></li>
+            <li><a href="https://docs.nunit.org"><i class="fa fa-book"></i> Documentation</a></li>
             <li><a href="/contact/"><i class="fa fa-envelope-o"></i> Contact</a></li>
             <li><a href="https://twitter.com/nunit" target="_blank"><i class="fa fa-twitter"></i> Twitter</a></li>
             <li><a href="https://gitter.im/nunit/nunit" target="_blank"><i class="fa fa-comments-o"></i> Gitter</a></li>


### PR DESCRIPTION
Resolves #483.

When moving the legacy docs and regenerating them, the nav links were relative. Now that they're on `docs.nunit.org`, the relative links are 404ing. Duh, Sean.