### PR TITLE
Adds documentation for the FixtureLifeCycle attribute

### DIFF
--- a/docs/articles/nunit/writing-tests/attributes.md
+++ b/docs/articles/nunit/writing-tests/attributes.md
@@ -16,6 +16,7 @@ This table lists all the attributes supported by NUnit.
 | [DefaultFloatingPointTolerance Attribute](attributes/defaultfloatingpointtolerance.md) | Indicates that the test should use the specified tolerance as default for float and double comparisons. |
 | [Description Attribute](attributes/description.md)         | Applies descriptive text to a Test, TestFixture or Assembly. |
 | [Explicit Attribute](attributes/explicit.md)            | Indicates that a test should be skipped unless explicitly run. |
+| [FixtureLifeCycle Attribute](attributes/fixturelifecycle.md)  | Specifies the lifecycle of a Fixture allowing a new instance of a test fixture to be constructed for each test. |
 | [Ignore Attribute](attributes/ignore.md)              | Indicates that a test shouldn't be run for some reason. |
 | [LevelOfParallelism Attribute](attributes/levelofparallelism.md)  | Specifies the level of parallelism at assembly level. |
 | [MaxTime Attribute](attributes/maxtime.md)             | Specifies the maximum time in milliseconds for a test case to succeed. |

--- a/docs/articles/nunit/writing-tests/attributes.md
+++ b/docs/articles/nunit/writing-tests/attributes.md
@@ -16,7 +16,7 @@ This table lists all the attributes supported by NUnit.
 | [DefaultFloatingPointTolerance Attribute](attributes/defaultfloatingpointtolerance.md) | Indicates that the test should use the specified tolerance as default for float and double comparisons. |
 | [Description Attribute](attributes/description.md)         | Applies descriptive text to a Test, TestFixture or Assembly. |
 | [Explicit Attribute](attributes/explicit.md)            | Indicates that a test should be skipped unless explicitly run. |
-| [FixtureLifeCycle Attribute](attributes/fixturelifecycle.md)  | Specifies the lifecycle of a Fixture allowing a new instance of a test fixture to be constructed for each test. |
+| [FixtureLifeCycle Attribute](attributes/fixturelifecycle.md)  | Specifies the lifecycle of a fixture allowing a new instance of a test fixture to be constructed for each test case. Useful in situations where test case parallelism is important. |
 | [Ignore Attribute](attributes/ignore.md)              | Indicates that a test shouldn't be run for some reason. |
 | [LevelOfParallelism Attribute](attributes/levelofparallelism.md)  | Specifies the level of parallelism at assembly level. |
 | [MaxTime Attribute](attributes/maxtime.md)             | Specifies the maximum time in milliseconds for a test case to succeed. |

--- a/docs/articles/nunit/writing-tests/attributes/fixturelifecycle.md
+++ b/docs/articles/nunit/writing-tests/attributes/fixturelifecycle.md
@@ -6,7 +6,7 @@ uid: fixturelifecycleattribute
 
 Added in **NUnit 3.13.**
 
-The **FixtureLifeCycleAttribute** is used to indicate that an instance for a test fixture or all test fixtures in an assembly should be constructed for each test within the fixture or assembly.
+The `FixtureLifeCycleAttribute` is used to indicate that an instance for a test fixture or all test fixtures in an assembly should be constructed for each test within the fixture or assembly.
 
 This attribute may be applied to a test fixture (class) or to a test assembly. It is useful in combination with the [Parallelizable Attribute](parallelizable.md) so that a new instance of a test fixture is constructed for every test within the test fixture. This allows tests to run in isolation without sharing instance fields and properties during parallel test runs. This make running parallel tests easier because it is easier to make your tests thread safe.
 
@@ -14,7 +14,7 @@ This attribute can be applied to classes or to the entire test assembly. If appl
 
 ## LifeCycle Enumeration
 
