### PR TITLE
Fixed missing parenthesis and curly bracket on the Ignore attribute page

### DIFF
--- a/docs/articles/nunit/writing-tests/attributes/ignore.md
+++ b/docs/articles/nunit/writing-tests/attributes/ignore.md
@@ -54,8 +54,8 @@ that can be parsed to a date.
 [Ignore("Waiting for Joe to fix his bugs", Until = "2014-07-31 12:00:00Z")]
 public class MyTests
 {
-  [Test]
-  public void Test1() { /* ... */ }
+ [Test]
+ public void Test1() { /* ... */ }
 }
 ```
 

--- a/docs/articles/nunit/writing-tests/attributes/ignore.md
+++ b/docs/articles/nunit/writing-tests/attributes/ignore.md
@@ -12,15 +12,15 @@ Note that the **IgnoreAttribute** is attached to a method. If you have multiple 
 ```csharp
 namespace NUnit.Tests
 {
-  using System;
-  using NUnit.Framework;
+    using System;
+    using NUnit.Framework;
 
-  [TestFixture]
-  [Ignore("Ignore a fixture")]
-  public class SuccessTests
-  {
-    // ...
-  }
+    [TestFixture]
+    [Ignore("Ignore a fixture")]
+    public class SuccessTests
+    {
+        // ...
+    }
 }
 ```
 
@@ -29,16 +29,17 @@ namespace NUnit.Tests
 ```csharp
 namespace NUnit.Tests
 {
-  using System;
-  using NUnit.Framework;
+    using System;
+    using NUnit.Framework;
 
-  [TestFixture]
-  public class SuccessTests
-  {
-    [Test]
-    [Ignore("Ignore a test")]
-    public void IgnoredTest()
-    { /* ... */ }
+    [TestFixture]
+    public class SuccessTests
+    {
+        [Test]
+        [Ignore("Ignore a test")]
+        public void IgnoredTest()
+        { /* ... */ }
+    }
 }
 ```
 
@@ -50,11 +51,11 @@ that can be parsed to a date.
 
 ```csharp
 [TestFixture]
-[Ignore("Waiting for Joe to fix his bugs", Until = "2014-07-31 12:00:00Z"]
+[Ignore("Waiting for Joe to fix his bugs", Until = "2014-07-31 12:00:00Z")]
 public class MyTests
 {
- [Test]
- public void Test1() { /* ... */ }
+    [Test]
+    public void Test1() { /* ... */ }
 }
 ```
 

--- a/docs/articles/nunit/writing-tests/attributes/ignore.md
+++ b/docs/articles/nunit/writing-tests/attributes/ignore.md
@@ -12,15 +12,15 @@ Note that the **IgnoreAttribute** is attached to a method. If you have multiple 
 ```csharp
 namespace NUnit.Tests
 {
-    using System;
-    using NUnit.Framework;
+  using System;
+  using NUnit.Framework;
 
-    [TestFixture]
-    [Ignore("Ignore a fixture")]
-    public class SuccessTests
-    {
-        // ...
-    }
+  [TestFixture]
+  [Ignore("Ignore a fixture")]
+  public class SuccessTests
+  {
+    // ...
+  }
 }
 ```
 
@@ -29,17 +29,17 @@ namespace NUnit.Tests
 ```csharp
 namespace NUnit.Tests
 {
-    using System;
-    using NUnit.Framework;
+  using System;
+  using NUnit.Framework;
 
-    [TestFixture]
-    public class SuccessTests
-    {
-        [Test]
-        [Ignore("Ignore a test")]
-        public void IgnoredTest()
-        { /* ... */ }
-    }
+  [TestFixture]
+  public class SuccessTests
+  {
+    [Test]
+    [Ignore("Ignore a test")]
+    public void IgnoredTest()
+    { /* ... */ }
+  }
 }
 ```
 
@@ -54,8 +54,8 @@ that can be parsed to a date.
 [Ignore("Waiting for Joe to fix his bugs", Until = "2014-07-31 12:00:00Z")]
 public class MyTests
 {
-    [Test]
-    public void Test1() { /* ... */ }
+  [Test]
+  public void Test1() { /* ... */ }
 }
 ```
 


### PR DESCRIPTION
- Added missing parenthesis in Ignore Until code example.
- Added missing curly bracket in Test Syntax section.

Resolves #765