### PR TITLE
Update docfx-action to 2.9.0 (with docfx 2.70.1)

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,4 +1,4 @@
-FROM ghcr.io/nunit/docfx-action:v2.8.0
+FROM ghcr.io/nunit/docfx-action:v2.9.0
 EXPOSE 8080
 
 ### Installing Node LTS into the container

--- a/.github/workflows/build-process.yml
+++ b/.github/workflows/build-process.yml
@@ -43,7 +43,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
         name: Check out the code
-      - uses: "nunit/docfx-action@v2.8.0"
+      - uses: "nunit/docfx-action@v2.9.0"
         name: Build with Docfx
         with:
           args: docs/docfx.json --warningsAsErrors true


### PR DESCRIPTION
Tested locally in a dev container. Should be fine to merge when the build passes.