### PR TITLE
Devcontainer: C# extension and alias for samples

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -21,3 +21,4 @@ RUN echo 'first_workspace=\"$(cd /workspaces && ls | head -1)\"; alias spellchec
 RUN echo 'first_workspace=\"$(cd /workspaces && ls | head -1)\"; alias lint="markdownlint -c /workspaces/$first_workspace/.github/linters/.markdown-lint.yml /workspaces/$first_workspace/docs/**/*.md"' >> ~/.bashrc
 RUN echo 'first_workspace=\"$(cd /workspaces && ls | head -1)\"; alias build="docfx /workspaces/$first_workspace/docs/docfx.json"' >> ~/.bashrc
 RUN echo 'first_workspace=\"$(cd /workspaces && ls | head -1)\"; alias serve="docfx /workspaces/$first_workspace/docs/docfx.json --serve"' >> ~/.bashrc
+RUN echo 'first_workspace=\"$(cd /workspaces && ls | head -1)\"; alias snippets="dotnet test /workspaces/$first_workspace/docs/snippets/Snippets.sln"' >> ~/.bashrc

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -12,6 +12,7 @@
 		"redhat.vscode-yaml",
 		"vsls-contrib.codetour",
 		"GitHub.vscode-pull-request-github",
-		"shuworks.vscode-table-formatter"
+		"shuworks.vscode-table-formatter",
+		"ms-dotnettools.csharp"
 	]
 }

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -59,7 +59,7 @@ You can open the repository in GitHub Codespaces. This will open an instance of 
 
 * Syntax highlighting for spelling and markdown issues
 * Auto-formatting on save according to our standards
-* Simple command aliases in the terminal: `spellcheck`, `lint`, `build`, and `serve` will cover most folks' workflow.
+* Simple command aliases in the terminal: `spellcheck`, `lint`, `build`, `serve`, and `snippets` will cover most folks' workflow.
 
 ### Option 3a: A Container Within VS Code
 

--- a/README.md
+++ b/README.md
@@ -16,9 +16,9 @@ The docs site is a project within the NUnit organization. [Read the vision at VI
 * Run `docfx build`
 * Run `docfx serve` and navigate to <http://localhost:8080/_site>
 
-## How to Build These Docs Within GitHub Codespaces
+## How to Build These Docs Within GitHub Codespaces or a Dev Container
 
-Fancy using GitHub Codespaces for your work on these docs? You can!
+Fancy using GitHub Codespaces for your work on these docs? Or want to work in the environment locally? You can!
 
 * Open the branch you want to work on in GitHub Codespaces
 * The tooling, VS code extensions, etc. that we use will immediately be available to you.
@@ -26,6 +26,7 @@ Fancy using GitHub Codespaces for your work on these docs? You can!
 * To serve / preview from the Codespaces terminal: `serve` (we've taken care of the rest for you)
 * To run markdown linting from the Codespaces terminal: `lint` (we've taken care of the rest for you)
 * To run spellcheck from the Codespaces terminal: `spellcheck` (we've taken care of the rest for you)
+* To build/test the snippets from the Codespaces terminal: `snippets` (we've taken care of the rest for you)
 
 We'll be working on follow-ups to make this more user-friendly, but it's now workable.
 


### PR DESCRIPTION
For use when working with snippets in the devcontainer.

Resolves #705.