### PR TITLE
Use dockerfile from GitHub Container Registry

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,4 +1,4 @@
-FROM nunitdocs/docfx-action:v1.4.0
+FROM docker pull ghcr.io/nunit/docfx-action:master
 EXPOSE 8080
 
 ### Installing Node into the container -- from https://github.com/nodejs/docker-node/tree/main/16/buster-slim


### PR DESCRIPTION
Supports #627. 

May resolve it; not sure.

This updates the Dockerfile for our codespaces definition to use the recently created [GitHub Container Registry container for nunit-docfx](https://github.com/nunit/docfx-action/pull/8).