### PR TITLE
Make readers aware of potential issue with semicolon in terminal

### DIFF
--- a/docs/articles/nunit/running-tests/Console-Command-Line.md
+++ b/docs/articles/nunit/running-tests/Console-Command-Line.md
@@ -82,6 +82,8 @@ the following forms:
 * `--OPTION:filename;format=formatname`
 * `--OPTION:filename;transform=xsltfile`
 
+Be aware that the semicolon (;) might need escaping in some terminals.
+
 The --result option may use any of the following formats:
 
 * nunit3 - the native XML format for NUnit 3

--- a/docs/articles/nunit/running-tests/NUnitLite-Options.md
+++ b/docs/articles/nunit/running-tests/NUnitLite-Options.md
@@ -66,6 +66,8 @@ the following forms:
 * `--OPTION:filename`
 * `--OPTION:filename;format=formatname`
 
+Be aware that the semicolon (;) might need escaping in some terminals.
+
 The `--result` option may use any of the following formats:
 
 * `nunit3` - the native XML format for NUnit 3.0


### PR DESCRIPTION
I ran into the issue described in https://github.com/nunit/nunit-console/issues/711.

In many shells/terminals, the semicolon in an option like `--explore:output.txt;format=cases` can be problematic.
In my case, with bash, the semicolon is parsed as a separator of commands.
So, `--explore:output.txt` is passed to nunit-console, but the `format=cases` part is separately executed by bash.
Because both of the resulting commands are valid, no warnings/errors are printed and nunit-console will write output into a file with the expected `output.txt` filename.
It made it look like nunit-console just didn't support the "format" attribute anymore.

I hope adding this mention of the semicolon in the docs will avoid some confusing/time-consuming debugging for other people.