### PR TITLE
Move console release notes

### DIFF
--- a/docs/articles/nunit-engine/release-notes.md
+++ b/docs/articles/nunit-engine/release-notes.md
@@ -2,7 +2,7 @@
 uid: consoleenginereleasenotes
 ---
 
-# Console and Engine
+# Console and Engine Release Notes
 
 ## NUnit Console & Engine 3.13 - November 30, 2021
 

--- a/docs/articles/nunit-engine/release-notes.md
+++ b/docs/articles/nunit-engine/release-notes.md
@@ -1,3 +1,7 @@
+---
+uid: consoleenginereleasenotes
+---
+
 # Console and Engine
 
 ## NUnit Console & Engine 3.13 - November 30, 2021

--- a/docs/articles/nunit-engine/toc.yml
+++ b/docs/articles/nunit-engine/toc.yml
@@ -7,3 +7,5 @@
 - name: Engine Extensions
   href: extensions/toc.yml
   topicHref: extensions/Index.md
+- name: Release Notes 
+  href: release-notes.md

--- a/docs/articles/nunit/release-notes/Pre-3.5-Release-Notes.md
+++ b/docs/articles/nunit/release-notes/Pre-3.5-Release-Notes.md
@@ -8,7 +8,7 @@ uid: pre35releasenotes
 > Combined Release Notes for the NUnit framework, console and engine, up to version 3.5. For later releases, see:
 >
 > * [Framework Release Notes](framework.md)
-> * [Console Release Notes](console-and-engine.md)
+> * [Console Release Notes](xref:consoleenginereleasenotes)
 
 ## NUnit 3.5 -  October 3, 2016
 

--- a/docs/articles/nunit/release-notes/toc.yml
+++ b/docs/articles/nunit/release-notes/toc.yml
@@ -1,7 +1,7 @@
 - name: Framework
   href: framework.md
 - name: Console and Engine
-  href: console-and-engine.md
+  topicHref: consoleenginereleasenotes
 - name: Breaking Changes
   topicUid: breakingchanges
 - name: Pre-3.5 Release notes

--- a/docs/articles/nunit/release-notes/toc.yml
+++ b/docs/articles/nunit/release-notes/toc.yml
@@ -1,7 +1,7 @@
 - name: Framework
   href: framework.md
 - name: Console and Engine
-  xref: consoleenginereleasenotes
+  topicUid: consoleenginereleasenotes
 - name: Breaking Changes
   topicUid: breakingchanges
 - name: Pre-3.5 Release notes

--- a/docs/articles/nunit/release-notes/toc.yml
+++ b/docs/articles/nunit/release-notes/toc.yml
@@ -1,7 +1,7 @@
 - name: Framework
   href: framework.md
 - name: Console and Engine
-  topicHref: consoleenginereleasenotes
+  xref: consoleenginereleasenotes
 - name: Breaking Changes
   topicUid: breakingchanges
 - name: Pre-3.5 Release notes

--- a/docs/articles/vs-test-adapter/AdapterV4-Release-Notes.md
+++ b/docs/articles/vs-test-adapter/AdapterV4-Release-Notes.md
@@ -11,7 +11,7 @@ This is a bug fix release, with the following fixes:
 
 ### Engine update
 
-The NUnit.Engine has been updated to version 3.13 in this release.  See [engine release notes](topicHref:consoleenginereleasenotes) for details.
+The NUnit.Engine has been updated to version 3.13 in this release.  See [engine release notes](xref:consoleenginereleasenotes) for details.
 
 ### Development
 

--- a/docs/articles/vs-test-adapter/AdapterV4-Release-Notes.md
+++ b/docs/articles/vs-test-adapter/AdapterV4-Release-Notes.md
@@ -11,7 +11,7 @@ This is a bug fix release, with the following fixes:
 
 ### Engine update
 
-The NUnit.Engine has been updated to version 3.13 in this release.  See [engine release notes](~/articles/nunit/release-notes/console-and-engine.md) for details.
+The NUnit.Engine has been updated to version 3.13 in this release.  See [engine release notes](topicHref:consoleenginereleasenotes) for details.
 
 ### Development
 


### PR DESCRIPTION
Resolves #609.

Releases notes for console/engine now live under Engine:

> ![image](https://user-images.githubusercontent.com/2148318/145921861-f220864a-e9e9-44be-86a6-64b820e8b04b.png)

Link remains under `NUnit` section.

> ![image](https://user-images.githubusercontent.com/2148318/145921955-7df2a886-ac56-4f7d-979e-4b50e8bef53f.png)

All other links now use a reference to the `uid` that was added for the article in this PR.