### PR TITLE
Use PAT for env deletion

### DIFF
--- a/.github/workflows/build-process.yml
+++ b/.github/workflows/build-process.yml
@@ -136,6 +136,6 @@ jobs:
         uses: peaceiris/actions-gh-pages@v3
         with:
           commit_message: ${{ github.event.head_commit.message }}
-          github_token: ${{ secrets.GITHUB_TOKEN }}
+          github_token: ${{ secrets.SEAN_PAT_TO_MANAGE_ENVIRONMENTS }}
           publish_dir: ./docs/_site
           publish_branch: gh-pages


### PR DESCRIPTION
Environment deletion can be automated, but requires permissions.

So, I generated a small-scoped token for and used it as a GitHub Actions secret.

Let's see if it works. :) 🤞 