### PR TITLE
Document console runner --configfile option for custom app config

### DIFF
--- a/docs/articles/nunit/running-tests/Console-Command-Line.md
+++ b/docs/articles/nunit/running-tests/Console-Command-Line.md
@@ -36,6 +36,7 @@ beginning with 2.0. Without the V2 driver, only version 3.0 and higher tests may
 |`--testparam:PARAMETER, --tp:PARAMETER` | A test PARAMETER specified in the form NAME=VALUE for consumption by tests. Multiple parameters must be specified separated using a `--testparam` or `--tp` option for each. |
 |`--params=PARAMETER, --p=PARAMETER` | (**NOTE:** _this is deprecated and will be removed in a future release. Please use --testparam instead_.) A test PARAMETER specified in the form NAME=VALUE for consumption by tests. Multiple parameters may be specified, separated by semicolons or by repeating the --params option multiple times. Case-sensitive. |
 |`--config=NAME` | NAME of a project configuration to load (e.g.: Debug). |
+|`--configfile=/path/to/custom.app.config` | Location to load an application configuration file from if outside dll directory. (_Console Runner 3.8+_) |
 |`--process=PROCESS` | PROCESS isolation for test assemblies. Values: Single, Separate, Multiple. If not specified, defaults to Separate for a single assembly or Multiple for more than one. By default, processes are run in parallel. |
 |`--inprocess` | This option is a synonym for --process=Single |
 |`--agents=NUMBER` | NUMBER of agents that may be allowed to run simultaneously assuming you are not running inprocess. If not specified, all agent processes run tests at the same time, whatever the number of assemblies. This setting is used to control running your assemblies in parallel. |

--- a/docs/articles/nunit/technical-notes/usage/Configuration-Files.md
+++ b/docs/articles/nunit/technical-notes/usage/Configuration-Files.md
@@ -14,5 +14,10 @@ be named nunit.tests.dll.config and located in the same directory as the dll.
 1. When multiple assemblies are specified in an NUnit project (file extension `.nunit`),
 it is possible to specify a common config file for the included test assemblies.
 
-2. When multiple assemblies are specified on the command-line using the `--domain:Single`
+2. A custom path to a configuration file can be specified on the command line using the
+`--configfile=/path/to/custom.app.config` option if using version 3.8 or higher of the
+console runner.
+
+4. When multiple assemblies are specified on the command-line using the `--domain:Single`
 option, no config file is currently used.
+

--- a/docs/articles/nunit/technical-notes/usage/Configuration-Files.md
+++ b/docs/articles/nunit/technical-notes/usage/Configuration-Files.md
@@ -18,6 +18,5 @@ it is possible to specify a common config file for the included test assemblies.
 `--configfile=/path/to/custom.app.config` option if using version 3.8 or higher of the
 console runner.
 
-4. When multiple assemblies are specified on the command-line using the `--domain:Single`
+3. When multiple assemblies are specified on the command-line using the `--domain:Single`
 option, no config file is currently used.
-


### PR DESCRIPTION
Fixes https://github.com/nunit/docs/issues/914

Documents an existing command line option to specify a custom application configuration file location for the NUnit Console Runner.