### PR TITLE
Switch to new container edition for builds

### DIFF
--- a/.github/workflows/build-process.yml
+++ b/.github/workflows/build-process.yml
@@ -39,6 +39,10 @@ jobs:
     steps:
       - uses: actions/checkout@v3
         name: Check out the code
+      - name: Set ownership
+        run: |
+          # this is to fix GIT not liking owner of the checkout dir
+          chown -R $(id -u):$(id -g) $PWD
       - uses: "nunit/docfx-action@v2.0.0-preview.1"
         name: Build with Docfx
         with:

--- a/.github/workflows/build-process.yml
+++ b/.github/workflows/build-process.yml
@@ -15,8 +15,6 @@ jobs:
     steps:
       - uses: actions/checkout@v3
         name: Check out the code
-        with:
-          set-safe-directory: ${{ github.workspace }}
       - name: Lint Code Base
         uses: docker://avtodev/markdown-lint:v1
         with:
@@ -27,8 +25,6 @@ jobs:
     steps:
       - uses: actions/checkout@v3
         name: Check out the code
-        with:
-          set-safe-directory: ${{ github.workspace }}
       - uses: actions/setup-node@v1
         name: Setup node
         with:
@@ -43,8 +39,6 @@ jobs:
     steps:
       - uses: actions/checkout@v3
         name: Check out the code
-        with:
-          set-safe-directory: ${{ github.workspace }}
       - uses: "nunit/docfx-action@v2.0.0-preview.3"
         name: Build with Docfx
         with:

--- a/.github/workflows/build-process.yml
+++ b/.github/workflows/build-process.yml
@@ -45,8 +45,6 @@ jobs:
         name: Check out the code
         with:
           set-safe-directory: ${{ github.workspace }}
-      - name: Explicitly mark all folders as safe
-        run: git config --system --add safe.directory '*'
       - uses: "nunit/docfx-action@v2.0.0-preview.3"
         name: Build with Docfx
         with:

--- a/.github/workflows/build-process.yml
+++ b/.github/workflows/build-process.yml
@@ -13,7 +13,7 @@ jobs:
     name: "Markdown linting"
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         name: Check out the code
       - name: Lint Code Base
         uses: docker://avtodev/markdown-lint:v1
@@ -23,7 +23,7 @@ jobs:
     name: "Spell check"
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         name: Check out the code
       - uses: actions/setup-node@v1
         name: Setup node
@@ -37,7 +37,7 @@ jobs:
     name: "Build the site with docfx"
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         name: Check out the code
       - uses: "nunit/docfx-action@v2.0.0-preview.1"
         name: Build with Docfx

--- a/.github/workflows/build-process.yml
+++ b/.github/workflows/build-process.yml
@@ -46,8 +46,8 @@ jobs:
         with:
           set-safe-directory: ${{ github.workspace }}
       - name: Explicitly mark all folders as safe
-        run: git config --global --add safe.directory '*'
-      - uses: "nunit/docfx-action@v2.0.0-preview.2"
+        run: git config --system --add safe.directory '*'
+      - uses: "nunit/docfx-action@v2.0.0-preview.3"
         name: Build with Docfx
         with:
           args: docs/docfx.json --warningsAsErrors true

--- a/.github/workflows/build-process.yml
+++ b/.github/workflows/build-process.yml
@@ -39,7 +39,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
         name: Check out the code
-      - uses: "nunit/docfx-action@v1.11.0"
+      - uses: "nunit/docfx-action@v2.0.0-preview.1"
         name: Build with Docfx
         with:
           args: docs/docfx.json --warningsAsErrors true

--- a/.github/workflows/build-process.yml
+++ b/.github/workflows/build-process.yml
@@ -15,6 +15,8 @@ jobs:
     steps:
       - uses: actions/checkout@v3
         name: Check out the code
+        with:
+          set-safe-directory: ${{ github.workspace }}
       - name: Lint Code Base
         uses: docker://avtodev/markdown-lint:v1
         with:
@@ -25,6 +27,8 @@ jobs:
     steps:
       - uses: actions/checkout@v3
         name: Check out the code
+        with:
+          set-safe-directory: ${{ github.workspace }}
       - uses: actions/setup-node@v1
         name: Setup node
         with:
@@ -39,10 +43,8 @@ jobs:
     steps:
       - uses: actions/checkout@v3
         name: Check out the code
-      - name: Set ownership
-        run: |
-          # this is to fix GIT not liking owner of the checkout dir
-          chown -R $(id -u):$(id -g) $PWD
+        with:
+          set-safe-directory: ${{ github.workspace }}
       - uses: "nunit/docfx-action@v2.0.0-preview.1"
         name: Build with Docfx
         with:

--- a/.github/workflows/build-process.yml
+++ b/.github/workflows/build-process.yml
@@ -45,6 +45,8 @@ jobs:
         name: Check out the code
         with:
           set-safe-directory: ${{ github.workspace }}
+      - name: Explicitly mark all folders as safe
+        run: git config --global --add safe.directory '*'
       - uses: "nunit/docfx-action@v2.0.0-preview.2"
         name: Build with Docfx
         with:

--- a/.github/workflows/build-process.yml
+++ b/.github/workflows/build-process.yml
@@ -45,7 +45,7 @@ jobs:
         name: Check out the code
         with:
           set-safe-directory: ${{ github.workspace }}
-      - uses: "nunit/docfx-action@v2.0.0-preview.1"
+      - uses: "nunit/docfx-action@v2.0.0-preview.2"
         name: Build with Docfx
         with:
           args: docs/docfx.json --warningsAsErrors true


### PR DESCRIPTION
Supports #687.

Docfx recently released 2.60.0-preview.2 which is now a cross-platform .NET Global Tool. This is very exciting and allowed us to re-do the docfx-action to use the .NET SDK Ubuntu-based container which I think is going to give us really nice flexibility in the future.

This PR is to adopt our new action, though it's still in preview, to work out any issues.

* [x] Change to docfx-action v2.0.0-preview.3 preview container