### PR TITLE
Auto-fix linting and remove line length linting

### DIFF
--- a/.github/linters/.markdownlint.yml
+++ b/.github/linters/.markdownlint.yml
@@ -19,10 +19,7 @@
 # Rules by id #
 ###############
 MD024: false
-MD013: 
-  line_length: 120
-  code_blocks: false
-  tables: false
+MD013: false
 MD026: false
 MD046: false # Mix of indented and fenced code blocks
 MD004: false

--- a/.markdownlintrc
+++ b/.markdownlintrc
@@ -1,11 +1,6 @@
 {
     "MD024": false,
-    "MD013": {
-        "line_length": 123,
-        "code_blocks": false,
-        "tables": false
-      
-    },
+    "MD013": false,
     "MD026": false,
     "MD046": false,
     "MD004": false

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -20,4 +20,7 @@
     "editor.wrappingIndent": "same",
     "editor.wordWrapColumn": 120,
     "editor.rulers": [120],
+    "editor.codeActionsOnSave": {
+        "source.fixAll.markdownlint": "always"
+    }
 }

--- a/README.md
+++ b/README.md
@@ -35,6 +35,16 @@ We'll be working on follow-ups to make this more user-friendly, but it's now wor
 * Open the root of the project (`/`, not `/docs`)
 * Run `markdownlint-cli2 --config ".github/linters/.markdownlint.yml" "docs/**/*.md"`
 
+We recommend adding the following settings to your VSCode environment if they don't come through in the repository:
+
+```json
+    "editor.codeActionsOnSave": {
+        "source.fixAll.markdownlint": "always"
+    }
+```
+
+This will fix 80% of the markdown linting issues for you upon save.
+
 We'd love your contributions! See [The contributing guide](CONTRIBUTING.md) for how to get involved.
 
 ## Building the API docs locally


### PR DESCRIPTION
After a quick conversation with @OsirisTerje we agreed that 1) it would be helpful to auto-fix markdownlint issues in docs on save, and 2) we didn't want the line length to cause issues in linting.

So, this PR:

* Adds the auto-fix on save functionality for Codespaces (and puts the same in the readme)
* Removes the line length linting
* Leaves the Rewrap plugin so that we can still have some friendly help on line length when desired
* Leaves `"editor.rulers": [120]` in settings so that we have a visual guideline.

Closes #887