### PR TITLE
Remove issue_template.md

### DIFF
--- a/.github/issue_template.md
+++ b/.github/issue_template.md
@@ -1,7 +1,0 @@
-<!-- 
-This repository is for issues with NUnit documentation.
- - If you have an issue with the test framework, go to: https://github.com/nunit/nunit/issues/new
- - If you have an issue with the console runner, go to: https://github.com/nunit/nunit-console/issues/new
- - If you have an issue with the VSTest adapter, go to: https://github.com/nunit/nunit3-vs-adapter/issues/new
- - If you have an issue with another component, go to: https://github.com/nunit#org-repositories
--->


### PR DESCRIPTION
We're now using the github new issue template configuration, which precludes the need for this text in the issue template. 

We may add a template back later, but for now I think this can be removed.