-The constructor of **FixtureLifeCycleAttribute** takes a **LifeCycle** attribute to indicate if a single instance of a test fixture should be created for all tests or if a new instance should be created for each test.
+The constructor of `FixtureLifeCycleAttribute` takes a `LifeCycle` attribute to indicate if a single instance of a test fixture should be created for all tests or if a new instance should be created for each test.
 
  Value | Meaning
 -------|---------
@@ -23,13 +23,13 @@ The constructor of **FixtureLifeCycleAttribute** takes a **LifeCycle** attribute
 
 ## Notes
 
-1. When using **LifeCycle.InstancePerTestCase**, **OneTimeSetUp** and **OneTimeTearDown** methods must be static and each are only called once. This is required so that the setup or teardown methods do not access instance fields or properties that are reset for every test.
+* When using `LifeCycle.InstancePerTestCase`, the [`OneTimeSetUp`](xref:onetimesetup-attribute) and [`OneTimeTearDown`](xref:onetimeteardown-attribute) methods must be static, and each are only called once. This is required so that the setup or teardown methods do not access instance fields or properties that are reset for every test.
 
-2. When using **LifeCycle.InstancePerTestCase**, a class's constructor will be called before every test is executed and **IDisposable** test fixtures will be disposed after the test is finished.
+* When using `LifeCycle.InstancePerTestCase`, a class's constructor will be called before every test is executed and `IDisposable` test fixtures will be disposed after the test is finished.
 
-3. **SetUp** and **TearDown** methods are called before and after every test.
+* [`SetUp`](xref:setup-attribute) and [`TearDown`](xref:teardown-attribute) methods are called before and after every test.
 
-4. The **Order** attribute is respected.
+* The `Order` attribute is respected.
 
 ## See Also
 

--- a/docs/articles/nunit/writing-tests/attributes/fixturelifecycle.md
+++ b/docs/articles/nunit/writing-tests/attributes/fixturelifecycle.md
@@ -10,7 +10,7 @@ The **FixtureLifeCycleAttribute** is used to indicate that an instance for a tes
 
 This attribute may be applied to a test fixture (class) or to a test assembly. It is useful in combination with the [Parallelizable Attribute](parallelizable.md) so that a new instance of a test fixture is constructed for every test within the test fixture. This allows tests to run in isolation without sharing instance fields and properties during parallel test runs. This make running parallel tests easier because it is easier to make your tests thread safe.
 
-This attribute can be applied to Classes or to the entire test Assembly. If applied to an Assembly, it may be overridden at the class level.
+This attribute can be applied to classes or to the entire test assembly. If applied to an assembly, it may be overridden at the class level.
 
 ## LifeCycle Enumeration
 

--- a/docs/articles/nunit/writing-tests/attributes/fixturelifecycle.md
+++ b/docs/articles/nunit/writing-tests/attributes/fixturelifecycle.md
@@ -1,0 +1,38 @@
+---
+uid: fixturelifecycleattribute
+---
+
+# FixtureLifeCycle
+
+Added in **NUnit 3.13.**
+
+The **FixtureLifeCycleAttribute** is used to indicate that an instance for a test fixture or all test fixtures in an assembly should be constructed for each test within the fixture or assembly.
+
+This attribute may be applied to a test fixture (class) or to a test assembly. It is useful in combination with the [Parallelizable Attribute](parallelizable.md) so that a new instance of a test fixture is constructed for every test within the test fixture. This allows tests to run in isolation without sharing instance fields and properties during parallel test runs. This make running parallel tests easier because it is easier to make your tests thread safe.
+
+This attribute can be applied to Classes or to the entire test Assembly. If applied to an Assembly, it may be overridden at the class level.
+
+## LifeCycle Enumeration
+
+The constructor of **FixtureLifeCycleAttribute** takes a **LifeCycle** attribute to indicate if a single instance of a test fixture should be created for all tests or if a new instance should be created for each test.
+
+ Value | Meaning
+-------|---------
+**LifeCycle.SingleInstance**     | A single instance is created and shared for all test cases
+**LifeCycle.InstancePerTestCase** | A new instance is created for each test case
+
+## Notes
+
+1. When using **LifeCycle.InstancePerTestCase**, **OneTimeSetUp** and **OneTimeTearDown** methods must be static and each are only called once. This is required so that the setup or teardown methods do not access instance fields or properties that are reset for every test.
+
+2. When using **LifeCycle.InstancePerTestCase**, a class's constructor will be called before every test is executed and **IDisposable** test fixtures will be disposed after the test is finished.
+
+3. **SetUp** and **TearDown** methods are called before and after every test.
+
+4. The **Order** attribute is respected.
+
+## See Also
+
+* [Parallelizable Attribute](parallelizable.md)
+* [OneTimeSetUp Attribute](onetimesetup.md)
+* [OneTimeTearDown Atttribute](onetimeteardown.md)

