### PR TITLE
Update Assert.Throws.md

### DIFF
--- a/docs/articles/nunit/writing-tests/assertions/classic-assertions/Assert.Throws.md
+++ b/docs/articles/nunit/writing-tests/assertions/classic-assertions/Assert.Throws.md
@@ -113,11 +113,11 @@ types. See the following code for examples:
 ```csharp
 // Require an ApplicationException - derived types fail!
 Assert.Throws(typeof(ApplicationException), code);
-Assert.Throws<ApplicationException>()(code);
+Assert.Throws<ApplicationException>(code);
 
 // Allow both ApplicationException and any derived type
-Assert.Throws(Is.InstanceOf(typeof(ApplicationException), code);
-Assert.Throws(Is.InstanceOf<ApplicationException>;(), code);
+Assert.Throws(Is.InstanceOf(typeof(ApplicationException)), code);
+Assert.Throws(Is.InstanceOf<ApplicationException>(), code);
 
 // Allow both ApplicationException and any derived type
 Assert.Catch<ApplicationException>(code);


### PR DESCRIPTION
There is currently non-compiling code in some of the Assert.Throws examples.

* Fix brackets and semicolons to correct C# syntax.