### PR TITLE
Correct Pairwise output order

### DIFF
--- a/docs/articles/nunit/writing-tests/attributes/pairwise.md
+++ b/docs/articles/nunit/writing-tests/attributes/pairwise.md
@@ -29,8 +29,8 @@ public void MyTest(
 For this test, NUnit currently calls the method six times, producing the following output:
 
 ```none
-a + y
 a - x
+a + y
 b - y
 b + x
 c - x


### PR DESCRIPTION
Now the documentation is in the same order the output is:

![image](https://github.com/nunit/docs/assets/5593825/50c93a91-748e-46f9-8edc-6589d2f63fe0)
