### PR TITLE
Use cSpell patterns

### DIFF
--- a/cSpell.json
+++ b/cSpell.json
@@ -141,10 +141,60 @@
         "unsortable",
         "Dalsbø"
     ],
-    "ignoreRegExpList": [
-        "\\((.*)\\)", // Markdown links
-        "uid: (.*)", // uid lines,
-        "```[a-z]*\n[\\s\\S]*?\n```", // Markdown code blocks. h/t https://coderwall.com/p/r6b4xg/regex-to-match-github-s-markdown-code-blocks,
-        "\\`([^\\`].*?)\\`" // inline code blocks. h/t https://stackoverflow.com/questions/41274241/how-to-capture-inline-markdown-code-but-not-a-markdown-code-fence-with-regex
-    ]
+    "patterns": [
+        {
+          "name": "Markdown links",
+          "pattern": "\\((.*)\\)",
+          "description": ""
+        },
+        {
+          "name": "Markdown code blocks",
+          "pattern": "/^(\\s*`{3,}).*[\\s\\S]*?^\\1/gmx",
+          "description": "Taken from the cSpell example at https://cspell.org/configuration/patterns/#verbose-regular-expressions"
+        },
+        {
+          "name": "Inline code blocks",
+          "pattern": "\\`([^\\`\\r\\n]+?)\\`",
+          "description": "https://stackoverflow.com/questions/41274241/how-to-capture-inline-markdown-code-but-not-a-markdown-code-fence-with-regex"
+        },
+        {
+          "name": "Link contents",
+          "pattern": "\\<a(.*)\\>",
+          "description": ""
+        },
+        {
+          "name": "Snippet references",
+          "pattern": "-- snippet:(.*)",
+          "description": ""
+        },
+        {
+          "name": "Snippet references 2",
+          "pattern": "\\<\\[sample:(.*)",
+          "description": "another kind of snippet reference"
+        },
+        {
+          "name": "Multi-line code blocks",
+          "pattern": "/^\\s*```[\\s\\S]*?^\\s*```/gm"
+        },
+        {
+          "name": "HTML Tags",
+          "pattern": "<[^>]*>",
+          "description": "Reference: https://stackoverflow.com/questions/11229831/regular-expression-to-remove-html-tags-from-a-string"
+        },
+        {
+            "name": "UID Lines",
+            "pattern": "uid: (.*)"
+        }
+      ],
+      "ignoreRegExpList": [
+        "Markdown links",
+        "Markdown code blocks",
+        "Inline code blocks",
+        "Link contents",
+        "Snippet references",
+        "Snippet references 2",
+        "Multi-line code blocks",
+        "HTML Tags",
+        "UID Lines"
+      ]
 }


### PR DESCRIPTION
Resolves #682.

This is the recommended way of setting regex patterns for cSpell. Bonus: it allows the file to be valid JSON now.