### PR TITLE
Move explicit `docs.nunit.org` URLs to be relative

### DIFF
--- a/docs/articles/nunit/getting-started/dotnet-core-and-dotnet-standard.md
+++ b/docs/articles/nunit/getting-started/dotnet-core-and-dotnet-standard.md
@@ -59,7 +59,7 @@ Meanwhile, you can run specific tests using the `--framework` command line optio
 
 #### How do I produce a test results file
 
-`dotnet test` can generate an NUnit3 test result file by adding a runsettings property. The property to add is [TestOutputXml](https://docs.nunit.org/articles/vs-test-adapter/Tips-And-Tricks.html#testoutputxml). This generation is done using the NUnit Engine report service, and produce the same result as the [NUnit3-console](https://www.nuget.org/packages/NUnit.Console/). This is available through the [NUnit3TestAdapter](https://www.nuget.org/packages/NUnit3TestAdapter).
+`dotnet test` can generate an NUnit3 test result file by adding a runsettings property. The property to add is [TestOutputXml](/articles/vs-test-adapter/Tips-And-Tricks.html#testoutputxml). This generation is done using the NUnit Engine report service, and produce the same result as the [NUnit3-console](https://www.nuget.org/packages/NUnit.Console/). This is available through the [NUnit3TestAdapter](https://www.nuget.org/packages/NUnit3TestAdapter).
 
 You run it by adding the setting on the command line (or in a runsettings file):
 

--- a/docs/articles/nunit/running-tests/NUnitLite-Options.md
+++ b/docs/articles/nunit/running-tests/NUnitLite-Options.md
@@ -48,7 +48,7 @@ selection options never even see them.
 
 The `--where` option introduces a _where clause_, the most flexible
 but also the most complex way to introduce tests. See the documentation of
-[Test SelectionLanguage](https://docs.nunit.org/articles/nunit/running-tests/Test-Selection-Language.html)
+[Test SelectionLanguage](/articles/nunit/running-tests/Test-Selection-Language.html)
 for details.
 
 The `--test` and `testlist` options allow selecting individual

--- a/docs/articles/vs-test-adapter/AdapterV3-Release-Notes.md
+++ b/docs/articles/vs-test-adapter/AdapterV3-Release-Notes.md
@@ -5,11 +5,11 @@
 This release has a series of enhancements and bugfixes.  There have been two 3.17 beta releases (beta.1 and beta.2) published earlier on nuget.org.
 A major bugfix is that the console output now is properly appearing.  There are also a series of fixes for corner cases.  
 
-[StopOnError](https://docs.nunit.org/articles/vs-test-adapter/Tips-And-Tricks.html#stoponerror) can be very useful to reduce time of long test runs that are failing.
+[StopOnError](/articles/vs-test-adapter/Tips-And-Tricks.html#stoponerror) can be very useful to reduce time of long test runs that are failing.
 
 The ability to set custom paths for the test code can be useful with data driven tests, where you want to point to the data file (and line number therein) instead of the default C# test code.
 
-See [here for all details](https://docs.nunit.org/articles/vs-test-adapter/Tips-And-Tricks.html) on the settings.
+See [here for all details](/articles/vs-test-adapter/Tips-And-Tricks.html) on the settings.
 
 ### Features and Enhancements
 

--- a/docs/articles/vs-test-adapter/AdapterV4-Release-Notes.md
+++ b/docs/articles/vs-test-adapter/AdapterV4-Release-Notes.md
@@ -23,16 +23,16 @@ Thanks to [Jan Inge Dalsbø](https://github.com/janid1967), [Taylor Willis](http
 
 ## NUnit3 Test Adapter for Visual Studio - Version 4.3.0 - Oct 29, 2022
 
-This version is for support of the .net 7 framework. See an overview of [supported frameworks here](https://docs.nunit.org/articles/vs-test-adapter/Supported-Frameworks.html).
+This version is for support of the .net 7 framework. See an overview of [supported frameworks here](/articles/vs-test-adapter/Supported-Frameworks.html).
 
-The support is due to the updated embedded [NUnit.Engine version 3.15.2](https://docs.nunit.org/articles/nunit-engine/release-notes.html#nunit-console--engine-3152---june-30-2022).
+The support is due to the updated embedded [NUnit.Engine version 3.15.2](/articles/nunit-engine/release-notes.html#nunit-console--engine-3152---june-30-2022).
 
 * [987](https://github.com/nunit/nunit3-vs-adapter/issues/987)  System.ArgumentException: Unknown framework version 7.0
 
 Other bugs fixed:
 
 * [990](https://github.com/nunit/nunit3-vs-adapter/issues/990) Missing output with failed test stack traces for Assert.Multiple
-* [997](https://github.com/nunit/nunit3-vs-adapter/issues/997) TRX report file folder inconsistent with XML report folder using .runsettings file. Note that a new runsettings flag has been added for supporting this, see [OutputXmlFolderMode](https://docs.nunit.org/articles/vs-test-adapter/Tips-And-Tricks.html#OutputXmlFolderMode).
+* [997](https://github.com/nunit/nunit3-vs-adapter/issues/997) TRX report file folder inconsistent with XML report folder using .runsettings file. Note that a new runsettings flag has been added for supporting this, see [OutputXmlFolderMode](/articles/vs-test-adapter/Tips-And-Tricks.html#OutputXmlFolderMode).
 
 ## NUnit3 Test Adapter for Visual Studio - Version 4.2.1 - Jan 21, 2022
 
@@ -92,7 +92,7 @@ The following additional features have been implemented in the final release.
 
 * [843](https://github.com/nunit/nunit3-vs-adapter/issues/843) Reporting random seed for a test case
 
-* [863](https://github.com/nunit/nunit3-vs-adapter/pull/863) The Test Name is by default added to the console output for tests. It can be turned off by the [UseTestNameInConsoleOutput](https://docs.nunit.org/articles/vs-test-adapter/Tips-And-Tricks.html#usetestnameinconsoleoutput) property.
+* [863](https://github.com/nunit/nunit3-vs-adapter/pull/863) The Test Name is by default added to the console output for tests. It can be turned off by the [UseTestNameInConsoleOutput](/articles/vs-test-adapter/Tips-And-Tricks.html#usetestnameinconsoleoutput) property.
 
 The following additional issue has been resolved:
 


### PR DESCRIPTION
This will ensure the links work correctly in any built environment, since docfx converts them at build time.

Resolves #607.