### PR TITLE
Use nameof() in docs to reduce magic strings

### DIFF
--- a/docs/articles/nunit/writing-tests/TestCaseData.md
+++ b/docs/articles/nunit/writing-tests/TestCaseData.md
@@ -10,7 +10,7 @@ The `TestCaseData` class provides extended test case information for a parameter
 [TestFixture]
 public class MyTests
 {
-    [TestCaseSource(typeof(MyDataClass), "TestCases")]
+    [TestCaseSource(typeof(MyDataClass), nameof(MyDataClass.TestCases)]
     public int DivideTest(int n, int d)
     {
         return n / d;


### PR DESCRIPTION
I tend to view `nameof` as a step above strings in code for these kinds of things, however I understand this is _close_ to subjective preference. Feelings will not be hurt if this isn't the view of the maintainers, just thought I'd try.

This was a passing observation while reading docs, if there are other places you'd like this to be applied, let me know and I will.

Thank you~!