### PR TITLE
Update Console-Command-Line.md

### DIFF
--- a/docs/articles/nunit/running-tests/Console-Command-Line.md
+++ b/docs/articles/nunit/running-tests/Console-Command-Line.md
@@ -29,7 +29,7 @@ beginning with 2.0. Without the V2 driver, only version 3.0 and higher tests may
 
 | Option | Description |
 | ------ | ----------- |
-|`@FILE` | Specifies the name (or path) of a FILE containing additional command-line arguments to be interpolated at the point where the @FILE expression appears. Each line in the file represents a separate command-line argument.|
+|`@FILE` | Specifies the name (or path) of a FILE containing additional command-line arguments to be inserted at the point where the @FILE expression appears. Each line in the file represents one argument to the console runner. If an option takes a value, that value must appear on the same line.|
 |`--test=FULLNAMES` | Comma-separated list of FULLNAMES of tests to run or explore. This option may be repeated. Note that this option is retained for backward compatibility. The --where option can now be used instead. |
 |`--testlist=FILE` | The name (or path) of a FILE containing a list of tests to run or explore, one per line. May also include comment lines, indicated by `#` in the first column. |
 |`--where=EXPRESSION` | An expression indicating which tests to run. It may specify test names, classes, methods, categories or properties comparing them to actual values with the operators ==, !=, =~ and !~. See [Test Selection Language](Test-Selection-Language.md) for a full description of the syntax. |


### PR DESCRIPTION
Reflects changes made to the console runner help message in response to nunit/nunit-console#1359. Users are confused about the distinction between command-line arguments and the arguments passed to the runner.