--- a/docs/articles/nunit/writing-tests/attributes/fixturelifecycle.md
+++ b/docs/articles/nunit/writing-tests/attributes/fixturelifecycle.md
@@ -33,6 +33,6 @@ The constructor of **FixtureLifeCycleAttribute** takes a **LifeCycle** attribute
 
 ## See Also
 
-* [Parallelizable Attribute](parallelizable.md)
-* [OneTimeSetUp Attribute](onetimesetup.md)
-* [OneTimeTearDown Attribute](onetimeteardown.md)
+* [Parallelizable Attribute](xref:parallelizableattribute)
+* [OneTimeSetUp Attribute](xref:onetimesetup-attribute)
+* [OneTimeTearDown Attribute](xref:onetimeteardown-attribute)

--- a/docs/articles/nunit/writing-tests/attributes/fixturelifecycle.md
+++ b/docs/articles/nunit/writing-tests/attributes/fixturelifecycle.md
@@ -4,7 +4,7 @@ uid: fixturelifecycleattribute
 
 # FixtureLifeCycle
 
-Added in **NUnit 3.13.**
+Added in **NUnit 3.13**
 
 The `FixtureLifeCycleAttribute` is used to indicate that an instance for a test fixture or all test fixtures in an assembly should be constructed for each test within the fixture or assembly.
 
@@ -18,8 +18,8 @@ The constructor of `FixtureLifeCycleAttribute` takes a `LifeCycle` attribute to 
 
  Value | Meaning
 -------|---------
-**LifeCycle.SingleInstance**     | A single instance is created and shared for all test cases
-**LifeCycle.InstancePerTestCase** | A new instance is created for each test case
+`LifeCycle.SingleInstance`     | A single instance is created and shared for all test cases
+`LifeCycle.InstancePerTestCase` | A new instance is created for each test case
 
 ## Notes
 

--- a/docs/articles/nunit/writing-tests/attributes/fixturelifecycle.md
+++ b/docs/articles/nunit/writing-tests/attributes/fixturelifecycle.md
@@ -35,4 +35,4 @@ The constructor of **FixtureLifeCycleAttribute** takes a **LifeCycle** attribute
 
 * [Parallelizable Attribute](parallelizable.md)
 * [OneTimeSetUp Attribute](onetimesetup.md)
-* [OneTimeTearDown Atttribute](onetimeteardown.md)
+* [OneTimeTearDown Attribute](onetimeteardown.md)

--- a/docs/articles/nunit/writing-tests/attributes/onetimesetup.md
+++ b/docs/articles/nunit/writing-tests/attributes/onetimesetup.md
@@ -58,11 +58,11 @@ class OneTimeSetUp methods before those in the derived classes.
 
 * Although it is possible to define multiple [`OneTimeSetUp`](xref:onetimesetup-attribute) methods in the same class, you should rarely do so. Unlike methods defined in separate classes in the inheritance hierarchy, the order in which they are executed is not guaranteed.
 
