### PR TITLE
Fix wording in theory.md

### DIFF
--- a/docs/articles/nunit/writing-tests/attributes/theory.md
+++ b/docs/articles/nunit/writing-tests/attributes/theory.md
@@ -83,7 +83,7 @@ public class SqrtTests
 
 ## Theories in Generic Fixtures
 
-In a generic fixture with Type parameter `T` individual methods using `T` as a parameter type or not generic, since `T`
+In a generic fixture with Type parameter `T` individual methods using `T` as a parameter type are not generic, since `T`
 has been resolved to an actual Type in instantiating the fixture instance. You may use such methods as theories and any
 data of the appropriate type will be used.
 


### PR DESCRIPTION
The first sentence under the section "Theories in Generic Fixtures" didn't make sense at first, until I substituted the word "or" with the phonetically similar word "are".