### PR TITLE
Document ThrowOnEachFailureUnderDebugger option

### DIFF
--- a/docs/articles/nunit/technical-notes/usage/Debugging-Support.md
+++ b/docs/articles/nunit/technical-notes/usage/Debugging-Support.md
@@ -7,8 +7,6 @@ This document describes framework functionality for debugging support of tests a
 (From version 4.2.0)
 
 Setting name defined by `FrameworkPackageSettings.ThrowOnEachFailureUnderDebugger` constant.
-
-
 It may sometimes be necessary to debug the current state of a test during an `Assertion.Multiple` block. Typically,
 assertion exceptions are thrown only after the block is completed.
 

--- a/docs/articles/nunit/technical-notes/usage/Debugging-Support.md
+++ b/docs/articles/nunit/technical-notes/usage/Debugging-Support.md
@@ -9,7 +9,8 @@ This document describes framework functionality for debugging support of tests a
 Setting name defined by `FrameworkPackageSettings.ThrowOnEachFailureUnderDebugger` constant.
 
 
-It may sometimes be necessary to debug the current state of a test during an `Assertion.Multiple` block. Typically, assertion exceptions are thrown only after the block is completed.
+It may sometimes be necessary to debug the current state of a test during an `Assertion.Multiple` block. Typically,
+assertion exceptions are thrown only after the block is completed.
 
 This boolean framework setting will cause the debugger to throw on a failed assertion during an `Assert.Multiple`
 block. This allows user to break execution on exception and inspect tested code state

--- a/docs/articles/nunit/technical-notes/usage/Debugging-Support.md
+++ b/docs/articles/nunit/technical-notes/usage/Debugging-Support.md
@@ -8,10 +8,12 @@ This document describes framework functionality for debugging support of tests a
 
 Setting name defined by `FrameworkPackageSettings.ThrowOnEachFailureUnderDebugger` constant.
 
-This boolean framework setting enables throwing of immediately catched assertion exception from `Assert.Multiple`
-block on each failed assertion. This allows user to break execution on exception and inspect tested code state
-at time of failure. In contrast default behavior of `Assert.Multiple` is to throw assertion exception only after
-whole block executed. In this situation tested code state could change or be unavailable.
+
+It may sometimes be necessary to debug the current state of a test during an `Assertion.Multiple` block. Typically, assertion exceptions are thrown only after the block is completed.
+
+This boolean framework setting will cause the debugger to throw on a failed assertion during an `Assert.Multiple`
+block. This allows user to break execution on exception and inspect tested code state
+at time of failure.
 
 Because this behavior is useful only for debugging, it is not active without attached debugger
 (`Debugger.IsAttached = true`).

--- a/docs/articles/nunit/technical-notes/usage/Debugging-Support.md
+++ b/docs/articles/nunit/technical-notes/usage/Debugging-Support.md
@@ -1,0 +1,17 @@
+# Debugging Support
+
+This document describes framework functionality for debugging support of tests and tested code.
+
+## `ThrowOnEachFailureUnderDebugger` Setting
+
+(From version 4.2.0)
+
+Setting name defined by `FrameworkPackageSettings.ThrowOnEachFailureUnderDebugger` constant.
+
+This boolean framework setting enables throwing of immediately catched assertion exception from `Assert.Multiple`
+block on each failed assertion. This allows user to break execution on exception and inspect tested code state
+at time of failure. In contrast default behavior of `Assert.Multiple` is to throw assertion exception only after
+whole block executed. In this situation tested code state could change or be unavailable.
+
+Because this behavior is useful only for debugging, it is not active without attached debugger
+(`Debugger.IsAttached = true`).

--- a/docs/articles/nunit/technical-notes/usage/Debugging-Support.md
+++ b/docs/articles/nunit/technical-notes/usage/Debugging-Support.md
@@ -15,5 +15,5 @@ This boolean framework setting will cause the debugger to throw on a failed asse
 block. This allows user to break execution on exception and inspect tested code state
 at time of failure.
 
-Because this behavior is useful only for debugging, it is not active without attached debugger
+Because this behavior is useful only for debugging, it is not activated without an attached debugger
 (`Debugger.IsAttached = true`).

