### PR TITLE
Use RenovateBot for API docs version in build

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -12,7 +12,7 @@
       "matchStrings": [
         "NUNIT_VERSION_FOR_API_DOCS: \"(?<currentValue>.*?)\""
       ],
-      "depNameTemplate": "docfx",
+      "depNameTemplate": "NUnit",
       "datasourceTemplate": "nuget"
     }
   ]

--- a/renovate.json
+++ b/renovate.json
@@ -2,5 +2,18 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
     "config:recommended"
+  ],
+  "customManagers": [
+    {
+      "customType": "regex",
+      "fileMatch": [
+        "^build-process.yml$"
+      ],
+      "matchStrings": [
+        "NUNIT_VERSION_FOR_API_DOCS: \"(?<currentValue>.*?)\""
+      ],
+      "depNameTemplate": "docfx",
+      "datasourceTemplate": "nuget"
+    }
   ]
 }


### PR DESCRIPTION
This introduces a RenovateBot custom manager.

In the `build-process.yml` file, it will look for the version in `NUNIT_VERSION_FOR_API_DOCS`, and will suggest an update for it when a new version of NUnit is published.

This ensures that our docs get PRs to stay up to date when a new version of NUnit is released.

Supports #941. Going to choose to leave it open for now because I have to merge this first before I can see if it's successful (I should see a PR generated to update to 4.1.0.