### PR TITLE
Add 'TestData.Categories' to 3.0 breaking change list

### DIFF
--- a/docs/articles/nunit/release-notes/breaking-changes.md
+++ b/docs/articles/nunit/release-notes/breaking-changes.md
@@ -130,6 +130,7 @@ Other breaking changes are grouped in the following tables.
 | NUnitLite          | NUnitLite executable tests must now reference nunit.framework in addition to NUnitLite. |
 | SetUpFixture       | Now uses `OneTimeSetUpAttribute` and `OneTimeTearDownAttribute` to designate higher-level setup and teardown methods. `SetUpAttribute` and `TearDownAttribute` are no longer allowed. |
 | TestCaseData       | The `Throws` Named Property is no longer available. Use `Assert.Throws` or `Assert.That` in your test case. |
+| TestCaseData       | The `Categories` Named Property is no longer available. Use `Properties["Category"]` instead. |
 | TestContext        | The fields available in the [TestContext](xref:testcontext) have changed, although the same information remains available as for NUnit V2. |
 | Async void tests   | No longer supported. Use `async Task` as the method signature instead. |
 


### PR DESCRIPTION
Fixes https://github.com/nunit/nunit/issues/4678 by adding a note that `TestCaseData.Categories` has been removed