--- a/docs/articles/nunit/technical-notes/usage/toc.yml
+++ b/docs/articles/nunit/technical-notes/usage/toc.yml
@@ -8,6 +8,8 @@
   href: Configuration-Files.md
 - name: Counting Tests
   href: Counting-Tests.md
+- name: Debugging Support
+  href: Debugging-Support.md
 - name: Engine Parallel Test Execution
   href: Engine-Parallel-Test-Execution.md
 - name: Framework Parallel Test Execution

--- a/docs/articles/vs-test-adapter/Tips-And-Tricks.md
+++ b/docs/articles/vs-test-adapter/Tips-And-Tricks.md
@@ -381,7 +381,7 @@ If set, this setting will allow parallel execution of tests even if the debugger
 
 #### ThrowOnEachFailureUnderDebugger
 
-If set, this setting will allow handled assert exception for each failue in `Assert.Multiple` block if the debugger
+If set, this setting will surface an assertion exception for each failure in an `Assert.Multiple` block if the debugger
 is attached. The default is `false`.
 
 (From version 4.6.0)

--- a/docs/articles/vs-test-adapter/Tips-And-Tricks.md
+++ b/docs/articles/vs-test-adapter/Tips-And-Tricks.md
@@ -381,7 +381,8 @@ If set, this setting will allow parallel execution of tests even if the debugger
 
 #### ThrowOnEachFailureUnderDebugger
 
-If set, this setting will allow handled assert exception for each failue in `Assert.Multiple` block if the debugger is attached. The default is `false`.
+If set, this setting will allow handled assert exception for each failue in `Assert.Multiple` block if the debugger
+is attached. The default is `false`.
 
 (From version 4.6.0)
 

--- a/docs/articles/vs-test-adapter/Tips-And-Tricks.md
+++ b/docs/articles/vs-test-adapter/Tips-And-Tricks.md
@@ -10,42 +10,43 @@ uid: tipsandtricks
 
 Certain NUnit Test Adapter settings are configurable using a .runsettings file. The following options are available:
 