- 2. **OneTimeSetUp** methods may be async if running under .NET 4.0 or higher.
+* [`OneTimeSetUp`](xref:onetimesetup-attribute) methods may be async if running under .NET 4.0 or higher.
 
- 3. **OneTimeSetUp** methods run in the context of the **TestFixture** or **SetUpFixture**, which is separate from the context of any individual test cases. It's important to keep this in mind when using [TestContext](xref:testcontext) methods and properties within the method.
+* [`OneTimeSetUp`](xref:onetimesetup-attribute) methods run in the context of the [`TestFixture`](xref:testfixtureattribute) or [`SetUpFixture`](xref:setupfixture-attribute), which is separate from the context of any individual test cases. It's important to keep this in mind when using [`TestContext`](xref:testcontext) methods and properties within the method.
 
- 4. When using **FixtureLifeCycle** with **LifeCycle.InstancePerTestCase**, the **OneTimeTearDown** method must be static and is only called once. This is required so that the setup method does not access instance fields or properties that are reset for every test.
+* When using [`FixtureLifeCycle`](xref:fixturelifecycleattribute) with `LifeCycle.InstancePerTestCase`, the [`OneTimeTearDown`](xref:onetimeteardown-attribute) method must be static and is only called once. This is required so that the setup method does not access instance fields or properties that are reset for every test.
 
 ## See Also
 

--- a/docs/articles/nunit/writing-tests/attributes/onetimesetup.md
+++ b/docs/articles/nunit/writing-tests/attributes/onetimesetup.md
@@ -56,7 +56,7 @@ class OneTimeSetUp methods before those in the derived classes.
 
 ## Notes
 
- 1. Although it is possible to define multiple **OneTimeSetUp** methods in the same class, you should rarely do so. Unlike methods defined in separate classes in the inheritance hierarchy, the order in which they are executed is not guaranteed.
+* Although it is possible to define multiple [`OneTimeSetUp`](xref:onetimesetup-attribute) methods in the same class, you should rarely do so. Unlike methods defined in separate classes in the inheritance hierarchy, the order in which they are executed is not guaranteed.
 
  2. **OneTimeSetUp** methods may be async if running under .NET 4.0 or higher.
 

--- a/docs/articles/nunit/writing-tests/attributes/onetimesetup.md
+++ b/docs/articles/nunit/writing-tests/attributes/onetimesetup.md
@@ -56,17 +56,17 @@ class OneTimeSetUp methods before those in the derived classes.
 
 ## Notes
 
- 1. Although it is possible to define multiple OneTimeSetUp methods
-    in the same class, you should rarely do so. Unlike methods defined in
-    separate classes in the inheritance hierarchy, the order in which they
-    are executed is not guaranteed.
+ 1. Although it is possible to define multiple **OneTimeSetUp** methods in the same class, you should rarely do so. Unlike methods defined in separate classes in the inheritance hierarchy, the order in which they are executed is not guaranteed.
 
- 2. OneTimeSetUp methods may be async if running under .NET 4.0 or higher.
+ 2. **OneTimeSetUp** methods may be async if running under .NET 4.0 or higher.
 
- 3. OneTimeSetUp methods run in the context of the TestFixture or SetUpFixture, which is separate from the context of    any individual test cases. It's important to keep this in mind when using [TestContext](xref:testcontext) methods and properties within the method.
+ 3. **OneTimeSetUp** methods run in the context of the **TestFixture** or **SetUpFixture**, which is separate from the context of any individual test cases. It's important to keep this in mind when using [TestContext](xref:testcontext) methods and properties within the method.
+
+ 4. When using **FixtureLifeCycle** with **LifeCycle.InstancePerTestCase**, the **OneTimeTearDown** method must be static and is only called once. This is required so that the setup method does not access instance fields or properties that are reset for every test.
 
 ## See Also
 
 * [SetUp Attribute](setup.md)
 * [TearDown Attribute](teardown.md)
 * [OneTimeTearDown Attribute](onetimeteardown.md)
