### PR TITLE
Initial warning about cross-process marshalling

### DIFF
--- a/docs/articles/nunit/extending-nunit/Custom-Attributes.md
+++ b/docs/articles/nunit/extending-nunit/Custom-Attributes.md
@@ -15,6 +15,10 @@ application, information about the tests may be returned for display, as is done
 
 The following interfaces are called at load time.
 
+> [!WARNING]
+> Parameter values injected into test methods by by an `ITestBuilder` are marshalled cross-process to the test execution process.
+> This can cause unexpected behaviour if there are attempts to use that value outside of the test scope.
+
 | Interface              | Used By |
 |------------------------|---------|
 | [IFixtureBuilder](IFixtureBuilder-Interface.md)       | Attributes that know how to build a fixture from a test class |


### PR DESCRIPTION
This catches me out every darn time!  I feel like it should be more obvious and pointed out.  In this case I've added an object as a parameter which is attached to an event bus which is maintained outside of the test execution.  This means that the event bus has an affinity with the "test discovery & creation" process wheras the things submitting events to it are in the "test execution" process.  Of course, this results in two 'copies' of the event bus, and any listeners to it (which were attached from the "discovery & creation" process) don't actually receive any of the events sent by the test execution.

I'm not 100% sure this is factually correct yet; I could use some assistance from maintainers to be confident that it's right.  At the moment this PR is more of a reminder to myself to look further into it and improve upon it.