### PR TITLE
Standardize xrefs to lowercase

### DIFF
--- a/docs/articles/developer-info/toc.yml
+++ b/docs/articles/developer-info/toc.yml
@@ -1,7 +1,7 @@
 - name: Team Practices
   href: Team-Practices.md
 - name: Specifications
-  topicUid: Specifications
+  topicUid: specifications
 - name: Notes Toward NUnit 4.0
   href: Notes-Toward-NUnit-4.0.md
 - name: Best Practices for XML Documentation

--- a/docs/articles/nunit-engine/Getting-Started.md
+++ b/docs/articles/nunit-engine/Getting-Started.md
@@ -22,7 +22,7 @@ The `TestEngineActivator` class is first used to obtain an instance of the engin
 
 Once a test package has been created, the engine can generate an instance of an `ITestRunner`, which will be constructed to reflect the structure of your test package.
 
-Finally, `Run` can be called on the `ITestRunner`, to run tests in the specified package. This will return an `XmlNode` which contains the results of the test run, in the standard [NUnit Test Results](xref:TestResultXMLFormat) format.
+Finally, `Run` can be called on the `ITestRunner`, to run tests in the specified package. This will return an `XmlNode` which contains the results of the test run, in the standard [NUnit Test Results](xref:testresultxmlformat) format.
 
 The following example shows the simplest path of how to get a copy of the engine, create a runner and run tests using the interfaces:
 

--- a/docs/articles/nunit-engine/extensions/Event-Listeners.md
+++ b/docs/articles/nunit-engine/extensions/Event-Listeners.md
@@ -1,5 +1,5 @@
 ---
-uid: EventListeners
+uid: eventlisteners
 ---
 
 # Event Listeners

--- a/docs/articles/nunit-engine/extensions/Framework-Drivers.md
+++ b/docs/articles/nunit-engine/extensions/Framework-Drivers.md
@@ -1,5 +1,5 @@
 ---
-uid: FrameworkDrivers
+uid: frameworkdrivers
 ---
 
 # Framework Drivers

--- a/docs/articles/nunit-engine/extensions/Project-Loaders.md
+++ b/docs/articles/nunit-engine/extensions/Project-Loaders.md
@@ -1,5 +1,5 @@
 ---
-uid: ProjectLoaders
+uid: projectloaders
 ---
 
 # Project Loaders

--- a/docs/articles/nunit-engine/extensions/Result-Writers.md
+++ b/docs/articles/nunit-engine/extensions/Result-Writers.md
@@ -1,5 +1,5 @@
 ---
-uid: ResultWriters
+uid: resultwriters
 ---
 
 # Result Writers

--- a/docs/articles/nunit/extending-nunit/Action-Attributes.md
+++ b/docs/articles/nunit/extending-nunit/Action-Attributes.md
@@ -1,5 +1,5 @@
 ---
-uid: ActionAttributes
+uid: actionattributes
 ---
 
 # Action Attributes

--- a/docs/articles/nunit/getting-started/toc.yml
+++ b/docs/articles/nunit/getting-started/toc.yml
@@ -7,4 +7,4 @@
 - name: Samples
   href: samples.md
 - name: Breaking Changes
-  topicUid: BreakingChanges
+  topicUid: breakingchanges

--- a/docs/articles/nunit/getting-started/upgrading.md
+++ b/docs/articles/nunit/getting-started/upgrading.md
@@ -8,7 +8,7 @@ notes for earlier versions of NUnit as well.
 
 ## Review Breaking Changes
 
-The [Breaking Changes](xref:BreakingChanges) page
+The [Breaking Changes](xref:breakingchanges) page
 lists missing and changed functionality in NUnit 3.0. You should review this
 page to see which items are likely to affect your own tests.
 

--- a/docs/articles/nunit/release-notes/breaking-changes.md
+++ b/docs/articles/nunit/release-notes/breaking-changes.md
@@ -97,7 +97,7 @@ Other breaking changes are grouped in the following tables.
 | NUnitLite          | NUnitLite executable tests must now reference nunit.framework in addition to NUnitLite. |
 | SetUpFixture       | Now uses `OneTimeSetUpAttribute` and `OneTimeTearDownAttribute` to designate higher-level setup and teardown methods. `SetUpAttribute` and `TearDownAttribute` are no longer allowed. |
 | TestCaseData       | The `Throws` Named Property is no longer available. Use `Assert.Throws` or `Assert.That` in your test case. |
-| TestContext        | The fields available in the [TestContext](xref:TestContext) have changed, although the same information remains available as for NUnit V2. |
+| TestContext        | The fields available in the [TestContext](xref:testcontext) have changed, although the same information remains available as for NUnit V2. |
 | Async void tests   | No longer supported. Use `async Task` as the method signature instead. |
 
 ### Console Features

--- a/docs/articles/nunit/release-notes/breaking-changes.md
+++ b/docs/articles/nunit/release-notes/breaking-changes.md
@@ -1,5 +1,5 @@
 ---
-uid: BreakingChanges
+uid: breakingchanges
 ---
 
 # Breaking Changes

--- a/docs/articles/nunit/release-notes/toc.yml
+++ b/docs/articles/nunit/release-notes/toc.yml
@@ -3,6 +3,6 @@
 - name: Console and Engine
   href: console-and-engine.md
 - name: Breaking Changes
-  topicUid: BreakingChanges
+  topicUid: breakingchanges
 - name: Pre-3.5 Release notes
   href: Pre-3.5-Release-Notes.md

--- a/docs/articles/nunit/running-tests/Console-Command-Line.md
+++ b/docs/articles/nunit/running-tests/Console-Command-Line.md
@@ -1,5 +1,5 @@
 ---
