### PR TITLE
chore: `markdownlint-cli2-config` is removed use `--config` flag instead

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -31,7 +31,7 @@ RUN chmod +x get-nunit-apidocs.sh
 # We get the first workspace, because there should only be one
 # This is so that when someone updates their devcontainer name, it doesn't get screwed up
 RUN echo 'first_workspace=\"$(cd /workspaces && ls | head -1)\"; alias spellcheck="cspell --config /workspaces/$first_workspace/cSpell.json \"/workspaces/$first_workspace/docs/**/*.md\" --no-progress"' >> ~/.bashrc
-RUN echo 'first_workspace=\"$(cd /workspaces && ls | head -1)\"; alias lint="markdownlint-cli2-config /workspaces/$first_workspace/.github/linters/.markdownlint.yml /workspaces/$first_workspace/docs/**/*.md"' >> ~/.bashrc
+RUN echo 'first_workspace=\"$(cd /workspaces && ls | head -1)\"; alias lint="markdownlint-cli2 --config /workspaces/$first_workspace/.github/linters/.markdownlint.yml /workspaces/$first_workspace/docs/**/*.md"' >> ~/.bashrc
 RUN echo 'first_workspace=\"$(cd /workspaces && ls | head -1)\"; alias build="docfx /workspaces/$first_workspace/docs/docfx.json"' >> ~/.bashrc
 RUN echo 'first_workspace=\"$(cd /workspaces && ls | head -1)\"; alias serve="docfx /workspaces/$first_workspace/docs/docfx.json --serve"' >> ~/.bashrc
 RUN echo 'first_workspace=\"$(cd /workspaces && ls | head -1)\"; alias snippets="dotnet test /workspaces/$first_workspace/docs/snippets/Snippets.sln"' >> ~/.bashrc

--- a/.github/workflows/build-process.yml
+++ b/.github/workflows/build-process.yml
@@ -24,7 +24,7 @@ jobs:
           node-version: "18"
       - run: npm install -g markdownlint-cli2
         name: Install markdownlint-cli2
-      - run: markdownlint-cli2-config ".github/linters/.markdownlint.yml" "docs/**/*.md"
+      - run: markdownlint-cli2 --config ".github/linters/.markdownlint.yml" "docs/**/*.md"
         name: run Markdownlint
   spellcheck:
     name: "Spell check"

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ We'll be working on follow-ups to make this more user-friendly, but it's now wor
 
 * Install `markdownlint-cli2`: `npm install markdownlint-cli2 -g`
 * Open the root of the project (`/`, not `/docs`)
-* Run `markdownlint-cli2-config ".github/linters/.markdownlint.yml" "docs/**/*.md"`
+* Run `markdownlint-cli2 --config ".github/linters/.markdownlint.yml" "docs/**/*.md"`
 
 We'd love your contributions! See [The contributing guide](CONTRIBUTING.md) for how to get involved.
 

--- a/docs/articles/nunit/extending-nunit/Custom-Attributes.md
+++ b/docs/articles/nunit/extending-nunit/Custom-Attributes.md
@@ -17,12 +17,12 @@ The following interfaces are called at load time.
 
 | Interface              | Used By |
 |------------------------|---------|
-| [IFixtureBuilder](IFixtureBuilder-Interface.md)       | Attributes that know how to build a fixture from a test class
-| [ITestBuilder](ITestBuilder-Interface.md)              | Attributes that know how to build one or more parameterized test cases for a method
-| [ISimpleTestBuilder](ISimpleTestBuilder-Interface.md) | Attributes that know how to build a single non-parameterized test case for a method
-| [IParameterDataSource](IParameterDataSource-Interface.md) | Attributes that supply values for a single parameter for use in generating test cases
-| [IImplyFixture](IImplyFixture-Interface.md)           | Attributes used on a method to signal that the defining class should be treated as a fixture
-| [IApplyToTest](IApplyToTest-Interface.md)             | Attributes that make modifications to a test immediately after it is constructed
+| [IFixtureBuilder](IFixtureBuilder-Interface.md)       | Attributes that know how to build a fixture from a test class |
+| [ITestBuilder](ITestBuilder-Interface.md)              | Attributes that know how to build one or more parameterized test cases for a method |
+| [ISimpleTestBuilder](ISimpleTestBuilder-Interface.md) | Attributes that know how to build a single non-parameterized test case for a method |
+| [IParameterDataSource](IParameterDataSource-Interface.md) | Attributes that supply values for a single parameter for use in generating test cases |
+| [IImplyFixture](IImplyFixture-Interface.md)           | Attributes used on a method to signal that the defining class should be treated as a fixture |
+| [IApplyToTest](IApplyToTest-Interface.md)             | Attributes that make modifications to a test immediately after it is constructed |
 
 ### Execution-Time Interfaces
 
@@ -33,5 +33,5 @@ The following interfaces are called at execution time.
 
 | Interface              | Used By |
 |------------------------|---------|
-| [IApplyToContext](IApplyToContext-Interface.md) | Attributes that set up the context prior to execution
-| [ICommandWrapper](ICommandWrapper-Interface.md) | Attributes that can wrap a `TestCommand` with another command
+| [IApplyToContext](IApplyToContext-Interface.md) | Attributes that set up the context prior to execution |
+| [ICommandWrapper](ICommandWrapper-Interface.md) | Attributes that can wrap a `TestCommand` with another command |


### PR DESCRIPTION
Fixes #883

The entry point `markdownlint-cli2-config` was removed in markdownlint-cli2 version 0.12.0.

See https://github.com/DavidAnson/markdownlint-cli2/blob/82c791e94c2e2ab2119437d61c722c8e0c20d6c9/CHANGELOG.md?plain=1#L11-L12

And failed build in https://github.com/nunit/nunit.analyzers/actions/runs/7596383794/job/20690026186?pr=675