### PR TITLE
Standardize linting tooling on asterisk as list style

### DIFF
--- a/.github/linters/.markdown-lint.yml
+++ b/.github/linters/.markdown-lint.yml
@@ -22,6 +22,8 @@ MD024: false
 MD013: false
 MD026: false
 MD046: false # Mix of indented and fenced code blocks
+MD004:
+  style: asterisk
 # MD004: false                  # Unordered list style
 # MD007:
 #   indent: 2                   # Unordered list indentation

--- a/.markdownlintrc
+++ b/.markdownlintrc
@@ -2,5 +2,8 @@
     "MD024": false,
     "MD013": false,
     "MD026": false,
-    "MD046": false
+    "MD046": false,
+    "MD004": {
+        "style": "asterisk"
+    }
 }

--- a/docs/articles/nunit/getting-started/dotnet-core-and-dotnet-standard.md
+++ b/docs/articles/nunit/getting-started/dotnet-core-and-dotnet-standard.md
@@ -45,11 +45,11 @@ This limitation is the same for all test adapters including xUnit and MSTest2.
 
 #### My tests aren't showing up in Visual Studio 2017 or later
 
-- Are you using the NuGet adapter package?
-- Are you using version 4.1.0 or newer of the NuGet package?
-- Do your tests target .NET Core or the full .NET Framework? (see above)
-- Have you added a Package Reference to `Microsoft.NET.Test.Sdk`?
-- Have you restarted Visual Studio? It is still a bit temperamental.
+* Are you using the NuGet adapter package?
+* Are you using version 4.1.0 or newer of the NuGet package?
+* Do your tests target .NET Core or the full .NET Framework? (see above)
+* Have you added a Package Reference to `Microsoft.NET.Test.Sdk`?
+* Have you restarted Visual Studio? It is still a bit temperamental.
 
 #### My tests multi-target .NET Core and .NET Framework, why can't I run both in Visual Studio
 


### PR DESCRIPTION
Previously, the linting rule defaulted to ensuring that list items were consistent within a doc.

This makes it explicit in our tooling that asterisks are the standard (as they're in 99% of the docs already).

CC @CharliePoole per our discussion