### PR TITLE
chore: Update cSpell.json schema version 0.1 -> 0.2

### DIFF
--- a/cSpell.json
+++ b/cSpell.json
@@ -1,5 +1,5 @@
 {
-    "version": "0.1",
+    "version": "0.2",
     "language": "en",
     "words": [
         "buildable",


### PR DESCRIPTION
Saw a warning in the build that the schema version was old. Adding this here; will make other adjustments as necessary if the build breaks