### PR TITLE
Markdown linting: latest tooling & accompanying fixes

### DIFF
--- a/.github/workflows/build-process.yml
+++ b/.github/workflows/build-process.yml
@@ -15,10 +15,14 @@ jobs:
     steps:
       - uses: actions/checkout@v3
         name: Check out the code
-      - name: Lint Code Base
-        uses: docker://avtodev/markdown-lint:v1
+      - uses: actions/setup-node@v1
+        name: Setup node
         with:
-          args: "docs/**/*.md"
+          node-version: "18"
+      - run: npm install -g markdownlint-cli
+        name: Install markdownlint
+      - run: markdownlint -c /workspaces/docs/.github/linters/.markdown-lint.yml /workspaces/docs/docs/**/*.md
+        name: run Markdownlint
   spellcheck:
     name: "Spell check"
     runs-on: ubuntu-latest

--- a/docs/articles/developer-info/Packaging-the-V3-Adapter.md
+++ b/docs/articles/developer-info/Packaging-the-V3-Adapter.md
@@ -95,5 +95,3 @@ Test both the vsix and NuGet packages using each version of Visual Studio you ha
 [semantic versioning]:https://semver.org/
 [Visual Studio Gallery]:https://visualstudiogallery.msdn.microsoft.com/0da0f6bd-9bb6-4ae3-87a8-537788622f2d
 [NuGet for the adapter]:https://www.nuget.org/packages/NUnitTestAdapter/
-[NuGet for the adapter with framework]:https://www.nuget.org/packages/NUnitTestAdapter.WithFramework/
-[nunit.org repository]:https://github.com/nunit/nunit.org