+* [FixtureLifeCycle Attribute](fixturelifecycle.md)

--- a/docs/articles/nunit/writing-tests/attributes/onetimeteardown.md
+++ b/docs/articles/nunit/writing-tests/attributes/onetimeteardown.md
@@ -57,19 +57,19 @@ class OneTimeTearDown methods after those in the derived classes.
 
 ## Notes
 
- 1. Although it is possible to define multiple **OneTimeTearDown** methods in the same class, you should rarely do so. Unlike methods defined in separate classes in the inheritance hierarchy, the order in which they are executed is not guaranteed.
+* Although it is possible to define multiple `OneTimeTearDown` methods in the same class, you should rarely do so. Unlike methods defined in separate classes in the inheritance hierarchy, the order in which they are executed is not guaranteed.
 
- 2. **OneTimeTearDown** methods may be async if running under .NET 4.0 or higher.
+ * `OneTimeTearDown` methods may be async if running under .NET 4.0 or higher.
 
- 3. **OneTimeTearDown** methods run in the context of the TestFixture or SetUpFixture, which is separate from the context of any individual test cases. It's important to keep this in mind when using [TestContext](xref:testcontext) methods and properties within the method.
+* `OneTimeTearDown` methods run in the context of the [`TestFixture`](xref:testfixtureattribute) or [`SetUpFixture`](xref:setupfixture-attribute), which is separate from the context of any individual test cases. It's important to keep this in mind when using [`TestContext`](xref:testcontext) methods and properties within the method.
 
- 4. When using **FixtureLifeCycle** with **LifeCycle.InstancePerTestCase**, the **OneTimeTearDown** method must be static and is only called once. This is required so that the teardown method does not access instance fields or properties that are reset for every test.
+* When using  [`FixtureLifeCycle`](xref:fixturelifecycleattribute) with `LifeCycle.InstancePerTestCase`, the `OneTimeTearDown` method must be static and is only called once. This is required so that the teardown method does not access instance fields or properties that are reset for every test.
 
 ## See Also
 
 * [SetUp Attribute](setup.md)
 * [TearDown Attribute](teardown.md)
-* [OneTimeSetUp Attribute](onetimesetup.md)
-* [TestFixture Attribute](testfixture.md)
-* [SetUpFixture Attribute](setupfixture.md)
-* [FixtureLifeCycle Attribute](fixturelifecycle.md)
+* [OneTimeSetUp Attribute](xref:onetimesetup-attribute)
+* [TestFixture Attribute](xref:testfixtureattribute)
+* [SetUpFixture Attribute](xref:setupfixture-attribute)
+* [FixtureLifeCycle Attribute](fixturelifecycleattribute)

--- a/docs/articles/nunit/writing-tests/attributes/onetimeteardown.md
+++ b/docs/articles/nunit/writing-tests/attributes/onetimeteardown.md
@@ -57,14 +57,13 @@ class OneTimeTearDown methods after those in the derived classes.
 
 ## Notes
 
- 1. Although it is possible to define multiple OneTimeTearDown methods
-    in the same class, you should rarely do so. Unlike methods defined in
-    separate classes in the inheritance hierarchy, the order in which they
-    are executed is not guaranteed.
+ 1. Although it is possible to define multiple **OneTimeTearDown** methods in the same class, you should rarely do so. Unlike methods defined in separate classes in the inheritance hierarchy, the order in which they are executed is not guaranteed.
 
- 2. OneTimeTearDown methods may be async if running under .NET 4.0 or higher.
+ 2. **OneTimeTearDown** methods may be async if running under .NET 4.0 or higher.
 
