### PR TITLE
Fixes #523 - finishes applying nameof() to areas where it can replace magic strings

### DIFF
--- a/docs/articles/nunit/writing-tests/ListMapper.md
+++ b/docs/articles/nunit/writing-tests/ListMapper.md
@@ -13,9 +13,9 @@ shows two forms of the same assert.
 string[] strings = new string[] { "a", "ab", "abc" };
 int[] lengths = new int[] { 1, 2, 3 };
 
-Assert.That(List.Map(strings).Property("Length"),
+Assert.That(List.Map(strings).Property(nameof(string.Length)),
        Is.EqualTo(lengths));
 
-Assert.That(new ListMapper(strings).Property("Length"),
+Assert.That(new ListMapper(strings).Property(nameof(string.Length)),
        Is.EqualTo(lengths));
 ```

--- a/docs/articles/nunit/writing-tests/ListMapper.md
+++ b/docs/articles/nunit/writing-tests/ListMapper.md
@@ -13,9 +13,9 @@ shows two forms of the same assert.
 string[] strings = new string[] { "a", "ab", "abc" };
 int[] lengths = new int[] { 1, 2, 3 };
 
-Assert.That(List.Map(strings).Property(nameof(string.Length)),
+Assert.That(List.Map(strings).Property("Length"),
        Is.EqualTo(lengths));
 
-Assert.That(new ListMapper(strings).Property(nameof(string.Length)),
+Assert.That(new ListMapper(strings).Property("Length"),
        Is.EqualTo(lengths));
 ```

--- a/docs/articles/nunit/writing-tests/TestFixtureData.md
+++ b/docs/articles/nunit/writing-tests/TestFixtureData.md
@@ -10,7 +10,7 @@ The following example varies the example shown under [TestFixture Attribute](xre
 a `TestFixtureSourceAttribute` with a data source in a separately defined class.
 
 ```csharp
-[TestFixtureSource(typeof(MyFixtureData), "Fixtureparams")]
+[TestFixtureSource(typeof(MyFixtureData), nameof(Fixtureparams))]
 public class ParameterizedTestFixture
 {
     private string eq1;

--- a/docs/articles/nunit/writing-tests/TestFixtureData.md
+++ b/docs/articles/nunit/writing-tests/TestFixtureData.md
@@ -10,7 +10,7 @@ The following example varies the example shown under [TestFixture Attribute](xre
 a `TestFixtureSourceAttribute` with a data source in a separately defined class.
 
 ```csharp
-[TestFixtureSource(typeof(MyFixtureData), nameof(Fixtureparams))]
+[TestFixtureSource(typeof(MyFixtureData), nameof(MyFixtureData.Fixtureparams))]
 public class ParameterizedTestFixture
 {
     private string eq1;

--- a/docs/articles/nunit/writing-tests/attributes/testcasesource.md
+++ b/docs/articles/nunit/writing-tests/attributes/testcasesource.md
@@ -16,7 +16,8 @@ tests with arguments.
 Consider a test of the divide operation, taking three arguments: the numerator, the denominator and the expected result. We can specify the test and its data using one of the forms of **TestCaseSourceAttribute**:
 
 ### Form 1 - [TestCaseSource(string sourceName)]
-##### Note: We use [nameof(DivideCases)](https://docs.microsoft.com/en-us/dotnet/csharp/language-reference/operators/nameof) here to avoid introducing [magic strings](https://en.wikipedia.org/wiki/Magic_string) into our code, which offers better resilience when refactoring.
+
+#### Note: We use [nameof(DivideCases)](https://docs.microsoft.com/en-us/dotnet/csharp/language-reference/operators/nameof) here to avoid introducing [magic strings](https://en.wikipedia.org/wiki/Magic_string) into our code, which offers better resilience when refactoring.
 
 ```csharp
 public class MyTestClass

--- a/docs/articles/nunit/writing-tests/attributes/testcasesource.md
+++ b/docs/articles/nunit/writing-tests/attributes/testcasesource.md
@@ -17,7 +17,8 @@ Consider a test of the divide operation, taking three arguments: the numerator, 
 
 ### Form 1 - [TestCaseSource(string sourceName)]
 
-#### Note: We use [nameof(DivideCases)](https://docs.microsoft.com/en-us/dotnet/csharp/language-reference/operators/nameof) here to avoid introducing [magic strings](https://en.wikipedia.org/wiki/Magic_string) into our code, which offers better resilience when refactoring.
+> [!NOTE]
+> We use [the `nameof` operator](https://docs.microsoft.com/dotnet/csharp/language-reference/operators/nameof) to avoid introducing [magic strings](https://wikipedia.org/wiki/Magic_string) into code, which offers better resilience when refactoring. While `nameof` is recommended, you could also use the string "DivideCases" to achieve the same outcome.
 
 ```csharp
 public class MyTestClass

--- a/docs/articles/nunit/writing-tests/attributes/testcasesource.md
+++ b/docs/articles/nunit/writing-tests/attributes/testcasesource.md
@@ -16,11 +16,12 @@ tests with arguments.
 Consider a test of the divide operation, taking three arguments: the numerator, the denominator and the expected result. We can specify the test and its data using one of the forms of **TestCaseSourceAttribute**:
 
 ### Form 1 - [TestCaseSource(string sourceName)]
+##### Note: We use [nameof(DivideCases)](https://docs.microsoft.com/en-us/dotnet/csharp/language-reference/operators/nameof) here to avoid introducing [magic strings](https://en.wikipedia.org/wiki/Magic_string) into our code, which offers better resilience when refactoring.
 
 ```csharp
 public class MyTestClass
 {
-    [TestCaseSource("DivideCases")]
+    [TestCaseSource(nameof(DivideCases))]
     public void DivideTest(int n, int d, int q)
     {
         Assert.AreEqual(q, n / d);
@@ -78,7 +79,7 @@ public class MyTestClass
 ```csharp
 public class MyTestClass
 {
-    [TestCaseSource(typeof(AnotherClass), "DivideCases")]
+    [TestCaseSource(typeof(AnotherClass), nameof(AnotherClass.DivideCases))]
     public void DivideTest(int n, int d, int q)
     {
         Assert.AreEqual(q, n / d);
@@ -162,7 +163,7 @@ the enumerator as follows:
 ```csharp
 static int[] EvenNumbers = new int[] { 2, 4, 6, 8 };
 
-[Test, TestCaseSource("EvenNumbers")]
+[Test, TestCaseSource(nameof(EvenNumbers))]
 public void TestMethod(int num)
 {
     Assert.IsTrue(num % 2 == 0);

--- a/docs/articles/nunit/writing-tests/attributes/testfixturesource.md
+++ b/docs/articles/nunit/writing-tests/attributes/testfixturesource.md
@@ -13,7 +13,7 @@ Consider a test fixture class taking two parameters in its constructor, a string
 ### Form 1 - [TestFixtureSource(string sourceName)]
 
 ```csharp
-[TestFixtureSource("FixtureArgs")]
+[TestFixtureSource(nameof(FixtureArgs))]
 public class MyTestClass
 {
     public MyTestClass(string word, int num) { ... }
@@ -38,7 +38,7 @@ to provide arguments for constructing the `TestFixture`. It has the following ch
 ### Form 2 - [TestFixtureSource(Type sourceType, string sourceName)]
 
 ```csharp
-[TestFixtureSource(typeof(AnotherClass), "FixtureArgs")]
+[TestFixtureSource(typeof(AnotherClass), nameof(AnotherClass.FixtureArgs)]
 public class MyTestClass
 {
     public MyTestClass(string word, int num) { ... }

--- a/docs/articles/nunit/writing-tests/attributes/testof.md
+++ b/docs/articles/nunit/writing-tests/attributes/testof.md
@@ -14,7 +14,7 @@ public class MyTests
  public void Test1() { /* ... */ }
 
  [Test]
- [TestOf("MySubClass")]
+ [TestOf(nameof(MySubClass))]
  public void Test2() { /* ... */ }
 }
 
@@ -30,4 +30,4 @@ public class MyOtherTests
 ```
 
 > [!NOTE]
-> you can currently only have one TestOf attribute per fixture or test.
+> You can currently only have one TestOf attribute per fixture or test.


### PR DESCRIPTION
Fixes #523 

This should finish the effort started in #519 .

Please advise if I've missed anything or if anybody feels there is an unjust replacement.

Thank you!