### PR TITLE
Update docfx-action to 2.5.0 in build/codespaces

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,4 +1,4 @@
-FROM ghcr.io/nunit/docfx-action:v2.4.0
+FROM ghcr.io/nunit/docfx-action:v2.5.0
 EXPOSE 8080
 
 ### Installing Node LTS into the container

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -15,7 +15,7 @@
 				"vsls-contrib.codetour",
 				"GitHub.vscode-pull-request-github",
 				"shuworks.vscode-table-formatter",
-				"ms-dotnettools.csharp",
+				"ms-dotnettools.csharp"
 			]
 		}
 	}

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -4,15 +4,19 @@
         "dockerfile": "Dockerfile"
     },
     "forwardPorts": [8080],
-    "extensions": [
-		"streetsidesoftware.code-spell-checker",
-		"oderwat.indent-rainbow",
-		"mdickin.markdown-shortcuts",
-		"davidanson.vscode-markdownlint",
-		"redhat.vscode-yaml",
-		"vsls-contrib.codetour",
-		"GitHub.vscode-pull-request-github",
-		"shuworks.vscode-table-formatter",
-		"ms-dotnettools.csharp"
-	]
+	"customizations": {
+		"vscode": {
+			"extensions": [
+				"streetsidesoftware.code-spell-checker",
+				"oderwat.indent-rainbow",
+				"mdickin.markdown-shortcuts",
+				"davidanson.vscode-markdownlint",
+				"redhat.vscode-yaml",
+				"vsls-contrib.codetour",
+				"GitHub.vscode-pull-request-github",
+				"shuworks.vscode-table-formatter",
+				"ms-dotnettools.csharp",
+			]
+		}
+	}
 }

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -15,7 +15,8 @@
 				"vsls-contrib.codetour",
 				"GitHub.vscode-pull-request-github",
 				"shuworks.vscode-table-formatter",
-				"ms-dotnettools.csharp"
+				"ms-dotnettools.csharp",
+				"github.vscode-github-actions"
 			]
 		}
 	}

--- a/.github/workflows/build-process.yml
+++ b/.github/workflows/build-process.yml
@@ -43,7 +43,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
         name: Check out the code
-      - uses: "nunit/docfx-action@v2.4.0"
+      - uses: "nunit/docfx-action@v2.5.0"
         name: Build with Docfx
         with:
           args: docs/docfx.json --warningsAsErrors true

--- a/docs/docfx.json
+++ b/docs/docfx.json
@@ -29,7 +29,8 @@
     "dest": "_site",
     "globalMetadata": {
       "_appTitle": "NUnit Docs",
-      "_googleTagId": "G-PCB5BYBNM2"
+      "_googleTagId": "G-PCB5BYBNM2",
+      "lang": "en"
     },
     "globalMetadataFiles": [],
     "fileMetadataFiles": [],

--- a/docs/docfx.json
+++ b/docs/docfx.json
@@ -28,7 +28,8 @@
     ],
     "dest": "_site",
     "globalMetadata": {
-      "_appTitle": "NUnit Docs"
+      "_appTitle": "NUnit Docs",
+      "_googleTagId": "G-PCB5BYBNM2"
     },
     "globalMetadataFiles": [],
     "fileMetadataFiles": [],


### PR DESCRIPTION
* [x] Updates docfx v2.65.3 -> v2.67.2
* [x] Add `_googleTagId` metadata with our existing tag
* [x] Reconcile all partial templates with existing templates (if only difference in header template is our google tag, remove it.)
* [x] Add "lang" metadata with property `en`
* [x] Addresses all breaking changes from docfx release notes https://github.com/dotnet/docfx/releases
* [x] Spot check in GitHub Codespace preview