- 3. OneTimeTearDown methods run in the context of the TestFixture or SetUpFixture, which is separate from the context of any individual test cases. It's important to keep this in mind when using [TestContext](xref:testcontext) methods and properties within the method.
+ 3. **OneTimeTearDown** methods run in the context of the TestFixture or SetUpFixture, which is separate from the context of any individual test cases. It's important to keep this in mind when using [TestContext](xref:testcontext) methods and properties within the method.
+
+ 4. When using **FixtureLifeCycle** with **LifeCycle.InstancePerTestCase**, the **OneTimeTearDown** method must be static and is only called once. This is required so that the teardown method does not access instance fields or properties that are reset for every test.
 
 ## See Also
 
@@ -73,3 +72,4 @@ class OneTimeTearDown methods after those in the derived classes.
 * [OneTimeSetUp Attribute](onetimesetup.md)
 * [TestFixture Attribute](testfixture.md)
 * [SetUpFixture Attribute](setupfixture.md)
+* [FixtureLifeCycle Attribute](fixturelifecycle.md)

--- a/docs/articles/nunit/writing-tests/attributes/onetimeteardown.md
+++ b/docs/articles/nunit/writing-tests/attributes/onetimeteardown.md
@@ -59,7 +59,7 @@ class OneTimeTearDown methods after those in the derived classes.
 
 * Although it is possible to define multiple `OneTimeTearDown` methods in the same class, you should rarely do so. Unlike methods defined in separate classes in the inheritance hierarchy, the order in which they are executed is not guaranteed.
 
- * `OneTimeTearDown` methods may be async if running under .NET 4.0 or higher.
+* `OneTimeTearDown` methods may be async if running under .NET 4.0 or higher.
 
 * `OneTimeTearDown` methods run in the context of the [`TestFixture`](xref:testfixtureattribute) or [`SetUpFixture`](xref:setupfixture-attribute), which is separate from the context of any individual test cases. It's important to keep this in mind when using [`TestContext`](xref:testcontext) methods and properties within the method.
 
@@ -72,4 +72,4 @@ class OneTimeTearDown methods after those in the derived classes.
 * [OneTimeSetUp Attribute](xref:onetimesetup-attribute)
 * [TestFixture Attribute](xref:testfixtureattribute)
 * [SetUpFixture Attribute](xref:setupfixture-attribute)
-* [FixtureLifeCycle Attribute](fixturelifecycleattribute)
+* [FixtureLifeCycle Attribute](xref:fixturelifecycleattribute)

--- a/docs/articles/nunit/writing-tests/attributes/parallelizable.md
+++ b/docs/articles/nunit/writing-tests/attributes/parallelizable.md
@@ -4,16 +4,16 @@ uid: parallelizableattribute
 
 # Parallelizable
 
-Added in **NUnit 3.7.**
+Added in **NUnit 3.7**
 
-The **ParallelizableAttribute** is used to indicate that a test and/or its descendants may be run in parallel with other tests. By default, no parallel execution takes place.
+The `ParallelizableAttribute` is used to indicate that a test and/or its descendants may be run in parallel with other tests. By default, no parallel execution takes place.
 
-When used without an argument, **Parallelizable** causes the test fixture or method on which it is placed to be queued for execution in parallel with other parallelizable tests. It may be used at the assembly, class or method level.
+When used without an argument, `Parallelizable` causes the test fixture or method on which it is placed to be queued for execution in parallel with other parallelizable tests. It may be used at the assembly, class or method level.
 
 > [!WARNING]
-> When tests are run in parallel, you are responsible for the thread safety of your tests. Tests that run at the same time and modify instance fields or properties without locks will cause unexpected behavior as they would in any multi-threaded program. If you are using fields or properties between parallel tests consider using the **FixtureLifeCycleAttribute** to construct a new instance of a test fixture (class) for each test that is run.
+> When tests are run in parallel, you are responsible for the thread safety of your tests. Tests that run at the same time and modify instance fields or properties without locks will cause unexpected behavior as they would in any multi-threaded program. If you are using fields or properties between parallel tests consider using the [`FixtureLifeCycleAttribute`](xref:fixturelifecycleattribute) to construct a new instance of a test fixture (class) for each test that is run.
 
