### PR TITLE
A few points for Task<> and IAsyncEnumerable<> support on *Source attributes

### DIFF
--- a/docs/articles/nunit/writing-tests/attributes/testcasesource.md
+++ b/docs/articles/nunit/writing-tests/attributes/testcasesource.md
@@ -31,6 +31,8 @@ It has the following characteristics:
 * It **must** be static. This is a change from NUnit 2.x.
 * It must return an `IEnumerable` or a type that implements `IEnumerable`. For fields an array is generally used. For
   properties and methods, you may return an array or implement your own iterator.
+  * Methods may also return an `IAsyncEnumerable` or a type that implements `IAsyncEnumerable`. (_NUnit 4+_)
+  * Methods may be async by wrapping the return type in a `Task<T>`. (_NUnit 3.14+_)
 * The individual items returned by the enumerator must be compatible with the signature of the method on which the
    attribute appears. See the **Test Case Construction** section below for details.
 
@@ -53,6 +55,8 @@ characteristics:
 * It **must** be static. This is a change from NUnit 2.x.
 * It must return an `IEnumerable` or a type that implements `IEnumerable`. For fields an array is generally used. For
   properties and methods, you may return an array or implement your own iterator.
+  * Methods may also return an `IAsyncEnumerable` or a type that implements `IAsyncEnumerable`. (_NUnit 4+_)
+  * Methods may be async by wrapping the return type in a `Task<T>`. (_NUnit 3.14+_)
 * The individual items returned by the enumerator must be compatible with the signature of the method on which the
    attribute appears. See the **Test Case Construction** section below for details.
 

--- a/docs/articles/nunit/writing-tests/attributes/testfixturesource.md
+++ b/docs/articles/nunit/writing-tests/attributes/testfixturesource.md
@@ -33,6 +33,8 @@ constructing the `TestFixture`. It has the following characteristics:
 * It **must** be static.
 * It must return an `IEnumerable` or a type that implements `IEnumerable`. For fields an array is generally used. For
   properties and methods, you may return an array or implement your own iterator.
+  * Methods may also return an `IAsyncEnumerable` or a type that implements `IAsyncEnumerable`. (_NUnit 4+_)
+  * Methods may be async by wrapping the return type in a `Task<T>`. (_NUnit 3.14+_)
 * The individual items returned by the enumerator must either be object arrays or derive from the
   `TestFixtureParameters` class. Arguments must be consistent with the fixture constructor.
 
@@ -66,6 +68,8 @@ characteristics:
 * It **must** be static.
 * It must return an `IEnumerable` or a type that implements `IEnumerable`. For fields an array is generally used. For
   properties and methods, you may return an array or implement your own iterator.
+  * Methods may also return an `IAsyncEnumerable` or a type that implements `IAsyncEnumerable`. (_NUnit 4+_)
+  * Methods may be async by wrapping the return type in a `Task<T>`. (_NUnit 3.14+_)
 * The individual items returned by the enumerator must either be object arrays or derive from the
   `TestFixtureParameters` class. Arguments must be consistent with the fixture constructor.
 

--- a/docs/articles/nunit/writing-tests/attributes/valuesource.md
+++ b/docs/articles/nunit/writing-tests/attributes/valuesource.md
@@ -21,7 +21,9 @@ characteristics:
 
 * It may be a field, a non-indexed property or a method taking no arguments.
 * It must be a static member.
-* It must return an IEnumerable or a type that implements IEnumerable.
+* It must return an `IEnumerable` or a type that implements `IEnumerable`.
+  * Methods may also return an `IAsyncEnumerable` or a type that implements `IAsyncEnumerable`. (_NUnit 4+_)
+  * Methods may be async by wrapping the return type in a `Task<T>`. (_NUnit 3.14+_)
 * The individual items returned from the enumerator must be compatible with the type of the parameter on which the
   attribute appears.
 


### PR DESCRIPTION
Relates to https://github.com/nunit/docs/issues/834 and https://github.com/nunit/docs/issues/756

A few quick notes about supported signatures for async method-sourced *Source attributes to start getting these into the docs. I'm only describing this as "Related to" instead of "Fixes" as I think some example method signatures could be helpful to add later.