-uid: ConsoleCommandLine
+uid: consolecommandline
 ---
 
 # Console Command Line

--- a/docs/articles/nunit/running-tests/Template-Based-Test-Naming.md
+++ b/docs/articles/nunit/running-tests/Template-Based-Test-Naming.md
@@ -1,5 +1,5 @@
 ---
-uid: TemplateBasedTestNaming
+uid: templatebasedtestnaming
 ---
 
 # Template-Based Test Naming

--- a/docs/articles/nunit/running-tests/Test-Selection-Language.md
+++ b/docs/articles/nunit/running-tests/Test-Selection-Language.md
@@ -1,5 +1,5 @@
 ---
-uid: TestSelectionLanguage
+uid: testselectionlanguage
 ---
 
 # Test Selection Language

--- a/docs/articles/nunit/running-tests/Test-Selection-Language.md
+++ b/docs/articles/nunit/running-tests/Test-Selection-Language.md
@@ -79,7 +79,7 @@ Although the syntax will accept any property name - including names that don't a
 
 In general, these properties were not created with filtering in mind, but you can use them if it suits your needs. Using the Category property currently accomplishes the same thing as the cat keyword. You should be aware that the use of these properties by NUnit is considered an implementation detail and they may change in the future.
 
-We envision that most filtering by property will be based on user-defined properties, created for this purpose by inheriting from [Property Attribute](xref:PropertyAttribute). When defining a property, you should keep the limitation to string values in mind. For example, a PriorityAttribute taking values of "High", "Medium" and "Low" could be used for filtering, while one that took the integers 1, 2 and 3 could not.
+We envision that most filtering by property will be based on user-defined properties, created for this purpose by inheriting from [Property Attribute](xref:propertyattribute). When defining a property, you should keep the limitation to string values in mind. For example, a PriorityAttribute taking values of "High", "Medium" and "Low" could be used for filtering, while one that took the integers 1, 2 and 3 could not.
 
 ## Filtering by Test Id
 

--- a/docs/articles/nunit/technical-notes/nunit-internals/Architectural-Overview.md
+++ b/docs/articles/nunit/technical-notes/nunit-internals/Architectural-Overview.md
@@ -79,4 +79,4 @@ Various popular mock frameworks will be supported. NUnit's own self-tests now us
 
 ## See Also
 
-You can also view the [Original Architectural Overview Document](xref:NUnit3Architecture2009) created for NUnit 3.0 in 2009.
+You can also view the [Original Architectural Overview Document](xref:nunit3architecture2009) created for NUnit 3.0 in 2009.

--- a/docs/articles/nunit/technical-notes/nunit-internals/NUnit-3.0-Architecture-(2009).md
+++ b/docs/articles/nunit/technical-notes/nunit-internals/NUnit-3.0-Architecture-(2009).md
@@ -1,5 +1,5 @@
 ---
-uid: NUnit3Architecture2009
+uid: nunit3architecture2009
 ---
 
 # NUnit 3.0 Architecture (2009)

--- a/docs/articles/nunit/technical-notes/nunit-internals/NUnit-3.0-Architecture-(2009).md
+++ b/docs/articles/nunit/technical-notes/nunit-internals/NUnit-3.0-Architecture-(2009).md
@@ -104,4 +104,4 @@ Various popular mock frameworks will be supported. One framework will be selecte
 
 ### Further Details
 
-More detailed specifications are being developed for each of the layers. Consult the [Specifications](xref:Specifications) index for their current status.
+More detailed specifications are being developed for each of the layers. Consult the [Specifications](xref:specifications) index for their current status.

--- a/docs/articles/nunit/technical-notes/nunit-internals/NUnit-APIs.md
+++ b/docs/articles/nunit/technical-notes/nunit-internals/NUnit-APIs.md
@@ -18,7 +18,7 @@ See [Test Engine API](xref:testengineapi) for more info.
 
 The NUnit TestEngine uses drivers to communicate with test frameworks. It is possible to create a driver for running any sort of test framework, supporting any language at all. The driver API is what makes this possible. The TestEngine has support for the NUnit 3 framework built in. An extension driver for running NUnit 2 tests is also available.
 
-The driver API is only intended to be implemented by drivers and is only used by the NUnit engine. See [Engine Driver API](xref:FrameworkDrivers) for more info.
+The driver API is only intended to be implemented by drivers and is only used by the NUnit engine. See [Engine Driver API](xref:frameworkdrivers) for more info.
 
 ## NUnit Framework API
 

--- a/docs/articles/nunit/technical-notes/nunit-internals/NUnit-Internals.md
+++ b/docs/articles/nunit/technical-notes/nunit-internals/NUnit-Internals.md
@@ -3,7 +3,7 @@
 * [Architectural Overview](Architectural-Overview.md)
 * [NUnit APIs](NUnit-APIs.md)
   * [Test Engine API](xref:testengineapi)
-  * [Framework Driver API](xref:FrameworkDrivers)
+  * [Framework Driver API](xref:frameworkdrivers)
   * [Framework API](Framework-Api.md)
 * [Framework Design](Framework-Design.md)
 * [Active Attributes](Active-Attributes.md)

