### PR TITLE
Remove description from deleted env

### DIFF
--- a/.github/workflows/closed-pr.yml
+++ b/.github/workflows/closed-pr.yml
@@ -13,4 +13,3 @@ jobs:
             step: delete-env
             token: ${{ secrets.GITHUB_TOKEN }}
             env: preview_${{github.event.number}}
-            desc: Environment Deleted


### PR DESCRIPTION
Was leftover from when I was deactivating them. May be causing the current error.