### PR TITLE
Add Custom 404 Page

### DIFF
--- a/docs/404.md
+++ b/docs/404.md
@@ -2,4 +2,4 @@
 
 We're sorry, but the page you're looking for cannot be found on the site.
 
-Feel free to [Open an issue in the NUnit Docs GitHub Repository](https://github.com/nunit/docs/issues/new) with the URL/content you expected to exist, and we'll be happy to look into it.
+Feel free to [Open an issue in the NUnit Docs GitHub Repository](https://github.com/nunit/docs/issues/new) with the URL or content you expected to exist, and we'll be happy to look into it.

--- a/docs/404.md
+++ b/docs/404.md
@@ -1,0 +1,5 @@
+# Page Not Found
+
+We're sorry, but the page you're looking for cannot be found on the site.
+
+Feel free to [Open an issue in the NUnit Docs GitHub Repository](https://github.com/nunit/docs/issues/new) with the URL/content you expected to exist, and we'll be happy to look into it.


### PR DESCRIPTION
Supports #360.

Uses docfx to create a 404.html

Google pages picks up on the 404.html file and should serve it.

Once this works, I'll see if the analytics picks up on where 404 pages are resulting (I think it does), or if I need to add specific analytics script on the 404 page.