### PR TITLE
Update Engine-Extensibility.md to add installation instructions

### DIFF
--- a/docs/articles/nunit/extending-nunit/Engine-Extensibility.md
+++ b/docs/articles/nunit/extending-nunit/Engine-Extensibility.md
@@ -131,7 +131,7 @@ By use of the `ExtensionPropertyAttribute` the assembly containing this extensio
 
 Of course, this means that the extension author must know a great deal about how each extension point works. That's why we provide a page for each supported extension points with details of how to use it.
 
-### Locating Addins
+### Locating Addins and Extensions
 
 Assemblies containing Addins and Extensions are stored in one or more locations indicated in files of type `.addins`. Each line of the file contains the path of an addin assembly or a directory containing assemblies. Wildcards may be used for assembly entries and relative paths are interpreted based on the location of the `.addins` file. The default `nunit.engine.addins` is located in the engine directory and lists addins we build with NUnit, which are contained in the addins directory.
 
@@ -151,3 +151,9 @@ special/myassembly.dll  # include a specific dll in a special directory
 Any assemblies specified in a `.addins` file will be scanned fully, looking for addins and extensions. Any directories specified will be browsed, first looking for any `.addins` files. If one or more files are found, the content of the files will direct all further browsing. If no such file is found, then all `.dll` files in the directory will be scanned, just as if a `.addins` file contained "*.dll."
 
 Assemblies are examined using Cecil, without actually loading them. Info is saved for actual instantiation of extensions on a just-in-time basis.
+
+### Installing Addins and Extensions
+
+In [the previous section](#loading-addins-and-extensions), we note how to use the `.addins` file to utilize an existing addin or extension. 
+
+To install an extension or add-in, ensure that the binaries will be in a known location, and then create or update a `.addins` file to point to that location so that the assemblies will be discovered by NUnit.

--- a/docs/articles/nunit/extending-nunit/Engine-Extensibility.md
+++ b/docs/articles/nunit/extending-nunit/Engine-Extensibility.md
@@ -131,7 +131,7 @@ By use of the `ExtensionPropertyAttribute` the assembly containing this extensio
 
 Of course, this means that the extension author must know a great deal about how each extension point works. That's why we provide a page for each supported extension points with details of how to use it.
 
-### Locating Addins and Extensions
+### Locating Extensions
 
 Assemblies containing Addins and Extensions are stored in one or more locations indicated in files of type `.addins`. Each line of the file contains the path of an addin assembly or a directory containing assemblies. Wildcards may be used for assembly entries and relative paths are interpreted based on the location of the `.addins` file. The default `nunit.engine.addins` is located in the engine directory and lists addins we build with NUnit, which are contained in the addins directory.
 
@@ -152,8 +152,8 @@ Any assemblies specified in a `.addins` file will be scanned fully, looking for 
 
 Assemblies are examined using Cecil, without actually loading them. Info is saved for actual instantiation of extensions on a just-in-time basis.
 
-### Installing Addins and Extensions
+### Installing Extensions
 
-In [the previous section](#loading-addins-and-extensions), we note how to use the `.addins` file to utilize an existing addin or extension.
+In [the previous section](#loading-extensions), we note how to use the `.addins` file to utilize an existing extension.
 
-To install an extension or add-in, ensure that the binaries will be in a known location, and then create or update a `.addins` file to point to that location so that the assemblies will be discovered by NUnit.
+To install an extension, ensure that the binaries will be in a known location, and then create or update a `.addins` file to point to that location so that the assemblies will be scanned and the extensions discovered by NUnit.

--- a/docs/articles/nunit/extending-nunit/Engine-Extensibility.md
+++ b/docs/articles/nunit/extending-nunit/Engine-Extensibility.md
@@ -154,6 +154,6 @@ Assemblies are examined using Cecil, without actually loading them. Info is save
 
 ### Installing Addins and Extensions
 
-In [the previous section](#loading-addins-and-extensions), we note how to use the `.addins` file to utilize an existing addin or extension. 
+In [the previous section](#loading-addins-and-extensions), we note how to use the `.addins` file to utilize an existing addin or extension.
 
 To install an extension or add-in, ensure that the binaries will be in a known location, and then create or update a `.addins` file to point to that location so that the assemblies will be discovered by NUnit.

--- a/docs/articles/nunit/extending-nunit/Engine-Extensibility.md
+++ b/docs/articles/nunit/extending-nunit/Engine-Extensibility.md
@@ -154,6 +154,6 @@ Assemblies are examined using Cecil, without actually loading them. Info is save
 
 ### Installing Extensions
 
-In [the previous section](#loading-extensions), we note how to use the `.addins` file to utilize an existing extension.
+In [the previous section](#locating-extensions), we note how to use the `.addins` file to utilize an existing extension.
 
 To install an extension, ensure that the binaries will be in a known location, and then create or update a `.addins` file to point to that location so that the assemblies will be scanned and the extensions discovered by NUnit.

--- a/docs/articles/nunit/extending-nunit/Engine-Extensibility.md
+++ b/docs/articles/nunit/extending-nunit/Engine-Extensibility.md
@@ -158,4 +158,6 @@ In [the previous section](#locating-extensions), we note how to use the `.addins
 
 To install an extension, ensure that the binaries will be in a known location, and then create or update a `.addins` file to point to that location so that the assemblies will be scanned and the extensions discovered by NUnit.
 
-Note that in the case of the NUnit Console when installed by NuGet or Chocolatey, extensions installed from the same package manager are detected automatically. The default `.addins` file for these packages contains logic to locate these extensions, and no manual alterations to are required.
+
+> [!NOTE]
+> When using the NUnit Console Runner by installing it via NuGet or Chocolatey, extensions installed from the same package manager are detected automatically. The default `.addins` file for these packages contains logic to locate these extensions, and no manual alterations to are required.

--- a/docs/articles/nunit/extending-nunit/Engine-Extensibility.md
+++ b/docs/articles/nunit/extending-nunit/Engine-Extensibility.md
@@ -158,6 +158,5 @@ In [the previous section](#locating-extensions), we note how to use the `.addins
 
 To install an extension, ensure that the binaries will be in a known location, and then create or update a `.addins` file to point to that location so that the assemblies will be scanned and the extensions discovered by NUnit.
 
-
 > [!NOTE]
 > When using the NUnit Console Runner by installing it via NuGet or Chocolatey, extensions installed from the same package manager are detected automatically. The default `.addins` file for these packages contains logic to locate these extensions, and no manual alterations to are required.

--- a/docs/articles/nunit/extending-nunit/Engine-Extensibility.md
+++ b/docs/articles/nunit/extending-nunit/Engine-Extensibility.md
@@ -157,3 +157,5 @@ Assemblies are examined using Cecil, without actually loading them. Info is save
 In [the previous section](#locating-extensions), we note how to use the `.addins` file to utilize an existing extension.
 
 To install an extension, ensure that the binaries will be in a known location, and then create or update a `.addins` file to point to that location so that the assemblies will be scanned and the extensions discovered by NUnit.
+
+Note that in the case of the NUnit Console when installed by NuGet or Chocolatey, extensions installed from the same package manager are detected automatically. The default `.addins` file for these packages contains logic to locate these extensions, and no manual alterations to are required.


### PR DESCRIPTION
If I'm reading this right, I think this is all the text that's required to document the installation process for an extension / add-in, since `.addins` is already covered in the NUnit engine docs.

Resolves #11. I think.