-The constructor takes an optional **ParallelScope** enumeration argument (see below), which indicates whether the attribute applies to the item itself, to its descendants or both. It defaults to **ParallelScope.Self**. The Scope may also be specified using the named property **scope=**, for example;
+The constructor takes an optional `ParallelScope` enumeration argument (see below), which indicates whether the attribute applies to the item itself, to its descendants or both. It defaults to `ParallelScope.Self`. The Scope may also be specified using the constructor argument `scope:`, for example;
 
 ```csharp
 [Parallelizable(scope: ParallelScope.All)]
@@ -25,10 +25,10 @@ This is a **[Flags]** enumeration used to specify which tests may run in paralle
 
  Value | Meaning | Valid On
 -------|---------|---------
-**ParallelScope.Self**     | the test itself may be run in parallel with other tests | Classes, Methods
-**ParallelScope.Children** | child tests may be run in parallel with one another     | Assembly, Classes
-**ParallelScope.Fixtures** | fixtures may be run in parallel with one another        | Assembly, Classes
-**ParallelScope.All**      | the test and its descendants may be run in parallel with others at the same level | Classes, Methods
+`ParallelScope.Self`     | the test itself may be run in parallel with other tests | Classes, Methods
+`ParallelScope.Children` | child tests may be run in parallel with one another     | Assembly, Classes
+`ParallelScope.Fixtures` | fixtures may be run in parallel with one another        | Assembly, Classes
+`ParallelScope.All`      | the test and its descendants may be run in parallel with others at the same level | Classes, Methods
 
 ## Notes
 

--- a/docs/articles/nunit/writing-tests/attributes/parallelizable.md
+++ b/docs/articles/nunit/writing-tests/attributes/parallelizable.md
@@ -34,7 +34,7 @@ This is a **[Flags]** enumeration used to specify which tests may run in paralle
 
 * Some values are invalid on certain elements, although they will compile. NUnit will report any tests so marked as invalid and will produce an error message.
 
-2. The **ParallelScope** enum has additional values, which are used internally but are not visible to users through Intellisense.
+* The `ParallelScope` enum has additional values, which are used internally but are not visible to users through Intellisense.
 
 3. The **ParallelizableAttribute** may be specified on multiple levels of the tests. Settings at a higher level may affect lower level tests, unless those lower-level tests override the inherited settings.
 

--- a/docs/articles/nunit/writing-tests/attributes/parallelizable.md
+++ b/docs/articles/nunit/writing-tests/attributes/parallelizable.md
@@ -36,7 +36,7 @@ This is a **[Flags]** enumeration used to specify which tests may run in paralle
 
 * The `ParallelScope` enum has additional values, which are used internally but are not visible to users through Intellisense.
 
-3. The **ParallelizableAttribute** may be specified on multiple levels of the tests. Settings at a higher level may affect lower level tests, unless those lower-level tests override the inherited settings.
+* The `ParallelizableAttribute` may be specified on multiple levels of the tests. Settings at a higher level may affect lower level tests, unless those lower-level tests override the inherited settings.
 
 ## See Also
 

--- a/docs/articles/nunit/writing-tests/attributes/parallelizable.md
+++ b/docs/articles/nunit/writing-tests/attributes/parallelizable.md
@@ -40,6 +40,6 @@ This is a **[Flags]** enumeration used to specify which tests may run in paralle
 
 ## See Also
 
-* [FixtureLifeCycle Attribute](fixturelifecycle.md)
+* [FixtureLifeCycle Attribute](xref:fixturelifecycleattribute)
 * [NonParallelizable Attribute](nonparallelizable.md)
 * [LevelOfParallelism Attribute](levelofparallelism.md)

--- a/docs/articles/nunit/writing-tests/attributes/parallelizable.md
+++ b/docs/articles/nunit/writing-tests/attributes/parallelizable.md
@@ -32,7 +32,7 @@ This is a **[Flags]** enumeration used to specify which tests may run in paralle
 
 ## Notes
 
-1. Some values are invalid on certain elements, although they will compile. NUnit will report any tests so marked as invalid and will produce an error message.
+* Some values are invalid on certain elements, although they will compile. NUnit will report any tests so marked as invalid and will produce an error message.
 
 2. The **ParallelScope** enum has additional values, which are used internally but are not visible to users through Intellisense.
 

--- a/docs/articles/nunit/writing-tests/attributes/parallelizable.md
+++ b/docs/articles/nunit/writing-tests/attributes/parallelizable.md
@@ -15,7 +15,7 @@ When used without an argument, **Parallelizable** causes the test fixture or met
 
 The constructor takes an optional **ParallelScope** enumeration argument (see below), which indicates whether the attribute applies to the item itself, to its descendants or both. It defaults to **ParallelScope.Self**. The Scope may also be specified using the named property **scope=**, for example;
 
-```c#
+```csharp
 [Parallelizable(scope: ParallelScope.All)]
 ```
 

