### PR TITLE
Update category.md

### DIFF
--- a/docs/articles/nunit/writing-tests/attributes/category.md
+++ b/docs/articles/nunit/writing-tests/attributes/category.md
@@ -2,14 +2,10 @@
 
 The Category attribute provides an alternative to suites for dealing with groups
 of tests. Either individual test cases or fixtures may be identified as
-belonging to a particular category. Both the gui and console test runners allow
-specifying a list of categories to be included in or excluded from the run.
+belonging to a particular category. Some runners, including the Console Runner,
+allow specifying categories to be included in or excluded from the run.
 When categories are used, only the tests in the selected categories will be
 run. Those tests in categories that are not selected are not reported at all.
-
-This feature is accessible by use of the /include and /exclude arguments to the
-console runner and through a separate "Categories" tab in the gui. The gui
-provides a visual indication of which categories are selected at any time.
 
 > [!WARNING]
 > While the C# syntax allows you to place a Category attribute on a SetUpFixture class, the attribute is ignored by NUnit and has no effect in current releases.


### PR DESCRIPTION
Removes references to NUnit V2 features: the GUI and the use of /include and /exclude command-line options. The framework should not try to specifically document any runners. It's enough to just say "some runners allow you to do this."