--- a/docs/articles/nunit/technical-notes/nunit-internals/Framework-Api.md
+++ b/docs/articles/nunit/technical-notes/nunit-internals/Framework-Api.md
@@ -110,9 +110,9 @@ public ExploreTestsAction(FrameworkController controller, string filter, object 
 
 where
 
-* **controller** is the FrameworkController instance that was created for managing the test assembly.
-* **filter** is the string representation of a filter in XML format to be used when exploring tests.
-* **handler** is an object implementing ICallbackEventHandler, to receive the result of the call.
+* __controller__ is the FrameworkController instance that was created for managing the test assembly.
+* __filter__ is the string representation of a filter in XML format to be used when exploring tests.
+* __handler__ is an object implementing ICallbackEventHandler, to receive the result of the call.
 
 The result returned from `handler.GetCallbackResult()` is the XML representation of the test assembly, containing all tests that passed the filter, arranged as a tree with child tests contained within their parents.
 

--- a/docs/articles/nunit/technical-notes/usage/Engine-Parallel-Test-Execution.md
+++ b/docs/articles/nunit/technical-notes/usage/Engine-Parallel-Test-Execution.md
@@ -4,7 +4,7 @@ The NUnit test engine is able to offer a certain degree of parallelization by ru
 
 If tests are already split across multiple assemblies, this is the simplest way to improve performance through parallel execution. By running in separate processes, the tests in each assembly are independent of one another so long as they do not use any common external resources such as files or databases. **Parallel execution is the default behavior** when running multiple assemblies together using the `nunit3-console` runner.
 
-Normally, __all__ the test processes run simultaneously. If you need to reduce the number of processes allowed to run at one time, you may specify a value for the `--agents` option on the `nunit3-console` command-line. For example, if you are running tests in 10 different processes, a setting of `--agents=3` will allow no more than three of them to execute simultaneously.
+Normally, **all** the test processes run simultaneously. If you need to reduce the number of processes allowed to run at one time, you may specify a value for the `--agents` option on the `nunit3-console` command-line. For example, if you are running tests in 10 different processes, a setting of `--agents=3` will allow no more than three of them to execute simultaneously.
 
 > [!NOTE]
 > This facility does not depend on the test framework used in any way. Test assemblies that use older versions of NUnit may be run in parallel processes just as easily as those using NUnit 3. If extensions are created to support additional frameworks, the NUnit engine will run those assemblies in parallel as well.

--- a/docs/articles/nunit/technical-notes/usage/Framework-Parallel-Test-Execution.md
+++ b/docs/articles/nunit/technical-notes/usage/Framework-Parallel-Test-Execution.md
@@ -37,21 +37,21 @@ This is a `[Flags]` type enumeration used to specify which tests may run in para
 
 It is important to note that a parallel or non-parallel specification only applies at that level where it appears and below. It cannot override the settings on higher-level tests. In this way, parallelism is not absolute but is relative to other tests at the same level in the tree. The following are a few examples of how this works:
 
-1. **Non-parallel class with parallel methods:** The methods only run in parallel with one another, not with the test methods of any other classes.
+1. __Non-parallel class with parallel methods:__ The methods only run in parallel with one another, not with the test methods of any other classes.
 
-2. **Parallel class with non-parallel methods:** The methods run sequentially, usually on the same thread that ran the class one-time setup, but may actually be running in parallel with other, unrelated methods from other classes.
+2. __Parallel class with non-parallel methods:__ The methods run sequentially, usually on the same thread that ran the class one-time setup, but may actually be running in parallel with other, unrelated methods from other classes.
 
-3. **Non-parallel SetUpFixture with parallel test fixtures:** The entire group of fixtures runs separately from any fixtures outside the group. Within the group, multiple fixtures run in parallel.
+3. __Non-parallel SetUpFixture with parallel test fixtures:__ The entire group of fixtures runs separately from any fixtures outside the group. Within the group, multiple fixtures run in parallel.
 
-4. **Parallel SetUpFixture with non-parallel test fixtures:** The group runs in parallel with other fixtures and groups. Within the group, only one fixture at a time may execute.
+4. __Parallel SetUpFixture with non-parallel test fixtures:__ The group runs in parallel with other fixtures and groups. Within the group, only one fixture at a time may execute.
 
-5. **Parallel SetUpFixture with non-parallel test fixtures containing parallel test cases:** This is just one example of a more complex setup. The fixtures themselves run as described in (4) but the cases within each fixture run in parallel with one another.
+5. __Parallel SetUpFixture with non-parallel test fixtures containing parallel test cases:__ This is just one example of a more complex setup. The fixtures themselves run as described in (4) but the cases within each fixture run in parallel with one another.
 
 Once you understand the principles, you can construct complex hierarchies of parallel and non-parallel tests.
 
 ## LevelOfParallelismAttribute
 
-This is an **assembly-level** attribute, which may be used to specify the level of parallelism, that is, the maximum number of worker threads executing tests in this assembly. It may be overridden using a command-line option in the console runner. If it is not specified, NUnit uses a default value based on the number of processors available or a specified minimum, whichever is greater.
+This is an __assembly-level__ attribute, which may be used to specify the level of parallelism, that is, the maximum number of worker threads executing tests in this assembly. It may be overridden using a command-line option in the console runner. If it is not specified, NUnit uses a default value based on the number of processors available or a specified minimum, whichever is greater.
 
 ## Parallel Execution Internals
 

--- a/docs/articles/nunit/writing-tests/attributes/explicit.md
+++ b/docs/articles/nunit/writing-tests/attributes/explicit.md
@@ -34,7 +34,7 @@ explicit tests that fall under the selection.
     --where "cat==X || cat==Y"
 ```
 
-However, the following options will __not__ include explicit tests
+However, the following options will **not** include explicit tests
 
 ```none
     --where test!=My.Namespace.Fixture

--- a/docs/articles/nunit/writing-tests/attributes/testcasesource.md
+++ b/docs/articles/nunit/writing-tests/attributes/testcasesource.md
@@ -42,7 +42,7 @@ The single attribute argument in this form is a string representing the name of 
 to provide test cases. It has the following characteristics:
 
 * It may be a field, property or method in the test class.
-* It __must__ be static. This is a change from NUnit 2.x.
+* It **must** be static. This is a change from NUnit 2.x.
 * It must return an `IEnumerable` or a type that implements `IEnumerable`. For fields an array is generally used. For properties and methods, you may return an array or implement your own iterator.
 * The individual items returned by the enumerator must be compatible
    with the signature of the method on which the attribute appears.
@@ -106,7 +106,7 @@ The second argument is a string representing the name of the source used
 to provide test cases. It has the following characteristics:
 
 * It may be a field, property or method in the test class.
-* It __must__ be static. This is a change from NUnit 2.x.
+* It **must** be static. This is a change from NUnit 2.x.
 * It must return an `IEnumerable` or a type that implements `IEnumerable`. For fields an array is generally used. For properties and methods, you may return an array or implement your own iterator.
 * The individual items returned by the enumerator must be compatible
    with the signature of the method on which the attribute appears.

--- a/docs/articles/nunit/writing-tests/attributes/testfixturesource.md
+++ b/docs/articles/nunit/writing-tests/attributes/testfixturesource.md
@@ -31,7 +31,7 @@ The single attribute argument in this form is a string representing the name of 
 to provide arguments for constructing the `TestFixture`. It has the following characteristics:
 
 * It may be a field, property or method in the test class.
-* It __must__ be static.
+* It **must** be static.
 * It must return an `IEnumerable` or a type that implements `IEnumerable`. For fields an array is generally used. For properties and methods, you may return an array or implement your own iterator.
 * The individual items returned by the enumerator must either be object arrays or derive from the `TestFixtureParameters` class. Arguments must be consistent with the fixture constructor.
 
@@ -62,7 +62,7 @@ The second argument is a string representing the name of the source used
 to provide test fixtures. It has the following characteristics:
 
 * It may be a field, property or method in the test class.
-* It __must__ be static.
+* It **must** be static.
 * It must return an `IEnumerable` or a type that implements `IEnumerable`. For fields an array is generally used. For properties and methods, you may return an array or implement your own iterator.
 * The individual items returned by the enumerator must either be object arrays or derive from the `TestFixtureParameters` class. Arguments must be consistent with the fixture constructor.
 


### PR DESCRIPTION
We used someone else's container action for markdown linting in our build process. If we use the markdownlint package directly, we'll have a consistent experience between our build & devcontainer tooling. Plus the container was old, and the latest markdownlint edition adds some more rules that we should address.