--- a/docs/articles/nunit/writing-tests/attributes/parallelizable.md
+++ b/docs/articles/nunit/writing-tests/attributes/parallelizable.md
@@ -4,11 +4,20 @@ uid: parallelizableattribute
 
 # Parallelizable
 
+Added in **NUnit 3.7.**
+
 The **ParallelizableAttribute** is used to indicate that a test and/or its descendants may be run in parallel with other tests. By default, no parallel execution takes place.
 
 When used without an argument, **Parallelizable** causes the test fixture or method on which it is placed to be queued for execution in parallel with other parallelizable tests. It may be used at the assembly, class or method level.
 
-The constructor takes an optional **ParallelScope** enumeration argument (see below), which indicates whether the attribute applies to the item itself, to its descendants or both. It defaults to **ParallelScope.Self**. The Scope may also be specified using the named property **Scope=**.
+> [!WARNING]
+> When tests are run in parallel, you are responsible for the thread safety of your tests. Tests that run at the same time and modify instance fields or properties without locks will cause unexpected behavior as they would in any multi-threaded program. If you are using fields or properties between parallel tests consider using the **FixtureLifeCycleAttribute** to construct a new instance of a test fixture (class) for each test that is run.
+
+The constructor takes an optional **ParallelScope** enumeration argument (see below), which indicates whether the attribute applies to the item itself, to its descendants or both. It defaults to **ParallelScope.Self**. The Scope may also be specified using the named property **scope=**, for example;
+
+```c#
+[Parallelizable(scope: ParallelScope.All)]
+```
 
 ## ParallelScope Enumeration
 
@@ -24,10 +33,13 @@ This is a **[Flags]** enumeration used to specify which tests may run in paralle
 ## Notes
 
 1. Some values are invalid on certain elements, although they will compile. NUnit will report any tests so marked as invalid and will produce an error message.
+
 2. The **ParallelScope** enum has additional values, which are used internally but are not visible to users through Intellisense.
+
 3. The **ParallelizableAttribute** may be specified on multiple levels of the tests. Settings at a higher level may affect lower level tests, unless those lower-level tests override the inherited settings.
 
 ## See Also
 
+* [FixtureLifeCycle Attribute](fixturelifecycle.md)
 * [NonParallelizable Attribute](nonparallelizable.md)
 * [LevelOfParallelism Attribute](levelofparallelism.md)


### PR DESCRIPTION
Fixes #534

Adds documentation for the new `FixtureLifeCycle` attribute and updates the docs for related attributes.

@jnm2 can you review this for accuracy please?