### PR TITLE
Use GitHub Action rather published docker image

### DIFF
--- a/.github/workflows/build-process.yml
+++ b/.github/workflows/build-process.yml
@@ -39,7 +39,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
         name: Check out the code
-      - uses: "docker://nunitdocs/docfx-action:v1.4.0"
+      - uses: "nunit/docfx-action@v1.5.0"
         name: Build with Docfx
         with:
           args: docs/docfx.json --warningsAsErrors true


### PR DESCRIPTION
Our build process refers to a published docker image. 

Rather than that, we should be able to use the Dockerfile that is in the GitHub Action's repo itself. 

I think this will avoid needing to publish an image to Docker hub, and allow us to clean up that extraneous DockerHub account etc.