-|                                  Key                                  |  Type  |                                    Options                                    |            Default            |
-| --------------------------------------------------------------------- | ------ | ----------------------------------------------------------------------------- | ----------------------------- |
-| [InternalTraceLevel](#internaltracelevel)                             | enum   | Off, Error, Warning, Info, Verbose,  Debug                                    | Nothing => Off                |
-| [NumberOfTestWorkers](#numberoftestworkers)                           | int    | nr of workers                                                                 | -1                            |
-| [ShadowCopyFiles](#shadowcopyfiles)                                   | bool   | True, False                                                                   | False                         |
-| [Verbosity](#verbosity)                                               | int    | -1, 0-5 . -1 means quiet mode                                                 | 0                             |
-| [UseVsKeepEngineRunning](#usevskeepenginerunning)                     | bool   | True, False                                                                   | False                         |
-| BasePath                                                              | string | path                                                                          | ?                             |
-| PrivateBinPath                                                        | string | directory1;directory2;etc                                                     | ?                             |
-| RandomSeed                                                            | int    | seed integer                                                                  | random                        |
-| DefaultTimeout                                                        | int    | timeout in mS, 0 means infinite                                               | 0                             |
-| [DefaultTestNamePattern](#defaulttestnamepattern)                     | string | Pattern for display name                                                      | {m}{a}                        |
-| [WorkDirectory](#workdirectory)                                       | string | specify directory                                                             | Test assembly location        |
-| [TestOutputXml](#testoutputxml)                                       | string | specify directory                                                             | Test Result Xml output folder |
-| [OutputXmlFolderMode](#outputxmlfoldermode)                           | enum   | UseResultDirectory,RelativeToResultDirectory,RelativeToWorkFolder,AsSpecified | RelativeToWorkFolder          |
-| [DumpXmlTestDiscovery](#dumpxmltestdiscovery-and-dumpxmltestresults)  | bool   | Enable dumping of NUnit discovery response xml                                | false                         |
-| [DumpXmlTestResults](#dumpxmltestdiscovery-and-dumpxmltestresults)    | bool   | Enable dumping of NUnit execution response xml                                | false                         |
-| [PreFilter](#prefilter)                                               | bool   | Enable pre-filtering to increase performance for Visual Studio testing        | false                         |
-| [ShowInternalProperties](#showinternalproperties)                     | bool   | Turn on showing internal NUnit properties in Test Explorer                    | false                         |
-| [Where](#where)                                                       | string | NUnit Filter expression                                                       |                               |
-| [UseParentFQNForParametrizedTests](#useparentfqnforparametrizedtests) | bool   | Enable parent as FQN for parametrized tests                                   | false                         |
-| [UseNUnitIdforTestCaseId](#usenunitidfortestcaseid)                   | bool   | Uses NUnit test id as VSTest Testcase Id, instead of FullyQualifiedName       | false                         |
-| [ConsoleOut](#consoleout)                                             | int    | Sends standard console output to the output window                            | 1                             |
-| [UseTestNameInConsoleOutput](#usetestnameinconsoleoutput)             | bool   | Adds name of test as a prefix in the output window for console output         | true                          |
-| [StopOnError](#stoponerror)                                           | bool   | Stops on first error                                                          | false                         |
-| [SkipNonTestAssemblies](#skipnontestassemblies)                       | bool   | Adapter supports NonTestAssemblyAttribute                                     | true                          |
-| [MapWarningTo](#mapwarningto)                                         | enum   | Map Assert.Warn to either Passed, Failed or Skipped                           | Skipped                       |
-| [DisplayName](#displayname)                                           | enum   | Set what a DisplayName is, options: Name, FullName or FullNameSep             | Name                          |
-| [FullnameSeparator](#fullnameseparator)                               | string | FullNameSep separator                                                         | ':'                           |
-| [DiscoveryMethod](#discoverymethod)                                   | enum   | How execution discovery is done, options are `Legacy` or `Current`            | Current                       |
-| [AssemblySelectLimit](#assemblyselectlimit)                           | int    | Number of tests accepted before filters are turned off                        | 2000                          |
-| [NewOutputXmlFileForEachRun](#newoutputxmlfileforeachrun)             | bool   | Creates a new file for each test run                                          | false                         |
-| [IncludeStackTraceForSuites](#includestacktraceforsuites)             | bool   | Includes stack trace for failures in suites, like exceptions in OneTimeSetup  | true                          |
-| [ExplicitMode](#explicitmode)                                         | enum   | Changes handling of explicit tests, options are `Strict` or `Relaxed`         | Strict                        |
-| [SkipExecutionWhenNoTests](#skipexecutionwhennotests)                 | bool   | Skip execution if no tests are found                                          | false                         |
-| [AllowParallelWithDebugger](#allowparallelwithdebugger)               | bool   | Allow parallel execution when debugger is attached                            | false                         |
+|                                  Key                                  |  Type  |                                    Options                                            |            Default            |
+| --------------------------------------------------------------------- | ------ | ------------------------------------------------------------------------------------- | ----------------------------- |
+| [InternalTraceLevel](#internaltracelevel)                             | enum   | Off, Error, Warning, Info, Verbose,  Debug                                            | Nothing => Off                |
+| [NumberOfTestWorkers](#numberoftestworkers)                           | int    | nr of workers                                                                         | -1                            |
+| [ShadowCopyFiles](#shadowcopyfiles)                                   | bool   | True, False                                                                           | False                         |
+| [Verbosity](#verbosity)                                               | int    | -1, 0-5 . -1 means quiet mode                                                         | 0                             |
+| [UseVsKeepEngineRunning](#usevskeepenginerunning)                     | bool   | True, False                                                                           | False                         |
+| BasePath                                                              | string | path                                                                                  | ?                             |
+| PrivateBinPath                                                        | string | directory1;directory2;etc                                                             | ?                             |
+| RandomSeed                                                            | int    | seed integer                                                                          | random                        |
+| DefaultTimeout                                                        | int    | timeout in mS, 0 means infinite                                                       | 0                             |
+| [DefaultTestNamePattern](#defaulttestnamepattern)                     | string | Pattern for display name                                                              | {m}{a}                        |
+| [WorkDirectory](#workdirectory)                                       | string | specify directory                                                                     | Test assembly location        |
+| [TestOutputXml](#testoutputxml)                                       | string | specify directory                                                                     | Test Result Xml output folder |
+| [OutputXmlFolderMode](#outputxmlfoldermode)                           | enum   | UseResultDirectory,RelativeToResultDirectory,RelativeToWorkFolder,AsSpecified         | RelativeToWorkFolder          |
+| [DumpXmlTestDiscovery](#dumpxmltestdiscovery-and-dumpxmltestresults)  | bool   | Enable dumping of NUnit discovery response xml                                        | false                         |
+| [DumpXmlTestResults](#dumpxmltestdiscovery-and-dumpxmltestresults)    | bool   | Enable dumping of NUnit execution response xml                                        | false                         |
+| [PreFilter](#prefilter)                                               | bool   | Enable pre-filtering to increase performance for Visual Studio testing                | false                         |
+| [ShowInternalProperties](#showinternalproperties)                     | bool   | Turn on showing internal NUnit properties in Test Explorer                            | false                         |
+| [Where](#where)                                                       | string | NUnit Filter expression                                                               |                               |
+| [UseParentFQNForParametrizedTests](#useparentfqnforparametrizedtests) | bool   | Enable parent as FQN for parametrized tests                                           | false                         |
+| [UseNUnitIdforTestCaseId](#usenunitidfortestcaseid)                   | bool   | Uses NUnit test id as VSTest Testcase Id, instead of FullyQualifiedName               | false                         |
+| [ConsoleOut](#consoleout)                                             | int    | Sends standard console output to the output window                                    | 1                             |
+| [UseTestNameInConsoleOutput](#usetestnameinconsoleoutput)             | bool   | Adds name of test as a prefix in the output window for console output                 | true                          |
+| [StopOnError](#stoponerror)                                           | bool   | Stops on first error                                                                  | false                         |
+| [SkipNonTestAssemblies](#skipnontestassemblies)                       | bool   | Adapter supports NonTestAssemblyAttribute                                             | true                          |
+| [MapWarningTo](#mapwarningto)                                         | enum   | Map Assert.Warn to either Passed, Failed or Skipped                                   | Skipped                       |
+| [DisplayName](#displayname)                                           | enum   | Set what a DisplayName is, options: Name, FullName or FullNameSep                     | Name                          |
+| [FullnameSeparator](#fullnameseparator)                               | string | FullNameSep separator                                                                 | ':'                           |
+| [DiscoveryMethod](#discoverymethod)                                   | enum   | How execution discovery is done, options are `Legacy` or `Current`                    | Current                       |
+| [AssemblySelectLimit](#assemblyselectlimit)                           | int    | Number of tests accepted before filters are turned off                                | 2000                          |
+| [NewOutputXmlFileForEachRun](#newoutputxmlfileforeachrun)             | bool   | Creates a new file for each test run                                                  | false                         |
+| [IncludeStackTraceForSuites](#includestacktraceforsuites)             | bool   | Includes stack trace for failures in suites, like exceptions in OneTimeSetup          | true                          |
+| [ExplicitMode](#explicitmode)                                         | enum   | Changes handling of explicit tests, options are `Strict` or `Relaxed`                 | Strict                        |
+| [SkipExecutionWhenNoTests](#skipexecutionwhennotests)                 | bool   | Skip execution if no tests are found                                                  | false                         |
+| [AllowParallelWithDebugger](#allowparallelwithdebugger)               | bool   | Allow parallel execution when debugger is attached                                    | false                         |
+| [ThrowOnEachFailureUnderDebugger](#throwoneachfailureunderdebugger)   | bool   | Allow assert exception on each failure from Assert.Multiple when debugger is attached | false                         |
 
 ### Visual Studio templates for runsettings
 
@@ -377,6 +378,12 @@ files. The default is false.
 If set, this setting will allow parallel execution of tests even if the debugger is attached.  The default is `false`.
 
 (From version 4.5.0)
+
+#### ThrowOnEachFailureUnderDebugger
+
+If set, this setting will allow handled assert exception for each failue in `Assert.Multiple` block if the debugger is attached. The default is `false`.
+
+(From version 4.6.0)
 
 ---
 


### PR DESCRIPTION
Fix https://github.com/nunit/nunit/issues/4765

@OsirisTerje , I've added adapter notes, but cannot find suitable document under `docs\articles\nunit\technical-notes`