### PR TITLE
Variables in example have been swapped

### DIFF
--- a/cSpell.json
+++ b/cSpell.json
@@ -119,7 +119,8 @@
     "Rebracer",
     "myassembly",
     "FULLNAMES",
-    "markdownlint"
+    "markdownlint",
+    "netcorefactory"
   ],
   "ignoreRegExpList": [
     "\\((.*)\\)", // Markdown links

--- a/docs/articles/nunit/writing-tests/attributes/theory.md
+++ b/docs/articles/nunit/writing-tests/attributes/theory.md
@@ -90,7 +90,7 @@ public class SqrtTests
         double sqrt = Math.Sqrt(num);
 
         Assert.That(sqrt >= 0.0);
-        Assert.That(sqrt * sqrt, Is.EqualTo(num).Within(0.000001));
+        Assert.That(num * num, Is.EqualTo(sqrt).Within(0.000001));
     }
 }
 ```

--- a/docs/articles/vs-test-adapter/Adapter-Release-Notes.md
+++ b/docs/articles/vs-test-adapter/Adapter-Release-Notes.md
@@ -1,5 +1,23 @@
 # Adapter Release Notes
 
+## NUnit3 Test Adapter for Visual Studio - Version 4.0.0-beta.1 - Nov 20, 2020
+
+This beta is based on the earlier alpha version, and includes new fixes, some reported in the alpha. A great thank you to those who reported and checked out the fixes in the alpha!
+
+The alpha has more than 32000 downloads, with only a few issues reported, so we feel safe to move up to a beta.  The time for beta will be much shorter, so we might be able to release a final 4.0.0 version before end of 2020.
+
+We have also been able to shoehorn some new features into the release.
+
+* [770](https://github.com/nunit/nunit3-vs-adapter/issues/770)  "Not a TestFixture, but TestSuite" error when using un-namespaced SetupFixture.
+* [774](https://github.com/nunit/nunit3-vs-adapter/issues/774) Tests not executed if Console.WriteLine() is used.
+* [780](https://github.com/nunit/nunit3-vs-adapter/issues/780) NUnit3TestAdapter 3.17.0 empty output file regression?
+* [781](https://github.com/nunit/nunit3-vs-adapter/issues/781) An exception occurred while test discoverer 'NUnit3TestDiscoverer' was loading tests. Exception: Object reference not set to an instance of an object, with VS2015.
+* [785](https://github.com/nunit/nunit3-vs-adapter/issues/785) Seemingly redundant dependency on Microsoft.DotNet.InternalAbstractions. Thanks to [teo-tsirpanis](https://github.com/teo-tsirpanis) for [PR 790](https://github.com/nunit/nunit3-vs-adapter/pull/790).
+* [786](https://github.com/nunit/nunit3-vs-adapter/issues/786) When using TRX logger, should warn about incompatible test adapter across .NET Framework and .NET Core and/or log where an adapter is located.
+* [788](https://github.com/nunit/nunit3-vs-adapter/issues/788) Documentation: Broken links in user guide [vs-test-adapter/Resources.html].
+* [797](https://github.com/nunit/nunit3-vs-adapter/issues/797) Proprietary licensed files
+* [800](https://github.com/nunit/nunit3-vs-adapter/issues/800) Rerun in azure devops overwrites last test results xml. Thanks to [netcorefactory](https://github.com/netcorefactory) for [PR 799](https://github.com/nunit/nunit3-vs-adapter/pull/799).
+
 ## NUnit3 Test Adapter for Visual Studio - Version 4.0.0-alpha.1 - July 12, 2020
 
 This is an early pre-release version.  

--- a/docs/articles/vs-test-adapter/Tips-And-Tricks.md
+++ b/docs/articles/vs-test-adapter/Tips-And-Tricks.md
@@ -4,7 +4,7 @@ uid: tipsandtricks
 
 # Tips and Tricks
 
-## NUnit 3.x
+## NUnit 3
 
 ### VS Test .Runsettings configuration
 
@@ -40,6 +40,7 @@ The following options are available:
 |[FullnameSeparator](#fullnameseparator)|string|FullNameSep separator|':'|
 |[DiscoveryMethod](#discoverymethod)|enum|How execution discovery is done, options are `Legacy` or `Current`|Current|
 |[AssemblySelectLimit](#assemblyselectlimit)|int|Number of tests accepted before filters are turned off|2000|
+|[NewOutputXmlFileForEachRun](#newoutputxmlfileforeachrun)|bool|Creates a new file for each test run|false|
 
 ### Visual Studio templates for runsettings
 
@@ -233,6 +234,17 @@ If you run from the IDE (Visual Studio) the adapter will receive a list of tests
 This might have an adverse effect if you select a category and you have more than 2000 tests, the category setting will be ignored. In that case, just increase this limit to higher than your number of tests.
 
 You might also receive a list from the command line, and in that case it will also be skipped the same way.  Here the category will be honoured since the category filter will be converted to a NUnit filter.
+
+(From version 4.0.0)
+
+#### NewOutputXmlFileForEachRun
+
+Default behavior is to produce one test output file which is being overwritten for each run  Setting this to `true`, the adapter produces a new test output file for each run, numbering them sequentially.  Default is `false`.
+
+The background is the following scenario, as described by [netcorefactory](https://github.com/netcorefactory) in [Issue 800](https://github.com/nunit/nunit3-vs-adapter/issues/800):
+
+"*Running test in azure devops one can choose to rerun failed ( flaky ) tests. Mostly when running (selenium) e2e tests this becomes important. The .xml results file is currently overwritten each retry run. Other test coverage tooling dependent on this file receives only latest run results.
+Better to allow the possibility to deliver a results file per run.*"
 
 (From version 4.0.0)
 


### PR DESCRIPTION
Just a little nitpick in the example provided in theory.md. The num and sqrt values seem to have been swapped.

`num * num` should equal `Sqrt(num)`, not the other way around.