### PR TITLE
Added mandatory file header of nunit-console

### DIFF
--- a/docs/articles/developer-info/NUnit-Copyright-Notice.md
+++ b/docs/articles/developer-info/NUnit-Copyright-Notice.md
@@ -1,5 +1,6 @@
 # NUnit Copyright Notice
 
+## NUnit
 ```text
 // ***********************************************************************
 // Copyright (c) yyyy Charlie Poole
@@ -23,4 +24,9 @@
 // OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 // ***********************************************************************
+```
+
+## NUnit Console
+```text
+// Copyright (c) Charlie Poole, Rob Prouse and Contributors. MIT License - see LICENSE.txt
 ```

--- a/docs/articles/developer-info/NUnit-Copyright-Notice.md
+++ b/docs/articles/developer-info/NUnit-Copyright-Notice.md
@@ -4,7 +4,7 @@
 
 ```text
 // ***********************************************************************
-// Copyright (c) yyyy Charlie Poole
+// Copyright (c) yyyy Charlie Poole, Rob Prouse
 //
 // Permission is hereby granted, free of charge, to any person obtaining
 // a copy of this software and associated documentation files (the

--- a/docs/articles/developer-info/NUnit-Copyright-Notice.md
+++ b/docs/articles/developer-info/NUnit-Copyright-Notice.md
@@ -1,6 +1,7 @@
 # NUnit Copyright Notice
 
 ## NUnit
+
 ```text
 // ***********************************************************************
 // Copyright (c) yyyy Charlie Poole
@@ -27,6 +28,7 @@
 ```
 
 ## NUnit Console
+
 ```text
 // Copyright (c) Charlie Poole, Rob Prouse and Contributors. MIT License - see LICENSE.txt
 ```


### PR DESCRIPTION
Since [PR #876](https://github.com/nunit/nunit-console/pull/876) the nunit-console project requires the following copyright-notice
```text
// Copyright (c) Charlie Poole, Rob Prouse and Contributors. MIT License - see LICENSE.txt
```