### PR TITLE
Add additional contribution content

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -23,12 +23,42 @@ We suggest [submitting an issue](https://github.com/nunit/docs/issues/new) with 
 
 ## Contributing Code via a Pull Request
 
-So you've got some docs you'd like to contribute to the project. First off -- Thank you! It means a lot to us that you'd take your time to help improve this project.
+So you've got some docs you'd like to contribute to the project. First off -- **Thank you**! It means a lot to us that you'd take your time to help improve this project.
 
 We try to avoid being strict about accepting PRs because we value contributions from others, but some general guidelines are below. If you are unsure about any of the steps to contribute, just ask -- we're happy to help.
 
 * You should probably [submit an issue](https://github.com/nunit/docs/issues/new) before beginning a pull request. This makes sure that we have a good heads up that you want to contribute, and also makes sure that if we don't think the idea is a good fit, you don't spend time writing docs only to have the PR rejected later.
-* You should fork the project first and create a branch for your changes off of the `master` branch.
+
+There are a few ways to contribute. Here's a video showing them, as of January 2023:
+
+[![IMAGE ALT TEXT HERE](https://img.youtube.com/vi/VSJwystllJM/0.jpg)](https://www.youtube.com/watch?v=VSJwystllJM)
+
+### Option 1: Using GitHub In-line Editing
+
+* From the NUnit docs site, you can click `Improve This Document` to take you to the markdown file for the page you're viewing.
+* From there, you can click the edit icon to edit the text.
+* Once you've made your changes, you can click `Commit These Changes` which will guide you through creating a branch and pull request to submit the change to us.
+
+Once the PR is submitted, our build will run. If there are any spellcheck issues or markdown linting issues, you'll receive an e-mail with the failures. No worries -- we'll help you out.
+
+### Option 2: Fork & Commit as Typical
+
+If you're familiar with OSS and GitHub, you can fork the repository, check it out, make a branch, and submit any changes. Our build process will pick up if there are spelling or markdown issues and we can work together to address them in the PR.
+
+### Option 3: A Richer Experience with GitHub Codespaces
+
+You can open the repository in GitHub Codespaces. This will open an instance of VS Code, in a browser window, with all of the extensions we use installed. You'll get:
+
+* Syntax highlighting for spelling and markdown issues
+* Auto-formatting on save according to our standards
+* Simple command aliases in the terminal: `spellcheck`, `lint`, `build`, and `serve` will cover most folks' workflow.
+
+### Option 3a: A Container Within VS Code
+
+You can check out the codebase on your local machine and open it with VSCode. If you have Docker installed, VS Code will prompt you to reopen within a container. It will build the same container that Codespaces above uses, and you'll have the same functionality available to you.
+
+## General Suggestions
+
 * We suggest creating a pull request early in the process and placing `WIP` or `In Progress` in the title of the pull request (you can edit it later). This way, as you add changes, we can see the progress, and might be able to jump in to help if we see things going off the rails. This one's your call, though; do whatever suits you.
 * Try to make many small commits, with notes, at each step of the way. This will help us understand your thought process when we review the PR. We'll squash these changes at the end of the process, so no worries about being verbose throughout.
 * Similarly, don't worry about pre-squashing your changes for us. We'll use Github's functionality at the end of the PR to do that when accepting it.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -27,7 +27,15 @@ So you've got some docs you'd like to contribute to the project. First off -- **
 
 We try to avoid being strict about accepting PRs because we value contributions from others, but some general guidelines are below. If you are unsure about any of the steps to contribute, just ask -- we're happy to help.
 
+## General Suggestions
+
 * You should probably [submit an issue](https://github.com/nunit/docs/issues/new) before beginning a pull request. This makes sure that we have a good heads up that you want to contribute, and also makes sure that if we don't think the idea is a good fit, you don't spend time writing docs only to have the PR rejected later.
+* We suggest creating a pull request early in the process and placing `WIP` or `In Progress` in the title of the pull request (you can edit it later). This way, as you add changes, we can see the progress, and might be able to jump in to help if we see things going off the rails. This one's your call, though; do whatever suits you.
+* Try to make many small commits, with notes, at each step of the way. This will help us understand your thought process when we review the PR. We'll squash these changes at the end of the process, so no worries about being verbose throughout.
+* Similarly, don't worry about pre-squashing your changes for us. We'll use Github's functionality at the end of the PR to do that when accepting it.
+* Before asking for a review or declaring the PR to be ready, make sure the CI build passes. You'll receive updates on this as you go, so the status at any given time should hopefully be clear.
+
+## How to Contribute
 
 There are a few ways to contribute. Here's a video showing them, as of January 2023:
 
@@ -56,13 +64,6 @@ You can open the repository in GitHub Codespaces. This will open an instance of 
 ### Option 3a: A Container Within VS Code
 
 You can check out the codebase on your local machine and open it with VSCode. If you have Docker installed, VS Code will prompt you to reopen within a container. It will build the same container that Codespaces above uses, and you'll have the same functionality available to you.
-
-## General Suggestions
-
-* We suggest creating a pull request early in the process and placing `WIP` or `In Progress` in the title of the pull request (you can edit it later). This way, as you add changes, we can see the progress, and might be able to jump in to help if we see things going off the rails. This one's your call, though; do whatever suits you.
-* Try to make many small commits, with notes, at each step of the way. This will help us understand your thought process when we review the PR. We'll squash these changes at the end of the process, so no worries about being verbose throughout.
-* Similarly, don't worry about pre-squashing your changes for us. We'll use Github's functionality at the end of the PR to do that when accepting it.
-* Before asking for a review or declaring the PR to be ready, make sure the CI build passes. You'll receive updates on this as you go, so the status at any given time should hopefully be clear.
 
 ## Is this confusing? Do you need help? Do you feel hesitant?
 


### PR DESCRIPTION
Hopefully addresses some of @CharliePoole's concerns around the contribution process being less accessible.

* Updates CONTRIBUTING.MD to walk through using in-line editing, the traditional method, and devcontainer via Codespaces or VS Code locally
* Links to a video I recorded demoing how to do it and how it all works.