### PR TITLE
Minor wording adjustment to migration guide

### DIFF
--- a/docs/articles/nunit/release-notes/Nunit4.0-MigrationGuide.md
+++ b/docs/articles/nunit/release-notes/Nunit4.0-MigrationGuide.md
@@ -96,7 +96,7 @@ Assert.That(actualText, Does.StartWith("42"), $"Expected '{actualText}' to start
 There are no code fixers for `FileAssert` and `DirectoryAssert`. They could be added, but we don't expect these to be
 used too much.
 
-#### Convert Classic Assert into NUnit 4.x equivalent
+#### Using Classic Asserts in NUnit 4.x
 
 If you want to keep the Classic Asserts and not convert them to the constraint model -- but do want to use the new NUnit
 4.x naming -- you'll need to update the code manually.

--- a/docs/articles/nunit/release-notes/Nunit4.0-MigrationGuide.md
+++ b/docs/articles/nunit/release-notes/Nunit4.0-MigrationGuide.md
@@ -96,7 +96,7 @@ Assert.That(actualText, Does.StartWith("42"), $"Expected '{actualText}' to start
 There are no code fixers for `FileAssert` and `DirectoryAssert`. They could be added, but we don't expect these to be
 used too much.
 
-#### Using Classic Asserts in NUnit 4.x
+#### Updating from Classic Asserts in NUnit 4.x
 
 If you want to keep the Classic Asserts and not convert them to the constraint model -- but do want to use the new NUnit
 4.x naming -- you'll need to update the code manually.


### PR DESCRIPTION
I've noticed a bit of hesitation on social media about the changes to assert styles. I thought a minor wording change could help here, mostly around dropping the word "convert" in one of the headings to minimize apparent friction.

I'm unsure which of these could be preferable so I've gone with the shorter, first alternative in this PR for now:

```diff
- #### Convert Classic Assert into NUnit 4.x equivalent
+ #### Using Classic Asserts in NUnit 4.x
```
or

```diff
- #### Convert Classic Assert into NUnit 4.x equivalent
+ #### Using Classic-style Asserts in NUnit 4.x
```

@manfred-brands @SeanKilleen I know you each put a lot of work into the guide, so I'd appreciate your thoughts on this