### PR TITLE
Add link to build process from build badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 This repository serves the content that is found at <http://docs.nunit.org>.
 
-![NUnit Documentation Build Process](https://github.com/nunit/docs/workflows/NUnit%20Documentation%20Build%20Process/badge.svg)
+[![NUnit Documentation Build Process](https://github.com/nunit/docs/actions/workflows/build-process.yml/badge.svg)](https://github.com/nunit/docs/actions/workflows/build-process.yml)
 
 ## What is the Docs site? How does it work?
 


### PR DESCRIPTION
Make the badge link to the build process and not to the image