### PR TITLE
Document NUnit Console exit codes

### DIFF
--- a/docs/articles/nunit/running-tests/Console-Runner.md
+++ b/docs/articles/nunit/running-tests/Console-Runner.md
@@ -14,7 +14,7 @@ result of the test run.
 
 ## Console Exit Codes
 
-The console will exit with zero if all tests pass, a positive number if there are any test failures, and a negative number in the case of any errors in running the test suite. The current exit codes used are summarised below:
+The console will exit with zero if all tests pass, a positive number if there are any test failures, and a negative number in the case of any errors in running the test suite. The current exit codes used are summarized below:
 
 | Exit code | Meaning |
 |---|---|
@@ -25,4 +25,4 @@ The console will exit with zero if all tests pass, a positive number if there ar
 |  -3   | No longer used. Previously used when a requested test fixture could not be found. |
 |  -4   | An invalid test fixture was found within the test suite. |
 |  -5   | No longer used. Previously used when the App Domain within which the tests were run could not be unloaded cleanly. This situation is now logged as a warning instead of an error, and will result in the console exiting zero.  |
-| -100  | An unexpected error occured. This may indicate a bug within the test runner - please consider filing an issue on the [nunit-console repository](https://github.com/nunit/nunit-console/issues).  |
+| -100  | An unexpected error occurred. This may indicate a bug within the test runner - please consider filing an issue on the [nunit-console repository](https://github.com/nunit/nunit-console/issues).  |

--- a/docs/articles/nunit/running-tests/Console-Runner.md
+++ b/docs/articles/nunit/running-tests/Console-Runner.md
@@ -11,3 +11,18 @@ It automatically saves its results in XML format, allowing you to produce report
 In this example, nunit3-console has just run selected tests in the mock-nunit-assembly.exe assembly that is part of the NUnit distribution. This assembly contains a number of tests, some
 of which are either ignored or marked explicit. The summary line shows the
 result of the test run.
+
+## Console Exit Codes
+
+The console will exit with zero if all tests pass, a positive number if there are any test failures, and a negative number in the case of any errors in running the test suite. The current exit codes used are summarised below:
+
+| Exit code | Meaning |
+|---|---|
+|   0   | All tests passed. Note that some tests may still have produced warnings -- those will be listed in the console output.  |
+| 1-100 | Some tests have failed. The exit code will reflect the number of test failures (capped at 100).  |
+|  -1   | Invalid argument found on command line. |
+|  -2   | One of the assemblies passed into the console was found to be invalid. This may include assemblies which contain no tests. |
+|  -3   | No longer used. Previously used when a requested test fixture could not be found. |
+|  -4   | An invalid test fixture was found within the test suite. |
+|  -5   | No longer used. Previously used when the App Domain within which the tests were run could not be unloaded cleanly. This situation is now logged as a warning instead of an error, and will result in the console exiting zero.  |
+| -100  | An unexpected error occured. This may indicate a bug within the test runner - please consider filing an issue on the [nunit-console repository](https://github.com/nunit/nunit-console/issues).  |


### PR DESCRIPTION
Fixes #333.

@SeanKilleen - any ideas how we can make sure this table has sensible column widths? In GitHub's markdown preview it wraps in a bit of an ugly way...maybe docfx will handle it differently?