--- a/docs/articles/nunit/technical-notes/nunit-internals/Test-Discovery-And-Execution.md
+++ b/docs/articles/nunit/technical-notes/nunit-internals/Test-Discovery-And-Execution.md
@@ -23,7 +23,7 @@ This API is currently under development. See [Test Engine API](xref:testengineap
 
 The NUnit TestEngine uses drivers to communicate with test frameworks. Initially, the engine will come with a driver for NUnit 3.0, followed by an NUnit 2.x driver. It is possible to create a driver for running any sort of test framework, supporting any language at all. The driver API is what makes this possible.
 
-The driver API is only intended to be implemented by drivers and is only used by the NUnit engine. This API is currently under development. See [Engine Driver API](xref:FrameworkDrivers) for more info.
+The driver API is only intended to be implemented by drivers and is only used by the NUnit engine. This API is currently under development. See [Engine Driver API](xref:frameworkdrivers) for more info.
 
 ## NUnit Framework API
 

--- a/docs/articles/nunit/technical-notes/nunit-internals/specs/Include and Exclude Attributes (Alternatives).md
+++ b/docs/articles/nunit/technical-notes/nunit-internals/specs/Include and Exclude Attributes (Alternatives).md
@@ -1,5 +1,5 @@
 ---
-uid: IncludeExcludeAttributesAlternatives
+uid: includeexcludeattributesalternatives
 ---
 
 # Include And Exclude Attributes Alternatives

--- a/docs/articles/nunit/technical-notes/nunit-internals/specs/Include-and-Exclude-Attributes-Spec.md
+++ b/docs/articles/nunit/technical-notes/nunit-internals/specs/Include-and-Exclude-Attributes-Spec.md
@@ -3,7 +3,7 @@
 > [!WARNING]
 > This is a draft. The contents may be out of date.
 
-This spec describes proposed new attributes to replace and extend the existing CultureAttribute and PlatformAttribute. We considered several alternative approaches to doing this and selected the approach described here. See [Include and Exclude Attributes (Alternatives)](xref:IncludeExcludeAttributesAlternatives) for the original discussion of choices.
+This spec describes proposed new attributes to replace and extend the existing CultureAttribute and PlatformAttribute. We considered several alternative approaches to doing this and selected the approach described here. See [Include and Exclude Attributes (Alternatives)](xref:includeexcludeattributesalternatives) for the original discussion of choices.
 
 ## Attributes
 

--- a/docs/articles/nunit/technical-notes/nunit-internals/specs/Specifications.md
+++ b/docs/articles/nunit/technical-notes/nunit-internals/specs/Specifications.md
@@ -1,5 +1,5 @@
 ---
-uid: Specifications
+uid: specifications
 ---
 
 # Specifications

--- a/docs/articles/nunit/technical-notes/nunit-internals/toc.yml
+++ b/docs/articles/nunit/technical-notes/nunit-internals/toc.yml
@@ -8,7 +8,7 @@
     - name: Test Engine API
       xref: testengineapi
     - name: Engine Driver API
-      xref: FrameworkDrivers
+      xref: frameworkdrivers
     - name: Framework API
       href: Framework-Api.md
 - name: Framework Design

--- a/docs/articles/nunit/technical-notes/usage/Assembly-Isolation.md
+++ b/docs/articles/nunit/technical-notes/usage/Assembly-Isolation.md
@@ -15,4 +15,4 @@ for which it was built. Within the agent process, NUnit's own code runs in the p
 
 If desired, multiple test assemblies may be loaded into the same process and
 even the same domain by use of the **-process** and **-domain** command-line
-options. See [Console Command Line](xref:ConsoleCommandLine).
+options. See [Console Command Line](xref:consolecommandline).

--- a/docs/articles/nunit/technical-notes/usage/Parameterized-Tests.md
+++ b/docs/articles/nunit/technical-notes/usage/Parameterized-Tests.md
@@ -1,5 +1,5 @@
 ---
-uid: ParameterizedTests
+uid: parameterizedtests
 ---
 
 # Parameterized Tests

--- a/docs/articles/nunit/technical-notes/usage/Runtime-Selection.md
+++ b/docs/articles/nunit/technical-notes/usage/Runtime-Selection.md
@@ -14,7 +14,7 @@ no suitable runtime can be found, an error is reported.
 The default runtime framework may be overridden using command line options.
 In all cases, NUnit will attempt to honor the options given, issuing an
 error message if the assembly cannot be loaded.
-See [Console Command Line](xref:ConsoleCommandLine) for more information.
+See [Console Command Line](xref:consolecommandline) for more information.
 
 * The **/framework** option of console runner allows you to specify
    the framework type and version to be used for a test run. When this option

--- a/docs/articles/nunit/technical-notes/usage/Test-Result-XML-Format.md
+++ b/docs/articles/nunit/technical-notes/usage/Test-Result-XML-Format.md
@@ -1,5 +1,5 @@
 ---
-uid: TestResultXMLFormat
+uid: testresultxmlformat
 ---
 
 # Test Result XML Format

--- a/docs/articles/nunit/writing-tests/Assumptions.md
+++ b/docs/articles/nunit/writing-tests/Assumptions.md
@@ -13,4 +13,4 @@ Assume.That(myString, Is.EqualTo("Hello"));
 `Assume.That()` has the same set of overloads as `Assert.That()`. For further details there, see the [Constraint Model](xref:constraintmodel) documentation.
 
 > [!NOTE]
-> Failing assumptions indicate that running tests is invalid,  while [Multiple Asserts](xref:MultipleAsserts) allow testing to continue after a failure. For that reason, the two features are incompatible and assumptions may not be used within a [multiple assert](xref:MultipleAsserts) block.
+> Failing assumptions indicate that running tests is invalid,  while [Multiple Asserts](xref:multipleasserts) allow testing to continue after a failure. For that reason, the two features are incompatible and assumptions may not be used within a [multiple assert](xref:multipleasserts) block.

--- a/docs/articles/nunit/writing-tests/Randomizer-Methods.md
+++ b/docs/articles/nunit/writing-tests/Randomizer-Methods.md
@@ -1,5 +1,5 @@
 ---
-uid: RandomizerMethods
+uid: randomizermethods
 ---
 
 # Randomizer Methods

--- a/docs/articles/nunit/writing-tests/TestCaseData.md
+++ b/docs/articles/nunit/writing-tests/TestCaseData.md
@@ -42,5 +42,5 @@ and methods, which may be appended to an instance in any order.
 * **Returns** specifies the expected result to be returned from the method, which must have a compatible return type.
 * **SetCategory(string)** applies a category to the test.
 * **SetDescription(string)** sets the description property of the test.
-* **SetName(string)** provides a name for the test. If not specified, a name is generated based on the method name and the arguments provided. See [Template Based Test Naming](xref:TemplateBasedTestNaming).
+* **SetName(string)** provides a name for the test. If not specified, a name is generated based on the method name and the arguments provided. See [Template Based Test Naming](xref:templatebasedtestnaming).
 * **SetProperty(string, string)**, **SetProperty(string, int)** and **SetProperty(string, double)** apply a named property and value to the test.

--- a/docs/articles/nunit/writing-tests/TestCaseData.md
+++ b/docs/articles/nunit/writing-tests/TestCaseData.md
@@ -1,5 +1,5 @@
 ---
-uid: TestCaseData
+uid: testcasedata
 ---
 
 # TestCaseData

--- a/docs/articles/nunit/writing-tests/TestContext.md
+++ b/docs/articles/nunit/writing-tests/TestContext.md
@@ -1,5 +1,5 @@
 ---
-uid: TestContext
+uid: testcontext
 ---
 
 # TestContext

--- a/docs/articles/nunit/writing-tests/TestFixtureData.md
+++ b/docs/articles/nunit/writing-tests/TestFixtureData.md
@@ -1,5 +1,5 @@
 ---
-uid: TestFixtureData
+uid: testfixturedata
 ---
 
 # TestFixtureData

--- a/docs/articles/nunit/writing-tests/assertions/classic-assertions/Assert.AreEqual.md
+++ b/docs/articles/nunit/writing-tests/assertions/classic-assertions/Assert.AreEqual.md
@@ -45,5 +45,5 @@ NUnit 3.0 adds the ability to compare generic collections and dictionaries.
 
 ## See Also
 
-* [Equal Constraint](xref:EqualConstraint)
+* [Equal Constraint](xref:equalconstraint)
 * [DefaultFloatingPointTolerance Attribute](../../attributes/defaultfloatingpointtolerance.md)

--- a/docs/articles/nunit/writing-tests/assertions/classic-assertions/Assert.AreNotEqual.md
+++ b/docs/articles/nunit/writing-tests/assertions/classic-assertions/Assert.AreNotEqual.md
@@ -13,4 +13,4 @@ See [Assert.AreEqual](Assert.AreEqual.md) for details of how NUnit performs equa
 ## See Also
 
 * [Assert.AreEqual](Assert.AreEqual.md)
-* [Equal Constraint](xref:EqualConstraint)
+* [Equal Constraint](xref:equalconstraint)

--- a/docs/articles/nunit/writing-tests/assertions/classic-assertions/Assert.AreNotSame.md
+++ b/docs/articles/nunit/writing-tests/assertions/classic-assertions/Assert.AreNotSame.md
@@ -10,4 +10,4 @@ Assert.AreNotSame(object expected, object actual,
 
 ## See Also
 
-* [SameAs Constraint](xref:SameAsConstraint)
+* [SameAs Constraint](xref:sameasconstraint)

--- a/docs/articles/nunit/writing-tests/assertions/classic-assertions/Assert.AreSame.md
+++ b/docs/articles/nunit/writing-tests/assertions/classic-assertions/Assert.AreSame.md
@@ -10,4 +10,4 @@ Assert.AreSame(object expected, object actual,
 
 ## See Also
 
-* [SameAs Constraint](xref:SameAsConstraint)
+* [SameAs Constraint](xref:sameasconstraint)

--- a/docs/articles/nunit/writing-tests/assertions/classic-assertions/Assert.Catch.md
+++ b/docs/articles/nunit/writing-tests/assertions/classic-assertions/Assert.Catch.md
@@ -22,4 +22,4 @@ T Assert.Catch<T>(TestDelegate code,
 * [Assert.CatchAsync](Assert.CatchAsync.md)
 * [Assert.Throws](Assert.Throws.md)
 * [Assert.ThrowsAsync](Assert.ThrowsAsync.md)
-* [ThrowsConstraint](xref:ThrowsConstraint)
+* [ThrowsConstraint](xref:throwsconstraint)

--- a/docs/articles/nunit/writing-tests/assertions/classic-assertions/Assert.CatchAsync.md
+++ b/docs/articles/nunit/writing-tests/assertions/classic-assertions/Assert.CatchAsync.md
@@ -22,4 +22,4 @@ T Assert.CatchAsync<T>(AsyncTestDelegate code,
 * [Assert.Catch](Assert.Catch.md)
 * [Assert.Throws](Assert.Throws.md)
 * [Assert.ThrowsAsync](Assert.ThrowsAsync.md)
-* [ThrowsConstraint](xref:ThrowsConstraint)
+* [ThrowsConstraint](xref:throwsconstraint)

--- a/docs/articles/nunit/writing-tests/assertions/classic-assertions/Assert.DoesNotThrow.md
+++ b/docs/articles/nunit/writing-tests/assertions/classic-assertions/Assert.DoesNotThrow.md
@@ -12,4 +12,4 @@ void Assert.DoesNotThrow(TestDelegate code,
 ## See Also
 
 * [Assert.Throws](Assert.Throws.md)
-* [ThrowsConstraint](xref:ThrowsConstraint)
+* [ThrowsConstraint](xref:throwsconstraint)

--- a/docs/articles/nunit/writing-tests/assertions/classic-assertions/Assert.DoesNotThrowAsync.md
+++ b/docs/articles/nunit/writing-tests/assertions/classic-assertions/Assert.DoesNotThrowAsync.md
@@ -12,4 +12,4 @@ void Assert.DoesNotThrowAsync(AsyncTestDelegate code,
 ## See Also
 
 * [Assert.ThrowsAsync](Assert.ThrowsAsync.md)
-* [ThrowsConstraint](xref:ThrowsConstraint)
+* [ThrowsConstraint](xref:throwsconstraint)

--- a/docs/articles/nunit/writing-tests/assertions/classic-assertions/Assert.Throws.md
+++ b/docs/articles/nunit/writing-tests/assertions/classic-assertions/Assert.Throws.md
@@ -131,4 +131,4 @@ Assert.Catch(code);
 * [Assert.Catch](Assert.Catch.md)
 * [Assert.CatchAsync](Assert.CatchAsync.md)
 * [Assert.ThrowsAsync](Assert.ThrowsAsync.md)
-* [ThrowsConstraint](xref:ThrowsConstraint)
+* [ThrowsConstraint](xref:throwsconstraint)

--- a/docs/articles/nunit/writing-tests/assertions/classic-assertions/Assert.ThrowsAsync.md
+++ b/docs/articles/nunit/writing-tests/assertions/classic-assertions/Assert.ThrowsAsync.md
@@ -65,4 +65,4 @@ public class UsingReturnValue
 * [Assert.Catch](Assert.Catch.md)
 * [Assert.CatchAsync](Assert.CatchAsync.md)
 * [Assert.Throws](Assert.Throws.md)
-* [ThrowsConstraint](xref:ThrowsConstraint)
+* [ThrowsConstraint](xref:throwsconstraint)

--- a/docs/articles/nunit/writing-tests/assertions/multiple-asserts.md
+++ b/docs/articles/nunit/writing-tests/assertions/multiple-asserts.md
@@ -1,5 +1,5 @@
 ---
-uid: MultipleAsserts
+uid: multipleasserts
 ---
 
 # Multiple Asserts

--- a/docs/articles/nunit/writing-tests/attributes.md
+++ b/docs/articles/nunit/writing-tests/attributes.md
@@ -11,8 +11,8 @@ This table lists all the attributes supported by NUnit.
 | [Category Attribute](attributes/category.md)            | Specifies one or more categories for the test. |
 | [Combinatorial Attribute](attributes/combinatorial.md)       | Generates test cases for all possible combinations of the values provided. |
 | [Culture Attribute](attributes/culture.md)             | Specifies cultures for which a test or fixture should be run. |
-| [Datapoint Attribute](attributes/datapoint.md)           | Provides data for [Theories](xref:Theory-Attribute). |
-| [DatapointSource Attribute](attributes/datapointsource.md)     | Provides data for [Theories](xref:Theory-Attribute). |
+| [Datapoint Attribute](attributes/datapoint.md)           | Provides data for [Theories](xref:theoryattribute). |
+| [DatapointSource Attribute](attributes/datapointsource.md)     | Provides data for [Theories](xref:theoryattribute). |
 | [DefaultFloatingPointTolerance Attribute](attributes/defaultfloatingpointtolerance.md) | Indicates that the test should use the specified tolerance as default for float and double comparisons. |
 | [Description Attribute](attributes/description.md)         | Applies descriptive text to a Test, TestFixture or Assembly. |
 | [Explicit Attribute](attributes/explicit.md)            | Indicates that a test should be skipped unless explicitly run. |

--- a/docs/articles/nunit/writing-tests/attributes/datapoint.md
+++ b/docs/articles/nunit/writing-tests/attributes/datapoint.md
@@ -31,4 +31,4 @@ For an example of use, see [Theory Attribute](theory.md)
 ## See Also
 
 * [Theory Attribute](theory.md)
-* [Parameterized Tests](xref:ParameterizedTests)
+* [Parameterized Tests](xref:parameterizedtests)

--- a/docs/articles/nunit/writing-tests/attributes/datapointsource.md
+++ b/docs/articles/nunit/writing-tests/attributes/datapointsource.md
@@ -34,4 +34,4 @@ For an example of use, see [Theory Attribute](theory.md)
 ## See Also
 
 * [Theory Attribute](theory.md)
-* [Parameterized Tests](xref:ParameterizedTests)
+* [Parameterized Tests](xref:parameterizedtests)

--- a/docs/articles/nunit/writing-tests/attributes/nontestassembly.md
+++ b/docs/articles/nunit/writing-tests/attributes/nontestassembly.md
@@ -20,4 +20,4 @@ assembly does not contain any tests.
 
 ## See Also
 
-* `--skipnontestassemblies` in [Console-Command-Line](xref:ConsoleCommandLine)
+* `--skipnontestassemblies` in [Console-Command-Line](xref:consolecommandline)

--- a/docs/articles/nunit/writing-tests/attributes/onetimesetup.md
+++ b/docs/articles/nunit/writing-tests/attributes/onetimesetup.md
@@ -63,7 +63,7 @@ class OneTimeSetUp methods before those in the derived classes.
 
  2. OneTimeSetUp methods may be async if running under .NET 4.0 or higher.
 
- 3. OneTimeSetUp methods run in the context of the TestFixture or SetUpFixture, which is separate from the context of    any individual test cases. It's important to keep this in mind when using [TestContext](xref:TestContext) methods and properties within the method.
+ 3. OneTimeSetUp methods run in the context of the TestFixture or SetUpFixture, which is separate from the context of    any individual test cases. It's important to keep this in mind when using [TestContext](xref:testcontext) methods and properties within the method.
 
 ## See Also
 

--- a/docs/articles/nunit/writing-tests/attributes/onetimeteardown.md
+++ b/docs/articles/nunit/writing-tests/attributes/onetimeteardown.md
@@ -64,7 +64,7 @@ class OneTimeTearDown methods after those in the derived classes.
 
  2. OneTimeTearDown methods may be async if running under .NET 4.0 or higher.
 
- 3. OneTimeTearDown methods run in the context of the TestFixture or SetUpFixture, which is separate from the context of any individual test cases. It's important to keep this in mind when using [TestContext](xref:TestContext) methods and properties within the method.
+ 3. OneTimeTearDown methods run in the context of the TestFixture or SetUpFixture, which is separate from the context of any individual test cases. It's important to keep this in mind when using [TestContext](xref:testcontext) methods and properties within the method.
 
 ## See Also
 

--- a/docs/articles/nunit/writing-tests/attributes/property.md
+++ b/docs/articles/nunit/writing-tests/attributes/property.md
@@ -1,5 +1,5 @@
 ---
-uid: PropertyAttribute
+uid: propertyattribute
 ---
 
 # Property

--- a/docs/articles/nunit/writing-tests/attributes/property.md
+++ b/docs/articles/nunit/writing-tests/attributes/property.md
@@ -33,7 +33,7 @@ namespace NUnit.Tests
 The PropertyAttribute is not currently used for any purpose by NUnit itself, other
 than to display them in the XML output file and in the Test Properties
 dialog of the gui. You may also use properties with the `--where` option on the
-command-line in order to select tests to run. See [Test Selection Language](xref:TestSelectionLanguage). Note
+command-line in order to select tests to run. See [Test Selection Language](xref:testselectionlanguage). Note
 that his filtering will only work for properties where the values have type string.
 
 User tests may access properties through the [TestContext](xref:testcontext) or by reflection.

--- a/docs/articles/nunit/writing-tests/attributes/property.md
+++ b/docs/articles/nunit/writing-tests/attributes/property.md
@@ -36,7 +36,7 @@ dialog of the gui. You may also use properties with the `--where` option on the
 command-line in order to select tests to run. See [Test Selection Language](xref:TestSelectionLanguage). Note
 that his filtering will only work for properties where the values have type string.
 
-User tests may access properties through the [TestContext](xref:TestContext) or by reflection.
+User tests may access properties through the [TestContext](xref:testcontext) or by reflection.
 
 ## Custom Property Attributes
 

--- a/docs/articles/nunit/writing-tests/attributes/random.md
+++ b/docs/articles/nunit/writing-tests/attributes/random.md
@@ -31,7 +31,7 @@ public Random(double min, double max, int count);
 public Random(float min, float max, int count);
 ```
 
-In the first form, without minimum and maximum values, the attribute automatically generates values of the appropriate numeric Type for the argument provided, using the `Randomizer` object associated with the current context. See [Randomizer Methods](xref:RandomizerMethods) for details.
+In the first form, without minimum and maximum values, the attribute automatically generates values of the appropriate numeric Type for the argument provided, using the `Randomizer` object associated with the current context. See [Randomizer Methods](xref:randomizermethods) for details.
 
 In general, the forms that specify a minimum and maximum should be used on arguments of the same type. However, the following exceptions are supported:
 

--- a/docs/articles/nunit/writing-tests/attributes/retry.md
+++ b/docs/articles/nunit/writing-tests/attributes/retry.md
@@ -6,4 +6,4 @@ Notes:
 
 1. The argument you specify is the total number of attempts and __not__ the number of retries after an initial failure. So `[Retry(1)]` does nothing and should not be used.
 2. It is not currently possible to use `RetryAttribute` on a `TestFixture` or any other type of test suite. Only single tests may be repeated.
-3. If a test has an unexpected exception, an error result is returned and it is not retried. Only assertion failures can trigger a retry. To convert an unexpected exception into an assertion failure, see the [ThrowsConstraint](xref:ThrowsConstraint).
+3. If a test has an unexpected exception, an error result is returned and it is not retried. Only assertion failures can trigger a retry. To convert an unexpected exception into an assertion failure, see the [ThrowsConstraint](xref:throwsconstraint).

--- a/docs/articles/nunit/writing-tests/attributes/test.md
+++ b/docs/articles/nunit/writing-tests/attributes/test.md
@@ -3,7 +3,7 @@
 The `Test` attribute is one way of marking a method inside a TestFixture class
 as a test. It is normally used for simple (non-parameterized) tests but may
 also be applied to parameterized tests without causing any extra test cases
-to be generated. See [Parameterized Tests](xref:ParameterizedTests) for more info.
+to be generated. See [Parameterized Tests](xref:parameterizedtests) for more info.
 
 The test method may be either an instance or a static method.
 

--- a/docs/articles/nunit/writing-tests/attributes/testcase.md
+++ b/docs/articles/nunit/writing-tests/attributes/testcase.md
@@ -54,7 +54,7 @@ TestCaseAttribute supports a number of additional named parameters:
 * **IgnoreReason** causes this test case to be ignored and specifies the reason.
 * **IncludePlatform** specifies a comma-delimited list of platforms on which the test should run.
 * **Reason** specifies the reason for not running this test case. Use in conjunction with **Explicit**.
-* **TestName** provides a name for the test. If not specified, a name is generated based on the method name and the arguments provided. See [Template Based Test Naming](xref:TemplateBasedTestNaming).
+* **TestName** provides a name for the test. If not specified, a name is generated based on the method name and the arguments provided. See [Template Based Test Naming](xref:templatebasedtestnaming).
 * **TestOf** specifies the Type that this test is testing
 
 ## Order of Execution

--- a/docs/articles/nunit/writing-tests/attributes/testcasesource.md
+++ b/docs/articles/nunit/writing-tests/attributes/testcasesource.md
@@ -157,7 +157,7 @@ the enumerator as follows:
 
 * If it is an object derived from the `TestCaseDataParameters` class,
    its properties are used to provide the test case. NUnit provides
-   the [TestCaseData](xref:TestCaseData) type for this purpose.
+   the [TestCaseData](xref:testcasedata) type for this purpose.
 * If the test has a single argument and the returned value matches the type of
    that argument it is used directly. This can eliminate a bit of extra typing by the programmer,
    as in this example:

--- a/docs/articles/nunit/writing-tests/attributes/testcasesource.md
+++ b/docs/articles/nunit/writing-tests/attributes/testcasesource.md
@@ -8,7 +8,7 @@ uid: testcasesourceattribute
 identify the source from which the required arguments will be provided.
 The attribute additionally identifies the method as a test method.
 The data is kept separate from the test itself and may be used by multiple
-test methods. See [Parameterized Tests](xref:ParameterizedTests) for a general introduction to
+test methods. See [Parameterized Tests](xref:parameterizedtests) for a general introduction to
 tests with arguments.
 
 ## Usage

--- a/docs/articles/nunit/writing-tests/attributes/testfixturesource.md
+++ b/docs/articles/nunit/writing-tests/attributes/testfixturesource.md
@@ -103,7 +103,7 @@ The individual items returned by the enumerator must either be object arrays or 
 In constructing tests, NUnit uses each item returned by
 the enumerator as follows:
 
-* If it is an object deriving from `TestFixtureParameters`, its properties are used to provide the test case. NUnit provides the [TestFixtureData](xref:TestFixtureData) class for this purpose.
+* If it is an object deriving from `TestFixtureParameters`, its properties are used to provide the test case. NUnit provides the [TestFixtureData](xref:testfixturedata) class for this purpose.
 * If it is an `object[]`, its members are used to provide the arguments for the method. This is the approach taken in the examples above.
 
 ## Notes

--- a/docs/articles/nunit/writing-tests/attributes/testfixturesource.md
+++ b/docs/articles/nunit/writing-tests/attributes/testfixturesource.md
@@ -3,7 +3,7 @@
 `TestFixtureSourceAttribute` is used on a parameterized fixture to
 identify the source from which the required constructor arguments will be provided.
 The data is kept separate from the fixture itself and may be used by multiple
-fixtures. See [Parameterized Tests](xref:ParameterizedTests) for a general introduction to
+fixtures. See [Parameterized Tests](xref:parameterizedtests) for a general introduction to
 tests with arguments.
 
 ## Usage

--- a/docs/articles/nunit/writing-tests/attributes/theory.md
+++ b/docs/articles/nunit/writing-tests/attributes/theory.md
@@ -8,14 +8,14 @@ A Theory is a special type of test, used to verify a general
 statement about the system under development. Normal tests are
 _example-based_. That is, the developer supplies one or
 more examples of inputs and expected outputs either within the
-code of the test or - in the case of [Parameterized Tests](xref:ParameterizedTests) -
+code of the test or - in the case of [Parameterized Tests](xref:parameterizedtests) -
 as arguments to the test method. A theory, on the other hand,
 makes a general statement that all of its assertions will pass
 for all arguments satisfying certain assumptions.
 
 Theories are implemented in NUnit as non-generic
 methods within a **TestFixture**, which are annotated
-with the **TheoryAttribute**. Theory methods must always have arguments and therefore appears quite similar to [Parameterized Tests](xref:ParameterizedTests)
+with the **TheoryAttribute**. Theory methods must always have arguments and therefore appears quite similar to [Parameterized Tests](xref:parameterizedtests)
 at first glance. However, a Theory incorporates additional data sources for its arguments and allows special processing for assumptions
 about that data. The key difference, though, is that theories
 make general statements and are more than just a set of examples.
@@ -126,4 +126,4 @@ public class TheorySampleTestsGeneric<T>
 
 * [Datapoint Attribute](datapoint.md)
 * [DatapointSource Attribute](datapointsource.md)
-* [Parameterized Tests](xref:ParameterizedTests)
+* [Parameterized Tests](xref:parameterizedtests)

--- a/docs/articles/nunit/writing-tests/attributes/theory.md
+++ b/docs/articles/nunit/writing-tests/attributes/theory.md
@@ -1,5 +1,5 @@
 ---
-uid: Theory-Attribute
+uid: theoryattribute
 ---
 
 # Theory

--- a/docs/articles/nunit/writing-tests/constraints/EqualConstraint.md
+++ b/docs/articles/nunit/writing-tests/constraints/EqualConstraint.md
@@ -1,5 +1,5 @@
 ---
-uid: EqualConstraint
+uid: equalconstraint
 ---
 
 # Equal Constraint

--- a/docs/articles/nunit/writing-tests/constraints/SameAsConstraint.md
+++ b/docs/articles/nunit/writing-tests/constraints/SameAsConstraint.md
@@ -1,5 +1,5 @@
 ---
-uid: SameAsConstraint
+uid: sameasconstraint
 ---
 
 # SameAs Constraint

--- a/docs/articles/nunit/writing-tests/constraints/ThrowsConstraint.md
+++ b/docs/articles/nunit/writing-tests/constraints/ThrowsConstraint.md
@@ -1,5 +1,5 @@
 ---
-uid: ThrowsConstraint
+uid: throwsconstraint
 ---
 
 # Throws Constraint

--- a/docs/articles/nunit/writing-tests/setup-teardown/SetUp-and-TearDown-Changes.md
+++ b/docs/articles/nunit/writing-tests/setup-teardown/SetUp-and-TearDown-Changes.md
@@ -98,4 +98,4 @@ This is potentially a [breaking change](xref:breakingchanges) for some users.
 
 ## Unresolved Issues
 
-* We need to define how setup and teardown methods are ordered with respect to the newly introduced [Action Attributes](xref:ActionAttributes) and how they interact.
+* We need to define how setup and teardown methods are ordered with respect to the newly introduced [Action Attributes](xref:actionattributes) and how they interact.

--- a/docs/articles/nunit/writing-tests/setup-teardown/SetUp-and-TearDown-Changes.md
+++ b/docs/articles/nunit/writing-tests/setup-teardown/SetUp-and-TearDown-Changes.md
@@ -47,7 +47,7 @@ For NUnit 3.0 we standardized the use of attributes for setup and teardown and r
 
 **TestFixtureSetUpAttribute** and **TestFixtureTearDownAttribute** continue to be supported as synonyms for **OneTimeSetUpAttribute** and **OneTimeTearDownAttribute** in test fixtures, but are deprecated.
 
-Since **SetUpAttribute** and **TearDownAttribute** are used in two different ways, it's not possible to simply deprecate their usage in SetUpFixture. They have been disallowed in that context, which is a [breaking change](xref:BreakingChanges).
+Since **SetUpAttribute** and **TearDownAttribute** are used in two different ways, it's not possible to simply deprecate their usage in SetUpFixture. They have been disallowed in that context, which is a [breaking change](xref:breakingchanges).
 
 ## How Setup and TearDown Methods Are Called
 
@@ -94,7 +94,7 @@ In NUnit 3.0, execution will proceed as follows:
 * BaseSetUp
 * BaseTearDown
 
-This is potentially a [breaking change](xref:BreakingChanges) for some users.
+This is potentially a [breaking change](xref:breakingchanges) for some users.
 
 ## Unresolved Issues
 

--- a/docs/articles/vs-test-adapter/Adapter-Release-Notes.md
+++ b/docs/articles/vs-test-adapter/Adapter-Release-Notes.md
@@ -124,7 +124,7 @@ This release has three major changes.
 
 2. The filter syntax issues we've had with special names and characters have been mostly solved, thanks to excellent work by [John M.Wright](https://github.com/johnmwright).  The filter syntax is now closer to a correct FQN (Full Qualified Name), but this might cause some issues with your own filter in some rare cases.  The fix done resolves a lot of issues, all of them listed below.  For a detailed explanation of what has been done, see the [Pull Request #668](https://github.com/nunit/nunit3-vs-adapter/pull/668).
 
-3. You can now use the NUnit filter syntax, either from command line or through settings in the runsettings file. This was due to an idea by [Michael Letterle](https://github.com/mletterle) and a subsequent implementation [Pull Request #669](https://github.com/nunit/nunit3-vs-adapter/pull/669).  Michael also wrote [a great blog post](https://blog.prokrams.com/2019/12/16/nunit3-filter-dotnet/) to explain how this works, and how he arrived at the solution.  For more information see the [NUnit Test Selection Language](xref:TestSelectionLanguage).
+3. You can now use the NUnit filter syntax, either from command line or through settings in the runsettings file. This was due to an idea by [Michael Letterle](https://github.com/mletterle) and a subsequent implementation [Pull Request #669](https://github.com/nunit/nunit3-vs-adapter/pull/669).  Michael also wrote [a great blog post](https://blog.prokrams.com/2019/12/16/nunit3-filter-dotnet/) to explain how this works, and how he arrived at the solution.  For more information see the [NUnit Test Selection Language](xref:testselectionlanguage).
 
 ### Resolved issues
 

--- a/docs/articles/vs-test-adapter/Tips-And-Tricks.md
+++ b/docs/articles/vs-test-adapter/Tips-And-Tricks.md
@@ -59,7 +59,7 @@ See <https://github.com/nunit/nunit3-vs-adapter/blob/8a9b8a38b7f808a4a78598542dd
 
 #### DefaultTestNamePattern
 
-The default format used to provide test names, expressed as an NUnit [Template Based Test Name Pattern](xref:TemplateBasedTestNaming).
+The default format used to provide test names, expressed as an NUnit [Template Based Test Name Pattern](xref:templatebasedtestnaming).
 
 #### WorkDirectory
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -14,7 +14,7 @@ This web site contains the documentation for all active NUnit projects as well a
 ## Developer Documentation
 
 * [Team practices](xref:teampractices) describe how NUnit works and how our teams work.
-* [Specifications](xref:Specifications) are descriptions of features we plan to add.
+* [Specifications](xref:specifications) are descriptions of features we plan to add.
 
 ## Legacy (NUnit V2) Documentation
 


### PR DESCRIPTION
Resolves #513.

* [x] Look up `xref:[A-Z]` in vscode search with case matching turned on. Searched in `.md` and `.yml` files
* [x] find/replace on the `xref`s
* [x] find/replace on the `uid`
* [x] find/replace on the `topicUid` in toc.yml files
* [x] Look up all uids and change them / topics